### PR TITLE
PCHR-429: Fix profile pic on Safari

### DIFF
--- a/civihr_employee_portal/templates/civihr-employee-portal-my-details--block.tpl.php
+++ b/civihr_employee_portal/templates/civihr-employee-portal-my-details--block.tpl.php
@@ -65,7 +65,7 @@
             <div class="well">
                 <div class="profile-image">
                     <?php if (isset($contact_data['image_URL']) && !empty($contact_data['image_URL'])) { ?>
-                        <img src="<?php print $contact_data['image_URL']; ?>" class="custom-scale-image" />
+                        <img src="<?php print $contact_data['image_URL']; ?>" />
                     <?php } else { ?>
                         <img src="<?php print drupal_get_path('module', 'civihr_employee_portal') . '/images/profile-default.png' ?>"/>
                     <?php } ?>


### PR DESCRIPTION
The profile pic on Safari, in the My Details block, appeared misaligned. There were some CSS rules applied to it via a class that didn't look to me any useful, so I removed the class