### PR TITLE
PCHR-412: Responsive dashboard

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -882,7 +882,7 @@ function civihr_employee_portal_make_link($link_text, $link_type = 'debit', $nid
 
     if ($link_type == 'calendar') {
         return '' . l($link_text, 'absence_calendar/nojs/show',
-            array('attributes' => array('class' => "btn btn-custom ctools-use-modal ctools-modal-civihr-default-style $class"))
+            array('attributes' => array('class' => "chr_action--icon--calendar ctools-use-modal ctools-modal-civihr-default-style $class"))
         ) . '';
     }
 
@@ -890,7 +890,7 @@ function civihr_employee_portal_make_link($link_text, $link_type = 'debit', $nid
         return '' . l($link_text, 'print-leave-report/',
             array(
                 'query' => array('absence_start_date_period_filter' => $nid),
-                'attributes' => array('class' => "btn btn-custom $class", 'target'=>'_blank')
+                'attributes' => array('class' => "chr_action--icon--print $class", 'target'=>'_blank')
             )
         ) . '';
     }
@@ -914,7 +914,7 @@ function civihr_employee_portal_make_link($link_text, $link_type = 'debit', $nid
     }
 
     return '' . l($link_text, 'absence_request/nojs/' . $link_type,
-        array('attributes' => array('class' => "btn btn-custom ctools-use-modal ctools-modal-civihr-custom-style $class"))
+        array('attributes' => array('class' => "chr_action ctools-use-modal ctools-modal-civihr-custom-style $class"))
     ) . '';
 }
 
@@ -3327,7 +3327,7 @@ function civihr_employee_portal_directory_block_form($form, &$form_state) {
     );
 
     $form['submit'] = array(
-        '#attributes' => array('class' => array('chr_panel__actions__action')),
+        '#attributes' => array('class' => array('chr_action')),
         '#type' => 'submit',
         '#value' => t('Go!'),
         '#prefix' => '<div class="chr_panel__actions">',

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -871,8 +871,19 @@ function _get_uf_match_contact($contact_id) {
 }
 
 /**
-* Helper function to make a link.
-*/
+ * Helper function to make a link.
+ *
+ * The links that are known to be a .chr_action element, have their text wrapper in a <span>
+ * so that they can be responsive if the class .chr_action--icon--responsive is applied
+ *
+ *
+ * @param string $link_text
+ * @param string $link_type
+ * @param string $nid
+ * @param string $class
+ *   Any additional css classes that the links must have
+ * @return string
+ */
 function civihr_employee_portal_make_link($link_text, $link_type = 'debit', $nid = '', $class = '') {
 
     // Set a default value if no text in supplied.
@@ -881,16 +892,20 @@ function civihr_employee_portal_make_link($link_text, $link_type = 'debit', $nid
     }
 
     if ($link_type == 'calendar') {
-        return '' . l($link_text, 'absence_calendar/nojs/show',
-            array('attributes' => array('class' => "chr_action--icon--calendar ctools-use-modal ctools-modal-civihr-default-style $class"))
+        return '' . l("<span>$link_text</span>", 'absence_calendar/nojs/show',
+            array(
+                'attributes' => array('class' => "chr_action--icon--calendar ctools-use-modal ctools-modal-civihr-default-style $class"),
+                'html' => true
+            )
         ) . '';
     }
 
     if ($link_type == 'leave_report') {
-        return '' . l($link_text, 'print-leave-report/',
+        return '' . l("<span>$link_text</span>", 'print-leave-report/',
             array(
                 'query' => array('absence_start_date_period_filter' => $nid),
-                'attributes' => array('class' => "chr_action--icon--print $class", 'target'=>'_blank')
+                'attributes' => array('class' => "chr_action--icon--print $class", 'target'=>'_blank'),
+                'html' => true
             )
         ) . '';
     }
@@ -913,8 +928,11 @@ function civihr_employee_portal_make_link($link_text, $link_type = 'debit', $nid
         ) . '';
     }
 
-    return '' . l($link_text, 'absence_request/nojs/' . $link_type,
-        array('attributes' => array('class' => "chr_action ctools-use-modal ctools-modal-civihr-custom-style $class"))
+    return '' . l("<span>$link_text</span>", 'absence_request/nojs/' . $link_type,
+        array(
+            'attributes' => array('class' => "chr_action ctools-use-modal ctools-modal-civihr-custom-style $class"),
+            'html' => true
+        )
     ) . '';
 }
 
@@ -3601,11 +3619,11 @@ function civihr_employee_portal_form_views_exposed_form_alter(&$form, &$form_sta
         }
 
         $form['open_calendar'] = array(
-            '#markup' => civihr_employee_portal_make_link(t('Open calendar'), 'calendar', null, 'chr_action--transparent')
+            '#markup' => civihr_employee_portal_make_link(t('Open calendar'), 'calendar', null, 'chr_action--transparent chr_action--icon--responsive')
         );
 
         $form['leave_report'] = array(
-            '#markup' => civihr_employee_portal_make_link(t('Print leave report'), 'leave_report', $request_date, 'chr_action--transparent')
+            '#markup' => civihr_employee_portal_make_link(t('Print leave report'), 'leave_report', $request_date, 'chr_action--transparent hidden-xs')
         );
 
         // Replace the print leave report URL with the selected date period URL

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -873,7 +873,7 @@ function _get_uf_match_contact($contact_id) {
 /**
 * Helper function to make a link.
 */
-function civihr_employee_portal_make_link($link_text, $link_type = 'debit', $nid = '') {
+function civihr_employee_portal_make_link($link_text, $link_type = 'debit', $nid = '', $class = '') {
 
     // Set a default value if no text in supplied.
     if (empty($link_text)) {
@@ -881,32 +881,41 @@ function civihr_employee_portal_make_link($link_text, $link_type = 'debit', $nid
     }
 
     if ($link_type == 'calendar') {
-        return '' . l($link_text, 'absence_calendar/nojs/show', array('attributes' => array('class' => 'btn btn-custom ctools-use-modal ctools-modal-civihr-default-style'))) . '';
+        return '' . l($link_text, 'absence_calendar/nojs/show',
+            array('attributes' => array('class' => "btn btn-custom ctools-use-modal ctools-modal-civihr-default-style $class"))
+        ) . '';
     }
 
     if ($link_type == 'leave_report') {
         return '' . l($link_text, 'print-leave-report/',
             array(
                 'query' => array('absence_start_date_period_filter' => $nid),
-                'attributes' => array('class' => 'btn btn-custom', 'target'=>'_blank')
+                'attributes' => array('class' => "btn btn-custom $class", 'target'=>'_blank')
             )
         ) . '';
     }
 
     if ($link_type == 'hr-resource') {
-        return '' . l($link_text, 'hr_resources/nojs/resource/' . $nid, array('attributes' => array('class' => 'ctools-use-modal ctools-modal-civihr-default-style'))) . '';
+        return '' . l($link_text, 'hr_resources/nojs/resource/' . $nid,
+            array('attributes' => array('class' => "ctools-use-modal ctools-modal-civihr-default-style $class"))
+        ) . '';
     }
-    
+
     if ($link_type == 'document') {
-        return '' . l($link_text, 'civi_documents/nojs/edit/' . $nid, array('attributes' => array('class' => 'ctools-use-modal ctools-modal-civihr-default-style'))) . '';
+        return '' . l($link_text, 'civi_documents/nojs/edit/' . $nid,
+            array('attributes' => array('class' => "ctools-use-modal ctools-modal-civihr-default-style $class"))
+        ) . '';
     }
 
     if ($link_type == 'civihr_report_settings') {
-        return '' . l($link_text, 'civihr_reports_settings/nojs/view', array('attributes' => array('class' => 'ctools-use-modal ctools-modal-civihr-default-style'))) . '';
+        return '' . l($link_text, 'civihr_reports_settings/nojs/view',
+            array('attributes' => array('class' => "ctools-use-modal ctools-modal-civihr-default-style $class"))
+        ) . '';
     }
 
-    return '' . l($link_text, 'absence_request/nojs/' . $link_type, array('attributes' => array('class' => 'btn btn-custom ctools-use-modal ctools-modal-civihr-custom-style'))) . '';
-
+    return '' . l($link_text, 'absence_request/nojs/' . $link_type,
+        array('attributes' => array('class' => "btn btn-custom ctools-use-modal ctools-modal-civihr-custom-style $class"))
+    ) . '';
 }
 
 /**
@@ -3318,9 +3327,11 @@ function civihr_employee_portal_directory_block_form($form, &$form_state) {
     );
 
     $form['submit'] = array(
+        '#attributes' => array('class' => array('chr_panel__actions__action')),
         '#type' => 'submit',
         '#value' => t('Go!'),
-        '#prefix' => '<hr>'
+        '#prefix' => '<div class="chr_panel__actions">',
+        '#suffix' => '</div>'
     );
 
     // Add the validation function

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -3601,11 +3601,11 @@ function civihr_employee_portal_form_views_exposed_form_alter(&$form, &$form_sta
         }
 
         $form['open_calendar'] = array(
-            '#markup' => civihr_employee_portal_make_link(t('Open calendar'), 'calendar')
+            '#markup' => civihr_employee_portal_make_link(t('Open calendar'), 'calendar', null, 'chr_action--transparent')
         );
 
         $form['leave_report'] = array(
-            '#markup' => civihr_employee_portal_make_link(t('Print leave report'), 'leave_report', $request_date),
+            '#markup' => civihr_employee_portal_make_link(t('Print leave report'), 'leave_report', $request_date, 'chr_action--transparent'),
             '#prefix' => '<div id="report-replace-div">',
             '#suffix' => '</div>',
         );

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -3605,9 +3605,7 @@ function civihr_employee_portal_form_views_exposed_form_alter(&$form, &$form_sta
         );
 
         $form['leave_report'] = array(
-            '#markup' => civihr_employee_portal_make_link(t('Print leave report'), 'leave_report', $request_date, 'chr_action--transparent'),
-            '#prefix' => '<div id="report-replace-div">',
-            '#suffix' => '</div>',
+            '#markup' => civihr_employee_portal_make_link(t('Print leave report'), 'leave_report', $request_date, 'chr_action--transparent')
         );
 
         // Replace the print leave report URL with the selected date period URL

--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.pages_default.inc
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.pages_default.inc
@@ -268,7 +268,10 @@ function civihr_employee_portal_features_default_page_manager_pages() {
     $pane->style = array(
       'settings' => NULL,
     );
-    $pane->css = array();
+    $pane->css = array(
+      'css_id' => '',
+      'css_class' => 'chr_panel__header--w-actions',
+    );
     $pane->extras = array();
     $pane->position = 0;
     $pane->locks = array();
@@ -312,7 +315,10 @@ function civihr_employee_portal_features_default_page_manager_pages() {
     $pane->style = array(
       'settings' => NULL,
     );
-    $pane->css = array();
+    $pane->css = array(
+      'css_id' => '',
+      'css_class' => 'chr_panel__header--w-actions',
+    );
     $pane->extras = array();
     $pane->position = 0;
     $pane->locks = array();

--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.pages_default.inc
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.pages_default.inc
@@ -261,8 +261,8 @@ function civihr_employee_portal_features_default_page_manager_pages() {
     $pane->shown = TRUE;
     $pane->access = array();
     $pane->configuration = array(
-      'override_title' => 0,
-      'override_title_text' => '',
+      'override_title' => 1,
+      'override_title_text' => t('My Leave'),
     );
     $pane->cache = array();
     $pane->style = array(
@@ -308,8 +308,8 @@ function civihr_employee_portal_features_default_page_manager_pages() {
     $pane->shown = TRUE;
     $pane->access = array();
     $pane->configuration = array(
-      'override_title' => 0,
-      'override_title_text' => '',
+      'override_title' => 1,
+      'override_title_text' => t('My Sickness Report'),
     );
     $pane->cache = array();
     $pane->style = array(

--- a/civihr_employee_portal/src/Blocks/AbsenceLinks.php
+++ b/civihr_employee_portal/src/Blocks/AbsenceLinks.php
@@ -41,10 +41,10 @@ class AbsenceLinks {
         $links = '';
         $links .= '<div class="chr_panel__actions">';
         $links .= '<div class="chr_panel__actions__inline-duo">';
-        $links .= civihr_employee_portal_make_link(t('Request TOIL'), 'credit', null, 'chr_panel__actions__action');
-        $links .= civihr_employee_portal_make_link(t('Request leave'), 'debit', null, 'chr_panel__actions__action');
+        $links .= civihr_employee_portal_make_link(t('Request TOIL'), 'credit');
+        $links .= civihr_employee_portal_make_link(t('Request leave'), 'debit');
         $links .= '</div>';
-        $links .= civihr_employee_portal_make_link(t('Use TOIL'), 'credit_use', null, 'chr_panel__actions__action');
+        $links .= civihr_employee_portal_make_link(t('Use TOIL'), 'credit_use');
         $links .= '</div>';
 
         return $links;

--- a/civihr_employee_portal/src/Blocks/AbsenceLinks.php
+++ b/civihr_employee_portal/src/Blocks/AbsenceLinks.php
@@ -39,11 +39,12 @@ class AbsenceLinks {
         drupal_add_js($civihr_style, 'setting');
 
         $links = '';
-        $links .= '<div id="absence-links" class="list-group" style="height: 50px;">';
-        $links .= civihr_employee_portal_make_link(t('Request TOIL'), 'credit');
-        $links .= civihr_employee_portal_make_link(t('Request leave'), 'debit');
-        $links .= civihr_employee_portal_make_link(t('Use TOIL'), 'credit_use');
-
+        $links .= '<div class="chr_panel__actions">';
+        $links .= '<div class="chr_panel__actions__inline-duo">';
+        $links .= civihr_employee_portal_make_link(t('Request TOIL'), 'credit', null, 'chr_panel__actions__action');
+        $links .= civihr_employee_portal_make_link(t('Request leave'), 'debit', null, 'chr_panel__actions__action');
+        $links .= '</div>';
+        $links .= civihr_employee_portal_make_link(t('Use TOIL'), 'credit_use', null, 'chr_panel__actions__action');
         $links .= '</div>';
 
         return $links;

--- a/civihr_employee_portal/src/Blocks/SicknessLinks.php
+++ b/civihr_employee_portal/src/Blocks/SicknessLinks.php
@@ -11,10 +11,8 @@ class SicknessLinks {
     public function generateBlock() {
 
         $links = '';
-        $links .= '<div id="absence-links" class="list-group" style="height: 50px;">';
-        $links .= civihr_employee_portal_make_link(t('Report new sickness'), 'sick');
-
-
+        $links .= '<div class="chr_panel__actions">';
+        $links .= civihr_employee_portal_make_link(t('Report new sickness'), 'sick', null, 'chr_panel__actions__action');
         $links .= '</div>';
 
         return $links;

--- a/civihr_employee_portal/src/Blocks/SicknessLinks.php
+++ b/civihr_employee_portal/src/Blocks/SicknessLinks.php
@@ -12,7 +12,7 @@ class SicknessLinks {
 
         $links = '';
         $links .= '<div class="chr_panel__actions">';
-        $links .= civihr_employee_portal_make_link(t('Report new sickness'), 'sick', null, 'chr_panel__actions__action');
+        $links .= civihr_employee_portal_make_link(t('Report new sickness'), 'sick');
         $links .= '</div>';
 
         return $links;

--- a/civihr_employee_portal/templates/civihr-employee-portal-my-details--block.tpl.php
+++ b/civihr_employee_portal/templates/civihr-employee-portal-my-details--block.tpl.php
@@ -47,8 +47,7 @@
 ?>
 
 <?php
-    // Show only if we have the logged in user
-    global $user;
+    global $user; // Show only if we have the logged in user
 
     $actions_classes = 'ctools-use-modal ctools-modal-civihr-default-style chr_action--icon--edit';
 
@@ -56,54 +55,35 @@
 ?>
 
 <div class="<?php print $classes; ?>"<?php print $attributes; ?>>
-
     <div class="row relative">
-<!--
-        <?php print render($title_prefix); ?>
-            <h2<?php print $title_attributes; ?>></h2>
-        <?php print render($title_suffix); ?>
- -->
-        <div class="col-md-2 column1 panel-panel">
-            <div class="well">
-                <div class="profile-image">
-                    <?php if (isset($contact_data['image_URL']) && !empty($contact_data['image_URL'])) { ?>
-                        <img src="<?php print $contact_data['image_URL']; ?>" />
-                    <?php } else { ?>
-                        <img src="<?php print drupal_get_path('module', 'civihr_employee_portal') . '/images/profile-default.png' ?>"/>
-                    <?php } ?>
-                </div>
-
+        <div class="col-md-2">
+            <div class="chr_panel--my-details__profile-image hidden-xs hidden-sm">
+                <?php if (isset($contact_data['image_URL']) && !empty($contact_data['image_URL'])) { ?>
+                    <img src="<?php print $contact_data['image_URL']; ?>" />
+                <?php } else { ?>
+                    <img src="<?php print drupal_get_path('module', 'civihr_employee_portal') . '/images/profile-default.png' ?>"/>
+                <?php } ?>
             </div>
         </div>
-
-        <div class="col-md-5 column2 panel-panel">
-            <div class="well">
-                <h5><?php print t('My Details'); ?></h5>
+        <div class="col-md-5 chr_panel--my-details__data-group">
+            <h5 class="chr_panel--my-details__data-group__title"><?php print t('My Details'); ?></h5>
+            <div class="chr_panel--my-details__data-group__content">
                 <?php print $contact_details; ?>
             </div>
-
         </div>
-
-        <div class="col-md-offset-7 vertical-splitter"></div>
-
-        <div class="col-md-5 column3 panel-panel">
-            <div class="well">
-                <h5><?php print $address_data_title ?></h5>
+        <div class="col-md-offset-7 vertical-splitter hidden-xs hidden-sm"></div>
+        <div class="col-md-5 chr_panel--my-details__data-group">
+            <h5 class="chr_panel--my-details__data-group__title"><?php print $address_data_title ?></h5>
+            <div class="chr_panel--my-details__data-group__content">
                 <?php print $address_data; ?>
             </div>
         </div>
-
     </div>
-
     <div class="chr_panel__actions">
         <?php print l(t('Edit my details'), 'my_details/nojs/view', array('attributes' => array('class' => $actions_classes))); ?>
         <?php print l(t('Edit emergency contact'), 'emergency_contacts/nojs/view', array('attributes' => array('class' => $actions_classes))); ?>
     </div>
-
 </div>
-
 <?php
-
     }
-
 ?>

--- a/civihr_employee_portal/templates/civihr-employee-portal-my-details--block.tpl.php
+++ b/civihr_employee_portal/templates/civihr-employee-portal-my-details--block.tpl.php
@@ -50,7 +50,7 @@
     // Show only if we have the logged in user
     global $user;
 
-    $actions_classes = 'btn btn-custom ctools-use-modal ctools-modal-civihr-default-style chr_panel__actions__action--icon--edit';
+    $actions_classes = 'ctools-use-modal ctools-modal-civihr-default-style chr_action--icon--edit';
 
     if ($user->uid) {
 ?>

--- a/civihr_employee_portal/templates/civihr-employee-portal-my-details--block.tpl.php
+++ b/civihr_employee_portal/templates/civihr-employee-portal-my-details--block.tpl.php
@@ -47,9 +47,11 @@
 ?>
 
 <?php
-
     // Show only if we have the logged in user
     global $user;
+
+    $actions_classes = 'btn btn-custom ctools-use-modal ctools-modal-civihr-default-style chr_panel__actions__action--icon--edit';
+
     if ($user->uid) {
 ?>
 
@@ -93,15 +95,9 @@
 
     </div>
 
-    <div class="row">
-
-        <div class="col-md-12">
-            <div class="splitter-top text-right actions">
-                <?php print l(t('Edit my details'), 'my_details/nojs/view', array('attributes' => array('class' => array('btn btn-custom ctools-use-modal ctools-modal-civihr-default-style')))); ?>
-                <?php print l(t('Edit emergency contact'), 'emergency_contacts/nojs/view', array('attributes' => array('class' => array('btn btn-custom ctools-use-modal ctools-modal-civihr-default-style')))); ?>
-            </div>
-        </div>
-
+    <div class="chr_panel__actions">
+        <?php print l(t('Edit my details'), 'my_details/nojs/view', array('attributes' => array('class' => $actions_classes))); ?>
+        <?php print l(t('Edit emergency contact'), 'emergency_contacts/nojs/view', array('attributes' => array('class' => $actions_classes))); ?>
     </div>
 
 </div>

--- a/civihr_employee_portal/views/views_export/views_absence_list.inc
+++ b/civihr_employee_portal/views/views_export/views_absence_list.inc
@@ -17,6 +17,7 @@ $view->disabled = FALSE; /* Edit this to true to make a default view disabled in
 /* Display: Master */
 $handler = $view->new_display('default', 'Master', 'default');
 $handler->display->display_options['title'] = 'Absence list';
+$handler->display->display_options['css_class'] = 'view--w-table';
 $handler->display->display_options['use_ajax'] = TRUE;
 $handler->display->display_options['use_more_always'] = FALSE;
 $handler->display->display_options['access']['type'] = 'role';

--- a/civihr_employee_portal/views/views_export/views_absence_list.inc
+++ b/civihr_employee_portal/views/views_export/views_absence_list.inc
@@ -440,7 +440,6 @@ $handler->display->display_options['filters']['absence_start_date_period_filter'
 $handler->display->display_options['filters']['absence_start_date_period_filter']['expose']['operator'] = 'absence_start_date_period_filter_op';
 $handler->display->display_options['filters']['absence_start_date_period_filter']['expose']['identifier'] = 'absence_start_date_period_filter';
 $handler->display->display_options['filters']['absence_start_date_period_filter']['is_grouped'] = TRUE;
-$handler->display->display_options['filters']['absence_start_date_period_filter']['group_info']['label'] = 'My leave';
 $handler->display->display_options['filters']['absence_start_date_period_filter']['group_info']['identifier'] = 'absence_start_date_period_filter';
 $handler->display->display_options['filters']['absence_start_date_period_filter']['group_info']['optional'] = FALSE;
 $handler->display->display_options['filters']['absence_start_date_period_filter']['group_info']['default_group'] = '1';
@@ -559,7 +558,6 @@ $handler->display->display_options['filters']['absence_start_date_period_filter'
 $handler->display->display_options['filters']['absence_start_date_period_filter']['expose']['operator'] = 'absence_start_date_period_filter_op';
 $handler->display->display_options['filters']['absence_start_date_period_filter']['expose']['identifier'] = 'absence_start_date_period_filter';
 $handler->display->display_options['filters']['absence_start_date_period_filter']['is_grouped'] = TRUE;
-$handler->display->display_options['filters']['absence_start_date_period_filter']['group_info']['label'] = 'My sickness report';
 $handler->display->display_options['filters']['absence_start_date_period_filter']['group_info']['identifier'] = 'absence_start_date_period_filter';
 $handler->display->display_options['filters']['absence_start_date_period_filter']['group_info']['optional'] = FALSE;
 $handler->display->display_options['filters']['absence_start_date_period_filter']['group_info']['default_group'] = '1';


### PR DESCRIPTION
*(For frontend-related things that are mentioned here, please refer to https://github.com/compucorp/civihr-employee-portal-theme/pull/14 )*

Things done:
* Amended `civihr_employee_portal_make_link`
  * It accepts an additional `$class` parameter, which adds custom classes to the link
  * In case of a `.chr_action`, it wraps the action's label in a `span` so that, if needed, the action can be responsive
* Added by default the `view--w-table` class to the absence list view
* Removed the labels of the exposed forms in the "My Leave" and "My Sickness Report" blocks, since they were used as a header, but now the blocks have their proper header displayed instead
* Implemented the new `.chr_action` component
* Refactored the "My Details" markup