### PR TITLE
PCHR-412: Add class to My Details block

### DIFF
--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.pages_default.inc
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.pages_default.inc
@@ -224,7 +224,10 @@ function civihr_employee_portal_features_default_page_manager_pages() {
     $pane->style = array(
       'settings' => NULL,
     );
-    $pane->css = array();
+    $pane->css = array(
+      'css_id' => '',
+      'css_class' => 'chr_panel--my-details',
+    );
     $pane->extras = array();
     $pane->position = 0;
     $pane->locks = array();


### PR DESCRIPTION
In order for the styling of the block to work properly, the "My Details" block must have the .chr_panel--my-details class applied by default