### PR TITLE
 PCHR-413: My Calendar modal responsiveness

### DIFF
--- a/calendar/theme/theme.inc
+++ b/calendar/theme/theme.inc
@@ -740,7 +740,7 @@ function theme_calendar_stripe_legend($vars) {
   foreach ($options as $key => $label) {
     $stripe = array_key_exists($key, $display_options) ? $display_options[$key] : CALENDAR_EMPTY_STRIPE;
     if ($stripe != CALENDAR_EMPTY_STRIPE) {
-      $rows[] = array($label, '<div style="background-color:' . $stripe . ';color:' . $stripe . '" class="stripe" title="Key: ' . $label . '">&nbsp;</div>');
+      $rows[] = array('<div style="background-color:' . $stripe . ';color:' . $stripe . '" class="stripe" title="Key: ' . $label . '">&nbsp;</div>', $label);
     }
   }
 


### PR DESCRIPTION
Just swapping placement of the calendar legend elements. The color square was put after the label, so it had to be absolutely positioned in order for it to be on the left of the label. It's just easier to actually change the order in the backend code

<img width="350" alt="legend" src="https://cloud.githubusercontent.com/assets/6400898/9954711/806dccd8-5deb-11e5-91ac-ade731f5567b.png">
