### PR TITLE
PCHR-513: Implement new CiviHR admin them on reports page

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -372,15 +372,10 @@ function civihr_employee_portal_theme($existing, $type, $theme, $path) {
  */
 function civihr_employee_portal_custom_theme() {
 
-    /**
-     *
-
     // Set the civihr_reports related pages to use the custom civihr admin theme and not the self service theme
     if (arg(0) == 'civihr_reports' || arg(0) == 'civihr_reports_settings') {
-        return 'seven';
+        return 'civihr_admin_theme';
     }
-
-     */
 }
 
 /**


### PR DESCRIPTION
For the reports page, although the page is being served by Drupal, we want to use the look-and-feel of the CiviHR admin. For this reason we explicitly apply the new admin theme (https://github.com/compucorp/civihr-employee-portal-theme/pull/40) on it