### PR TITLE
Pchr 262 - absence reports, refactor, settings + fixes

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -3405,6 +3405,12 @@ function civihr_employee_portal_schema_alter(&$schema) {
         'not null' => TRUE,
         'description' => 'Activity ID.',
     );
+    $schema['absence_list']['fields']['contact_id'] = array(
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'description' => 'CiviCRM Contact ID.',
+    );
     $schema['absence_list']['fields']['absence_title'] = array(
         'type' => 'varchar',
         'length' => 200,

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -297,31 +297,21 @@ function civihr_employee_portal_theme($existing, $type, $theme, $path) {
     // This will set the template file for any view page which is custom report (overriding the theme file what is suggested by drupal views as default)
     $template_url = 'templates/civihr-employee-portal-custom-reports-filter-result';
 
-    // @TODO test with more custom views
-    $view_displays_to_rewrite = array();
-
-    // Fte groups
-    $view_displays_to_rewrite['views_view__filter_fte_location'] = 1;
-
-    // Headcount groups
-    $view_displays_to_rewrite['views_view__filter_headcount_location'] = 1;
-    $view_displays_to_rewrite['views_view__filter_headcount_department'] = 1;
-
-    // Gender groups
-    $view_displays_to_rewrite['views_view__filter_gender_location'] = 1;
-
-    // Age groups
-    $view_displays_to_rewrite['views_view__filter_age_location'] = 1;
+    // Whitelist the available report types
+    $register_class = new ReportSettingsForm('report_settings_form', 'civihr_reports');
+    $register_class->getYAxisFilterTypes();
 
     // This will hold any custom view display names where we need to override the template file
     $theme_hooks = array();
 
-    foreach ($view_displays_to_rewrite as $view_name => $val) {
-        $theme_hooks[$view_name] = array(
-            'template' => $template_url,
-            'base hook' => 'views_view',
-            'arguments' => array('view' => NULL)
-        );
+    foreach ($register_class->getYAxisFilterTypes() as $YAxis => $Y) {
+        foreach ($register_class->getXAxisFilterTypes() as $XAxis => $X) {
+            $theme_hooks['views_view__filter_' . $YAxis . '_' . $XAxis] = array(
+                'template' => $template_url,
+                'base hook' => 'views_view',
+                'arguments' => array('view' => NULL)
+            );
+        }
     }
 
     return $theme_hooks + array(

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -3437,17 +3437,29 @@ function civihr_employee_portal_schema_alter(&$schema) {
         'not null' => TRUE,
         'description' => 'Absence activity (Is Credit type?)',
     );
-    $schema['absence_list']['fields']['absence_start_date_timestamp'] = array(
+    $schema['absence_list']['fields']['absence_start_date'] = array(
         'type' => 'varchar',
         'mysql_type' => 'DATETIME',
         'not null' => FALSE,
         'description' => 'Absence start date.',
     );
-    $schema['absence_list']['fields']['absence_end_date_timestamp'] = array(
+    $schema['absence_list']['fields']['absence_end_date'] = array(
         'type' => 'varchar',
         'mysql_type' => 'DATETIME',
         'not null' => FALSE,
         'description' => 'Absence end date.',
+    );
+    $schema['absence_list']['fields']['absence_start_date_timestamp'] = array(
+        'type' => 'varchar',
+        'mysql_type' => 'DATETIME',
+        'not null' => FALSE,
+        'description' => 'Absence start date. (TIMESTAMP)',
+    );
+    $schema['absence_list']['fields']['absence_end_date_timestamp'] = array(
+        'type' => 'varchar',
+        'mysql_type' => 'DATETIME',
+        'not null' => FALSE,
+        'description' => 'Absence end date. (TIMESTAMP)',
     );
     $schema['absence_list']['fields']['details'] = array(
         'type' => 'text',

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -1235,7 +1235,7 @@
         // For montly reports load the date slider
         // Otherwise load the date picker filter
         // If more logic needed maybe we can change to switch statement
-        if (Drupal.settings.civihr_employee_portal_reports.prefix == 'civihr_reports_monthly') {
+        if (Drupal.settings.civihr_employee_portal_reports.prefix == 'civihr_reports_monthly' || Drupal.settings.civihr_employee_portal_reports.prefix == 'civihr_reports_absence') {
             // Init date slider
             this.initSlider();
         }
@@ -1300,7 +1300,7 @@
         var $sliderControl = _this.$DOM.sections.slider.find('[data-graph-slider-control]');
 
         var format = { view: 'DD/MM/YYYY', month_view: 'MM/YYYY', api: 'YYYY-MM-DD' };
-        var range = [moment('01/01/2010', format.view), moment('31/12/2013', format.view)];
+        var range = [moment('01/01/2010', format.view), moment('31/12/2016', format.view)];
         var init = [moment('01/01/2012', format.view), moment('31/12/2012', format.view)];
         var start_range_date = '01/01/2010';
 
@@ -1308,7 +1308,7 @@
             range: true,
             step: 1,
             min: 0,
-            max: 47,
+            max: 83,
             values: [24, 35],
             create: function () {
                 $sliderControl.find('.ui-slider-handle').each(function (index) {

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -486,8 +486,10 @@
                         return d.data.department;
                     })
                     .rollup(function (d) {
-                        return d3.sum(d, function(g) {
-                            return 1;
+                        return d3.sum(d, function(d) {
+                            // If specific count field is defined, use it as count
+                            // Otherwise fallback to count as 1 (summing up results)
+                            return d.data.count || 1;
                         });
                     })
                     .entries(_chart.data);

--- a/civihr_employee_portal/src/Forms/ReportSettingsForm.php
+++ b/civihr_employee_portal/src/Forms/ReportSettingsForm.php
@@ -115,11 +115,16 @@ class ReportSettingsForm extends BaseForm {
      */
     public function setXAxisFilterTypes($additional_filters = array()) {
 
+        // @TODO -> Filter machine name contract type should be contract_type,
+        // But then the label in the page is showing with underscore
+        // Fix use the label value not the key!
         $filters = array(
             'all' => t('All'),
             'location' => t('Location'),
             'department' => t('Department'),
-            'level' => t('Level')
+            'level' => t('Level'),
+            'contract type' => t('Contract Type'),
+            'project type' => t('Project Type'),
         );
 
         // This function allows to add any new X Axis types if needed and passed to the function properly

--- a/civihr_employee_portal/src/Forms/ReportSettingsForm.php
+++ b/civihr_employee_portal/src/Forms/ReportSettingsForm.php
@@ -118,7 +118,8 @@ class ReportSettingsForm extends BaseForm {
         $filters = array(
             'all' => t('All'),
             'location' => t('Location'),
-            'department' => t('Department')
+            'department' => t('Department'),
+            'level' => t('Level')
         );
 
         // This function allows to add any new X Axis types if needed and passed to the function properly

--- a/civihr_employee_portal/templates/civihr-employee-portal-custom-reports.tpl.php
+++ b/civihr_employee_portal/templates/civihr-employee-portal-custom-reports.tpl.php
@@ -81,7 +81,7 @@
                 </div>
             </div>
 
-            <?php if (arg(0) == 'civihr_reports_monthly') { ?>
+            <?php if (arg(0) == 'civihr_reports_monthly' || arg(0) == 'civihr_reports_absence') { ?>
                 <div class="row">
                     <div class="col-xs-12" data-graph-section="slider">
                         <div data-graph-slider>

--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -38,6 +38,9 @@ function civihr_employee_portal_views_data_alter(&$data) {
     // Add custom date handler for job contract start/end dates
     $data['hrjc_details']['period_start_date']['argument']['handler'] = 'civihr_employee_portal_argument_date_range';
     $data['hrjc_details']['period_end_date']['argument']['handler'] = 'civihr_employee_portal_argument_date_range';
+
+    $data['absence_list']['absence_start_date']['argument']['handler'] = 'civihr_employee_portal_argument_date_range';
+    $data['absence_list']['absence_end_date']['argument']['handler'] = 'civihr_employee_portal_argument_date_range';
         
     $data['json']['absence_entitlement'] = array(
         'title' => t('Absence entitlement value'),

--- a/civihr_employee_portal/views/includes/civihr_employee_portal_handler_absence_duration.inc
+++ b/civihr_employee_portal/views/includes/civihr_employee_portal_handler_absence_duration.inc
@@ -35,7 +35,12 @@ class civihr_employee_portal_handler_absence_duration extends views_handler_fiel
         
         else {
             $value = $this->get_value($values);
-            
+
+            // If the raw format type is selected return the count but not add any specific formatting
+            if (isset($this->options['duration_type']) && $this->options['duration_type'] == 'no_format') {
+                return $value / (6 * 80);
+            }
+
             return $value <= 480 ? $value / (6 * 80) . ' day' : $value / (6 * 80) . ' days';
         }
         
@@ -56,6 +61,7 @@ class civihr_employee_portal_handler_absence_duration extends views_handler_fiel
     function options_form(&$form, &$form_state) {    
         
         $options = array();
+        $options['no_format'] = t('Raw result output');
         
         // Get the absence types
         $absenceTypes = get_civihr_absence_types();

--- a/civihr_employee_portal/views/views_export/report_days_taken_location_absence.inc
+++ b/civihr_employee_portal/views/views_export/report_days_taken_location_absence.inc
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * Exported view absence_reports_days_taken_location report
+ */
+
+$view = new view();
+$view->name = 'absence_reports_days_taken_location';
+$view->description = '';
+$view->tag = 'default';
+$view->base_table = 'absence_list';
+$view->human_name = 'Absence Reports / Days Taken - Location';
+$view->core = 7;
+$view->api_version = '3.0';
+$view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
+
+/* Display: Master */
+$handler = $view->new_display('default', 'Master', 'default');
+$handler->display->display_options['title'] = 'Absence Reports / Days Taken - Location(sum)';
+$handler->display->display_options['use_more_always'] = FALSE;
+$handler->display->display_options['access']['type'] = 'none';
+$handler->display->display_options['cache']['type'] = 'none';
+$handler->display->display_options['query']['type'] = 'views_query';
+$handler->display->display_options['query']['options']['distinct'] = TRUE;
+$handler->display->display_options['exposed_form']['type'] = 'basic';
+$handler->display->display_options['pager']['type'] = 'some';
+$handler->display->display_options['pager']['options']['items_per_page'] = '0';
+$handler->display->display_options['pager']['options']['offset'] = '0';
+$handler->display->display_options['style_plugin'] = 'views_json';
+$handler->display->display_options['style_options']['root_object'] = 'results';
+$handler->display->display_options['style_options']['top_child_object'] = 'data';
+$handler->display->display_options['style_options']['plaintext_output'] = 1;
+$handler->display->display_options['style_options']['remove_newlines'] = 0;
+$handler->display->display_options['style_options']['jsonp_prefix'] = '';
+$handler->display->display_options['style_options']['using_views_api_mode'] = 0;
+$handler->display->display_options['style_options']['object_arrays'] = 0;
+$handler->display->display_options['style_options']['numeric_strings'] = 0;
+$handler->display->display_options['style_options']['bigint_string'] = 0;
+$handler->display->display_options['style_options']['pretty_print'] = 0;
+$handler->display->display_options['style_options']['unescaped_slashes'] = 0;
+$handler->display->display_options['style_options']['unescaped_unicode'] = 0;
+$handler->display->display_options['style_options']['char_encoding'] = array();
+/* Relationship: Absence entity: Contact_id */
+$handler->display->display_options['relationships']['contact_id']['id'] = 'contact_id';
+$handler->display->display_options['relationships']['contact_id']['table'] = 'absence_list';
+$handler->display->display_options['relationships']['contact_id']['field'] = 'contact_id';
+/* Relationship: CiviCRM Contacts: HRJobContract Role entity */
+$handler->display->display_options['relationships']['hrjc_role']['id'] = 'hrjc_role';
+$handler->display->display_options['relationships']['hrjc_role']['table'] = 'civicrm_contact';
+$handler->display->display_options['relationships']['hrjc_role']['field'] = 'hrjc_role';
+$handler->display->display_options['relationships']['hrjc_role']['relationship'] = 'contact_id';
+/* Field: Absence entity: Absence entity ID */
+$handler->display->display_options['fields']['id']['id'] = 'id';
+$handler->display->display_options['fields']['id']['table'] = 'absence_list';
+$handler->display->display_options['fields']['id']['field'] = 'id';
+
+/* Display: Page */
+$handler = $view->new_display('page', 'Page', 'page');
+$handler->display->display_options['defaults']['fields'] = FALSE;
+/* Field: Absence entity: Absence entity ID */
+$handler->display->display_options['fields']['id']['id'] = 'id';
+$handler->display->display_options['fields']['id']['table'] = 'absence_list';
+$handler->display->display_options['fields']['id']['field'] = 'id';
+$handler->display->display_options['fields']['id']['label'] = 'absence_entity_id';
+$handler->display->display_options['fields']['id']['separator'] = '';
+/* Field: Absence entity: Absence_title */
+$handler->display->display_options['fields']['absence_title']['id'] = 'absence_title';
+$handler->display->display_options['fields']['absence_title']['table'] = 'absence_list';
+$handler->display->display_options['fields']['absence_title']['field'] = 'absence_title';
+$handler->display->display_options['fields']['absence_title']['label'] = 'gender';
+/* Field: HRJobContract Role entity: Location */
+$handler->display->display_options['fields']['location']['id'] = 'location';
+$handler->display->display_options['fields']['location']['table'] = 'hrjc_role';
+$handler->display->display_options['fields']['location']['field'] = 'location';
+$handler->display->display_options['fields']['location']['relationship'] = 'hrjc_role';
+$handler->display->display_options['fields']['location']['label'] = 'department';
+/* Field: Absence entity: Absence type row value (Duration) */
+$handler->display->display_options['fields']['duration']['id'] = 'duration';
+$handler->display->display_options['fields']['duration']['table'] = 'absence_list';
+$handler->display->display_options['fields']['duration']['field'] = 'duration';
+$handler->display->display_options['fields']['duration']['label'] = 'count';
+$handler->display->display_options['fields']['duration']['duration_type'] = 'no_format';
+/* Field: Absence entity: Absence_start_date */
+$handler->display->display_options['fields']['absence_start_date']['id'] = 'absence_start_date';
+$handler->display->display_options['fields']['absence_start_date']['table'] = 'absence_list';
+$handler->display->display_options['fields']['absence_start_date']['field'] = 'absence_start_date';
+/* Field: Absence entity: Absence_end_date */
+$handler->display->display_options['fields']['absence_end_date']['id'] = 'absence_end_date';
+$handler->display->display_options['fields']['absence_end_date']['table'] = 'absence_list';
+$handler->display->display_options['fields']['absence_end_date']['field'] = 'absence_end_date';
+$handler->display->display_options['defaults']['arguments'] = FALSE;
+/* Contextual filter: Absence entity: Absence_start_date */
+$handler->display->display_options['arguments']['absence_start_date']['id'] = 'absence_start_date';
+$handler->display->display_options['arguments']['absence_start_date']['table'] = 'absence_list';
+$handler->display->display_options['arguments']['absence_start_date']['field'] = 'absence_start_date';
+$handler->display->display_options['arguments']['absence_start_date']['default_argument_type'] = 'fixed';
+$handler->display->display_options['arguments']['absence_start_date']['summary']['number_of_records'] = '0';
+$handler->display->display_options['arguments']['absence_start_date']['summary']['format'] = 'default_summary';
+$handler->display->display_options['arguments']['absence_start_date']['summary_options']['items_per_page'] = '25';
+$handler->display->display_options['arguments']['absence_start_date']['civihr_range'] = '>=';
+$handler->display->display_options['arguments']['absence_start_date']['civihr_range_empty'] = '1';
+/* Contextual filter: Absence entity: Absence_end_date */
+$handler->display->display_options['arguments']['absence_end_date']['id'] = 'absence_end_date';
+$handler->display->display_options['arguments']['absence_end_date']['table'] = 'absence_list';
+$handler->display->display_options['arguments']['absence_end_date']['field'] = 'absence_end_date';
+$handler->display->display_options['arguments']['absence_end_date']['default_argument_type'] = 'fixed';
+$handler->display->display_options['arguments']['absence_end_date']['summary']['number_of_records'] = '0';
+$handler->display->display_options['arguments']['absence_end_date']['summary']['format'] = 'default_summary';
+$handler->display->display_options['arguments']['absence_end_date']['summary_options']['items_per_page'] = '25';
+$handler->display->display_options['arguments']['absence_end_date']['civihr_range'] = '<=';
+$handler->display->display_options['arguments']['absence_end_date']['civihr_range_empty'] = '1';
+$handler->display->display_options['path'] = 'civihr_reports_absence_days_taken-location';
+$translatables['absence_reports_days_taken_location'] = array(
+    t('Master'),
+    t('Absence Reports / Days Taken - Location(sum)'),
+    t('more'),
+    t('Apply'),
+    t('Reset'),
+    t('Sort by'),
+    t('Asc'),
+    t('Desc'),
+    t('CiviCRM Contact'),
+    t('HRJobContract Role entity'),
+    t('Absence entity ID'),
+    t('.'),
+    t(','),
+    t('Page'),
+    t('absence_entity_id'),
+    t('gender'),
+    t('department'),
+    t('count'),
+    t('Absence_start_date'),
+    t('Absence_end_date'),
+    t('All'),
+);

--- a/civihr_employee_portal/views/views_export/report_fte_level.inc
+++ b/civihr_employee_portal/views/views_export/report_fte_level.inc
@@ -1,0 +1,243 @@
+<?php
+
+/**
+ * Exported view fte_level report
+ */
+
+$view = new view();
+$view->name = 'fte_level';
+$view->description = '';
+$view->tag = 'default';
+$view->base_table = 'hrjc_role';
+$view->human_name = 'FTE / Level';
+$view->core = 7;
+$view->api_version = '3.0';
+$view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
+
+/* Display: Master */
+$handler = $view->new_display('default', 'Master', 'default');
+$handler->display->display_options['title'] = 'Headcount / Filter by Level';
+$handler->display->display_options['use_ajax'] = TRUE;
+$handler->display->display_options['use_more_always'] = FALSE;
+$handler->display->display_options['group_by'] = TRUE;
+$handler->display->display_options['access']['type'] = 'none';
+$handler->display->display_options['cache']['type'] = 'none';
+$handler->display->display_options['query']['type'] = 'views_query';
+$handler->display->display_options['exposed_form']['type'] = 'basic';
+$handler->display->display_options['pager']['type'] = 'full';
+$handler->display->display_options['pager']['options']['items_per_page'] = '0';
+$handler->display->display_options['pager']['options']['offset'] = '0';
+$handler->display->display_options['pager']['options']['id'] = '0';
+$handler->display->display_options['pager']['options']['quantity'] = '9';
+$handler->display->display_options['style_plugin'] = 'views_json';
+$handler->display->display_options['style_options']['root_object'] = 'results';
+$handler->display->display_options['style_options']['top_child_object'] = 'data';
+$handler->display->display_options['style_options']['plaintext_output'] = 1;
+$handler->display->display_options['style_options']['remove_newlines'] = 0;
+$handler->display->display_options['style_options']['jsonp_prefix'] = '';
+$handler->display->display_options['style_options']['using_views_api_mode'] = 0;
+$handler->display->display_options['style_options']['object_arrays'] = 0;
+$handler->display->display_options['style_options']['numeric_strings'] = 0;
+$handler->display->display_options['style_options']['bigint_string'] = 0;
+$handler->display->display_options['style_options']['pretty_print'] = 0;
+$handler->display->display_options['style_options']['unescaped_slashes'] = 0;
+$handler->display->display_options['style_options']['unescaped_unicode'] = 0;
+$handler->display->display_options['style_options']['char_encoding'] = array();
+/* Field: HRJobContract Role entity: Department */
+$handler->display->display_options['fields']['department_1']['id'] = 'department_1';
+$handler->display->display_options['fields']['department_1']['table'] = 'hrjc_role';
+$handler->display->display_options['fields']['department_1']['field'] = 'department';
+$handler->display->display_options['fields']['department_1']['label'] = 'department';
+/* Field: COUNT(HRJobContract Role entity: Department) */
+$handler->display->display_options['fields']['department']['id'] = 'department';
+$handler->display->display_options['fields']['department']['table'] = 'hrjc_role';
+$handler->display->display_options['fields']['department']['field'] = 'department';
+$handler->display->display_options['fields']['department']['group_type'] = 'count';
+$handler->display->display_options['fields']['department']['label'] = 'count';
+$handler->display->display_options['fields']['department']['separator'] = '';
+
+/* Display: FTE / Level (sum) */
+$handler = $view->new_display('page', 'FTE / Level (sum)', 'page');
+$handler->display->display_options['defaults']['title'] = FALSE;
+$handler->display->display_options['title'] = 'FTE / Filter by Level';
+$handler->display->display_options['defaults']['relationships'] = FALSE;
+/* Relationship: HRJobContract Role entity: Contact_id */
+$handler->display->display_options['relationships']['contact_id']['id'] = 'contact_id';
+$handler->display->display_options['relationships']['contact_id']['table'] = 'hrjc_role';
+$handler->display->display_options['relationships']['contact_id']['field'] = 'contact_id';
+/* Relationship: CiviCRM Contacts: HRJobContract Hour entity */
+$handler->display->display_options['relationships']['hrjc_hour']['id'] = 'hrjc_hour';
+$handler->display->display_options['relationships']['hrjc_hour']['table'] = 'civicrm_contact';
+$handler->display->display_options['relationships']['hrjc_hour']['field'] = 'hrjc_hour';
+$handler->display->display_options['relationships']['hrjc_hour']['relationship'] = 'contact_id';
+$handler->display->display_options['defaults']['fields'] = FALSE;
+/* Field: HRJobContract Role entity: Level_type */
+$handler->display->display_options['fields']['level_type']['id'] = 'level_type';
+$handler->display->display_options['fields']['level_type']['table'] = 'hrjc_role';
+$handler->display->display_options['fields']['level_type']['field'] = 'level_type';
+$handler->display->display_options['fields']['level_type']['label'] = 'department';
+/* Field: SUM(HRJobContract Hour entity: Hours_fte) */
+$handler->display->display_options['fields']['hours_fte']['id'] = 'hours_fte';
+$handler->display->display_options['fields']['hours_fte']['table'] = 'hrjc_hour';
+$handler->display->display_options['fields']['hours_fte']['field'] = 'hours_fte';
+$handler->display->display_options['fields']['hours_fte']['relationship'] = 'hrjc_hour';
+$handler->display->display_options['fields']['hours_fte']['group_type'] = 'sum';
+$handler->display->display_options['fields']['hours_fte']['label'] = 'count';
+$handler->display->display_options['path'] = 'civihr_reports_fte-level';
+
+/* Display: Filter by Level */
+$handler = $view->new_display('block', 'Filter by Level', 'filter_fte_level');
+$handler->display->display_options['defaults']['title'] = FALSE;
+$handler->display->display_options['title'] = 'FTE / Filter by Level';
+$handler->display->display_options['defaults']['group_by'] = FALSE;
+$handler->display->display_options['defaults']['pager'] = FALSE;
+$handler->display->display_options['pager']['type'] = 'full';
+$handler->display->display_options['pager']['options']['items_per_page'] = '2';
+$handler->display->display_options['pager']['options']['offset'] = '0';
+$handler->display->display_options['pager']['options']['id'] = '0';
+$handler->display->display_options['pager']['options']['quantity'] = '9';
+$handler->display->display_options['defaults']['style_plugin'] = FALSE;
+$handler->display->display_options['style_plugin'] = 'table';
+$handler->display->display_options['style_options']['columns'] = array(
+    'department_1' => 'department_1',
+    'contact_id' => 'contact_id',
+);
+$handler->display->display_options['style_options']['default'] = '-1';
+$handler->display->display_options['style_options']['info'] = array(
+    'department_1' => array(
+        'sortable' => 1,
+        'default_sort_order' => 'asc',
+        'align' => '',
+        'separator' => '',
+        'empty_column' => 0,
+    ),
+    'contact_id' => array(
+        'sortable' => 0,
+        'default_sort_order' => 'asc',
+        'align' => '',
+        'separator' => '',
+        'empty_column' => 0,
+    ),
+);
+$handler->display->display_options['defaults']['style_options'] = FALSE;
+$handler->display->display_options['defaults']['row_plugin'] = FALSE;
+$handler->display->display_options['defaults']['row_options'] = FALSE;
+$handler->display->display_options['defaults']['relationships'] = FALSE;
+/* Relationship: HRJobContract Role entity: Contact_id */
+$handler->display->display_options['relationships']['contact_id']['id'] = 'contact_id';
+$handler->display->display_options['relationships']['contact_id']['table'] = 'hrjc_role';
+$handler->display->display_options['relationships']['contact_id']['field'] = 'contact_id';
+$handler->display->display_options['defaults']['fields'] = FALSE;
+/* Field: CiviCRM Contacts: Display Name */
+$handler->display->display_options['fields']['display_name']['id'] = 'display_name';
+$handler->display->display_options['fields']['display_name']['table'] = 'civicrm_contact';
+$handler->display->display_options['fields']['display_name']['field'] = 'display_name';
+$handler->display->display_options['fields']['display_name']['relationship'] = 'contact_id';
+$handler->display->display_options['fields']['display_name']['link_to_civicrm_contact'] = 0;
+/* Field: HRJobContract Role entity: Location */
+$handler->display->display_options['fields']['location']['id'] = 'location';
+$handler->display->display_options['fields']['location']['table'] = 'hrjc_role';
+$handler->display->display_options['fields']['location']['field'] = 'location';
+/* Field: HRJobContract Role entity: Level_type */
+$handler->display->display_options['fields']['level_type']['id'] = 'level_type';
+$handler->display->display_options['fields']['level_type']['table'] = 'hrjc_role';
+$handler->display->display_options['fields']['level_type']['field'] = 'level_type';
+$handler->display->display_options['fields']['level_type']['label'] = 'Level type';
+/* Field: Bulk operations: HRJobContract Role entity */
+$handler->display->display_options['fields']['views_bulk_operations']['id'] = 'views_bulk_operations';
+$handler->display->display_options['fields']['views_bulk_operations']['table'] = 'hrjc_role';
+$handler->display->display_options['fields']['views_bulk_operations']['field'] = 'views_bulk_operations';
+$handler->display->display_options['fields']['views_bulk_operations']['vbo_settings']['display_type'] = '0';
+$handler->display->display_options['fields']['views_bulk_operations']['vbo_settings']['enable_select_all_pages'] = 1;
+$handler->display->display_options['fields']['views_bulk_operations']['vbo_settings']['row_clickable'] = 1;
+$handler->display->display_options['fields']['views_bulk_operations']['vbo_settings']['force_single'] = 0;
+$handler->display->display_options['fields']['views_bulk_operations']['vbo_settings']['entity_load_capacity'] = '10';
+$handler->display->display_options['fields']['views_bulk_operations']['vbo_operations'] = array(
+    'action::views_data_export_action_csv_export' => array(
+        'selected' => 1,
+        'skip_confirmation' => 1,
+        'override_label' => 1,
+        'label' => 'CSV',
+    ),
+);
+$handler->display->display_options['defaults']['arguments'] = FALSE;
+/* Contextual filter: HRJobContract Role entity: Level_type */
+$handler->display->display_options['arguments']['level_type']['id'] = 'level_type';
+$handler->display->display_options['arguments']['level_type']['table'] = 'hrjc_role';
+$handler->display->display_options['arguments']['level_type']['field'] = 'level_type';
+$handler->display->display_options['arguments']['level_type']['default_argument_type'] = 'fixed';
+$handler->display->display_options['arguments']['level_type']['summary']['number_of_records'] = '0';
+$handler->display->display_options['arguments']['level_type']['summary']['format'] = 'default_summary';
+$handler->display->display_options['arguments']['level_type']['summary_options']['items_per_page'] = '25';
+$handler->display->display_options['arguments']['level_type']['limit'] = '0';
+$handler->display->display_options['defaults']['filter_groups'] = FALSE;
+$handler->display->display_options['defaults']['filters'] = FALSE;
+
+/* Display: CSV data export */
+$handler = $view->new_display('views_data_export', 'CSV data export', 'headcount_level_export');
+$handler->display->display_options['defaults']['title'] = FALSE;
+$handler->display->display_options['title'] = 'FTE / Filter by Level';
+$handler->display->display_options['defaults']['group_by'] = FALSE;
+$handler->display->display_options['pager']['type'] = 'some';
+$handler->display->display_options['style_plugin'] = 'views_data_export_csv';
+$handler->display->display_options['defaults']['fields'] = FALSE;
+/* Field: HRJobContract Role entity: Location */
+$handler->display->display_options['fields']['location']['id'] = 'location';
+$handler->display->display_options['fields']['location']['table'] = 'hrjc_role';
+$handler->display->display_options['fields']['location']['field'] = 'location';
+/* Field: HRJobContract Role entity: Level_type */
+$handler->display->display_options['fields']['level_type']['id'] = 'level_type';
+$handler->display->display_options['fields']['level_type']['table'] = 'hrjc_role';
+$handler->display->display_options['fields']['level_type']['field'] = 'level_type';
+$handler->display->display_options['fields']['level_type']['label'] = 'Level Type';
+$handler->display->display_options['defaults']['arguments'] = FALSE;
+/* Contextual filter: HRJobContract Role entity: Level_type */
+$handler->display->display_options['arguments']['level_type']['id'] = 'level_type';
+$handler->display->display_options['arguments']['level_type']['table'] = 'hrjc_role';
+$handler->display->display_options['arguments']['level_type']['field'] = 'level_type';
+$handler->display->display_options['arguments']['level_type']['default_argument_type'] = 'fixed';
+$handler->display->display_options['arguments']['level_type']['summary']['number_of_records'] = '0';
+$handler->display->display_options['arguments']['level_type']['summary']['format'] = 'default_summary';
+$handler->display->display_options['arguments']['level_type']['summary_options']['items_per_page'] = '25';
+$handler->display->display_options['arguments']['level_type']['limit'] = '0';
+$handler->display->display_options['path'] = 'fte-level-export';
+$handler->display->display_options['displays'] = array(
+    'filter_fte_location' => 'filter_fte_location',
+    'default' => 0,
+    'page' => 0,
+);
+$handler->display->display_options['sitename_title'] = 0;
+$translatables['fte_level'] = array(
+    t('Master'),
+    t('Headcount / Filter by Level'),
+    t('more'),
+    t('Apply'),
+    t('Reset'),
+    t('Sort by'),
+    t('Asc'),
+    t('Desc'),
+    t('Items per page'),
+    t('- All -'),
+    t('Offset'),
+    t('« first'),
+    t('‹ previous'),
+    t('next ›'),
+    t('last »'),
+    t('department'),
+    t('count'),
+    t('FTE / Level (sum)'),
+    t('FTE / Filter by Level'),
+    t('CiviCRM Contact'),
+    t('HRJobContract Hour entity'),
+    t('Filter by Level'),
+    t('FTE / Filter by Level'),
+    t('Display Name'),
+    t('Location'),
+    t('Level type'),
+    t('HRJobContract Role entity'),
+    t('- Choose an operation -'),
+    t('CSV'),
+    t('All'),
+    t('CSV data export'),
+    t('Level Type'),
+);

--- a/civihr_employee_portal/views/views_export/report_fte_level.inc
+++ b/civihr_employee_portal/views/views_export/report_fte_level.inc
@@ -202,7 +202,7 @@ $handler->display->display_options['arguments']['level_type']['summary_options']
 $handler->display->display_options['arguments']['level_type']['limit'] = '0';
 $handler->display->display_options['path'] = 'fte-level-export';
 $handler->display->display_options['displays'] = array(
-    'filter_fte_location' => 'filter_fte_location',
+    'filter_fte_level' => 'filter_fte_level',
     'default' => 0,
     'page' => 0,
 );

--- a/civihr_hrjobcontract_entities/civihr_hrjobcontract_entities.module
+++ b/civihr_hrjobcontract_entities/civihr_hrjobcontract_entities.module
@@ -894,6 +894,10 @@ function civihr_hrjobcontract_entities_entity_property_info_alter(&$info) {
     $info['hrjobcontract_pay']['properties']['contact_id']['type'] = 'civicrm_contact';
     $info['hrjobcontract_pension']['properties']['contact_id']['type'] = 'civicrm_contact';
     $info['hrjobcontract_role']['properties']['contact_id']['type'] = 'civicrm_contact';
+
+    // Add relationship to CiviCRM contact for the Absence Entity
+    $info['civihr_absences']['properties']['contact_id']['type'] = 'civicrm_contact';
+
 }
 
 /**


### PR DESCRIPTION
- More abstracted whitelisting for the template file - based on the report types it will load the templates/civihr-employee-portal-custom-reports-filter-result.tpl file. Previously the report types were hardcoded
- Added View FTE / Level - from the demo presentation
- Added new relationship handler -> absence view can now have a relationship with contact entity. Previously the absence view we were unable to link it to contact entity in the views
- Added raw result type for duration handler - this raw result type is used to calculate the duration in the absence days taken report
- Added days taken view and report
- Fixed date range slider to show month names and not days
- Added some more default X axis filter types so they can be set in the settings page and enabled