### PR TITLE
UY-24: Donot send cancellation email to Old Manager

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5314,7 +5314,10 @@ function _getManagerContacts($contact_id) {
     // If Leave approver is find, assign him as the manager (add contact ID to $assigned_manager_contact_ids array)
     foreach ($contactRelationships as $key => $relation) {
         if ($relation['relation'] == variable_get('relationship_name_to_use', 'has Leave Approved by')) {
-            if($relation['is_active'] == 1){
+            if($relation['is_active'] == 1
+               &&
+               ($relation['end_date'] >= date('Y-m-d') || $relation['end_date'] == ''))
+            {
                 $assigned_manager_contact_ids[] = $relation['contact_id_b'];
                 $manager_found++;
             }

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5348,10 +5348,5 @@ function _getManagerContacts($contact_id) {
  * @return boolean
  */
 function relationActiveAndCurrent($relation){
-  if($relation['is_active'] == 1
-    &&
-    ($relation['end_date'] >= date('Y-m-d') || $relation['end_date'] == '')){
-      return true;
-  }
-  return false;
+  return $relation['is_active'] == 1 && (strtotime($relation['end_date']) >= time() || empty($relation['end_date']));
 }

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5313,15 +5313,13 @@ function _getManagerContacts($contact_id) {
 
     // If Leave approver is find, assign him as the manager (add contact ID to $assigned_manager_contact_ids array)
     foreach ($contactRelationships as $key => $relation) {
-        if ($relation['relation'] == variable_get('relationship_name_to_use', 'has Leave Approved by')) {
-            if($relation['is_active'] == 1
-               &&
-               ($relation['end_date'] >= date('Y-m-d') || $relation['end_date'] == ''))
-            {
-                $assigned_manager_contact_ids[] = $relation['contact_id_b'];
-                $manager_found++;
-            }
+      if ($relation['relation'] == variable_get('relationship_name_to_use', 'has Leave Approved by')) {
+        if(relationActiveAndCurrent($relation))
+        {
+          $assigned_manager_contact_ids[] = $relation['contact_id_b'];
+          $manager_found++;
         }
+      }
     }
 
     // If no assigned managers found
@@ -5341,4 +5339,19 @@ function _getManagerContacts($contact_id) {
     }
 
     return $assigned_manager_contact_ids;
+}
+
+/**
+ * Function to determine if given manager-contact relationship is inactive or active
+ *
+ * @param array $relation
+ * @return boolean
+ */
+function relationActiveAndCurrent($relation){
+  if($relation['is_active'] == 1
+    &&
+    ($relation['end_date'] >= date('Y-m-d') || $relation['end_date'] == '')){
+      return true;
+  }
+  return false;
 }


### PR DESCRIPTION
Issue:
The cancellation emails were getting sent to old managers as well.

Solution:
Modify function `function _getManagerContacts($contact_id)` to return only active managers.