### PR TITLE
PCHR-759: Show leave request for past managers

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.info
+++ b/civihr_employee_portal/civihr_employee_portal.info
@@ -63,6 +63,7 @@ files[] = views/includes/views_json_query_argument_request_handler.inc
 files[] = views/includes/views_json_query_argument_document_contacts_request_handler.inc
 files[] = views/includes/views_json_query_argument_task_contacts_request_handler.inc
 files[] = views/includes/views_json_query_argument_appraisal_contact_id_request_handler.inc
+files[] = views/includes/civihr_employee_portal_handler_manager_id.inc
 
 ; Custom js
 scripts[] = js/scripts.js

--- a/civihr_employee_portal/src/Blocks/ManagerCalendar.php
+++ b/civihr_employee_portal/src/Blocks/ManagerCalendar.php
@@ -19,7 +19,7 @@ class ManagerCalendar {
 
         $uid = $user->uid;
         $result = db_query('SELECT aal.employee_id, aal.id, aal.activity_type_id, aal.absence_title, aal.duration, aal.absence_start_date_timestamp, aal.absence_end_date_timestamp, absence_status
-        FROM {absence_approval_list} aal WHERE aal.drupal_uid = :uid', array(':uid' => $user->uid));
+        FROM {absence_approval_list} aal');
 
         // Result is returned as a iterable object that returns a stdClass object on each iteration
         foreach ($result as $record) {

--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -462,6 +462,26 @@ function civihr_employee_portal_views_data_alter(&$data) {
         'sort' => array('handler' => 'views_handler_sort'),
     );
     
+    $data['absence_approval_list']['manager_id'] = array(
+        'title' => t('Manager ID'),
+        'help' => t('Manager ID field value'),
+        'real field' => 'manager_id',
+        'field' => array(
+            'handler' => 'civihr_employee_portal_handler_manager_id',
+            'click sortable' => TRUE,
+        ),
+        'argument' => array(
+            'handler' => 'views_handler_argument_string',
+            'name_field' => 'title',
+            'string' => TRUE
+        ),
+        'filter' => array(
+            'handler' => 'views_handler_filter_string',
+            'help' => t('Filter results to a particular result set'),
+        ),
+        'sort' => array('handler' => 'views_handler_sort'),
+    );
+
     // Add custom date handler
     $data['absence_approval_list']['absence_start_date_timestamp']['field']['handler'] = 'views_handler_field_date';
     $data['absence_approval_list']['absence_start_date_timestamp']['sort']['handler'] = 'views_handler_sort_date';
@@ -503,6 +523,28 @@ function civihr_employee_portal_views_pre_render(&$view) {
       $view->result = removeInactiveManagers($view->result);
       $view->result = removeInactiveDepartments($view->result);
     }
+
+    if($view->name == "approvals"){
+      $view->result = removeAbsencesForOtherManagers($view->result);
+    }
+}
+
+/**
+ * Remove absences of contacts that belong to managers other than the currently logged in manager
+ *
+ */
+function removeAbsencesForOtherManagers($results){
+  global $user;
+  $managerData = get_civihr_uf_match_data($user->uid);
+  $managerId = $managerData['contact_id'];
+
+  foreach($results as $key => $value){
+    $managers = _getManagerContacts($value->absence_approval_list_employee_id);
+    if(!in_array($managerId, $managers)){
+      unset($results[$key]);
+    }
+  }
+  return $results;
 }
 
 /**

--- a/civihr_employee_portal/views/includes/civihr_employee_portal_handler_manager_id.inc
+++ b/civihr_employee_portal/views/includes/civihr_employee_portal_handler_manager_id.inc
@@ -1,0 +1,5 @@
+<?php
+
+class civihr_employee_portal_handler_manager_id extends views_handler_field{
+    
+}

--- a/civihr_employee_portal/views/views_export/views_manager_approval_list.inc
+++ b/civihr_employee_portal/views/views_export/views_manager_approval_list.inc
@@ -248,6 +248,11 @@ $handler->display->display_options['fields']['absence_status']['field'] = 'absen
 $handler->display->display_options['fields']['absence_status']['label'] = 'Status';
 $handler->display->display_options['fields']['absence_status']['alter']['alter_text'] = TRUE;
 $handler->display->display_options['fields']['absence_status']['alter']['text'] = '<div id="act-id-[id]">[absence_status]</div>';
+/* Field: Absence approval entity: Manager ID */
+$handler->display->display_options['fields']['manager_id']['id'] = 'manager_id';
+$handler->display->display_options['fields']['manager_id']['table'] = 'absence_approval_list';
+$handler->display->display_options['fields']['manager_id']['field'] = 'manager_id';
+$handler->display->display_options['fields']['manager_id']['exclude'] = TRUE;
 $handler->display->display_options['defaults']['sorts'] = FALSE;
 /* Sort criterion: Absence approval entity: Absence_start_date_timestamp */
 $handler->display->display_options['sorts']['absence_start_date_timestamp']['id'] = 'absence_start_date_timestamp';
@@ -321,6 +326,7 @@ $translatables['approvals'] = array(
   t('next ›'),
   t('last »'),
   t('Nothing to show yet!'),
+  t('Manager ID'),
   t('Awaiting Approvals'),
   t('Awaiting Approvals dashboard block'),
   t('<a href="absence_all/nojs/view" class="chr_action--icon--list chr_action--transparent chr_action--icon--responsive ctools-use-modal ctools-modal-civihr-custom-large-style"><span>Show all Absences</span></a><a href="manager_approval/nojs/calendar/show" class="chr_action--icon--calendar chr_action--transparent chr_action--icon--responsive ctools-use-modal ctools-modal-civihr-default-style"><span>Open Calendar</span></a>'),

--- a/civihr_employee_portal/views/views_export/views_manager_approval_list.inc
+++ b/civihr_employee_portal/views/views_export/views_manager_approval_list.inc
@@ -29,25 +29,25 @@ $handler->display->display_options['pager']['options']['offset'] = '0';
 $handler->display->display_options['style_plugin'] = 'table';
 $handler->display->display_options['style_options']['row_class'] = 'manager-approval-row';
 $handler->display->display_options['style_options']['columns'] = array(
-    'id' => 'id',
-    'absence_title' => 'absence_title',
+  'id' => 'id',
+  'absence_title' => 'absence_title',
 );
 $handler->display->display_options['style_options']['default'] = '-1';
 $handler->display->display_options['style_options']['info'] = array(
-    'id' => array(
-        'sortable' => 0,
-        'default_sort_order' => 'asc',
-        'align' => '',
-        'separator' => '',
-        'empty_column' => 0,
-    ),
-    'absence_title' => array(
-        'sortable' => 0,
-        'default_sort_order' => 'asc',
-        'align' => '',
-        'separator' => '',
-        'empty_column' => 0,
-    ),
+  'id' => array(
+    'sortable' => 0,
+    'default_sort_order' => 'asc',
+    'align' => '',
+    'separator' => '',
+    'empty_column' => 0,
+  ),
+  'absence_title' => array(
+    'sortable' => 0,
+    'default_sort_order' => 'asc',
+    'align' => '',
+    'separator' => '',
+    'empty_column' => 0,
+  ),
 );
 /* Header: Global: Text area */
 $handler->display->display_options['header']['area']['id'] = 'area';
@@ -155,15 +155,6 @@ $handler->display->display_options['fields']['nothing_1']['alter']['text'] = '<d
 $handler->display->display_options['sorts']['absence_start_date_timestamp']['id'] = 'absence_start_date_timestamp';
 $handler->display->display_options['sorts']['absence_start_date_timestamp']['table'] = 'absence_approval_list';
 $handler->display->display_options['sorts']['absence_start_date_timestamp']['field'] = 'absence_start_date_timestamp';
-/* Contextual filter: Absence approval entity: Drupal_uid */
-$handler->display->display_options['arguments']['drupal_uid']['id'] = 'drupal_uid';
-$handler->display->display_options['arguments']['drupal_uid']['table'] = 'absence_approval_list';
-$handler->display->display_options['arguments']['drupal_uid']['field'] = 'drupal_uid';
-$handler->display->display_options['arguments']['drupal_uid']['default_action'] = 'default';
-$handler->display->display_options['arguments']['drupal_uid']['default_argument_type'] = 'current_user';
-$handler->display->display_options['arguments']['drupal_uid']['summary']['number_of_records'] = '0';
-$handler->display->display_options['arguments']['drupal_uid']['summary']['format'] = 'default_summary';
-$handler->display->display_options['arguments']['drupal_uid']['summary_options']['items_per_page'] = '25';
 
 /* Display: Approved / Rejected */
 $handler = $view->new_display('page', 'Approved / Rejected', 'page');
@@ -292,47 +283,45 @@ $handler->display->display_options['filters']['absence_status']['table'] = 'abse
 $handler->display->display_options['filters']['absence_status']['field'] = 'absence_status';
 $handler->display->display_options['filters']['absence_status']['value'] = '1';
 $translatables['approvals'] = array(
-    t('Master'),
-    t('Manager Absence Approval'),
-    t('more'),
-    t('Apply'),
-    t('Reset'),
-    t('Sort by'),
-    t('Asc'),
-    t('Desc'),
-    t('<a href="manager_approval/nojs/calendar/show" class="ctools-use-modal ctools-modal-civihr-default-style">Open manager calendar</a>'),
-    t('Nothing to approve yet!'),
-    t('Employee CiviCRM Contact ID'),
-    t('.'),
-    t('Main Absence ID'),
-    t('Activity type ID'),
-    t('Employee name'),
-    t('Type'),
-    t('Duration'),
-    t('Dates'),
-    t('[absence_start_date_timestamp] - [absence_end_date_timestamp] ([duration])'),
-    t('Status'),
-    t('<div id="act-id-[id]">[absence_status]</div>'),
-    t('Pick days'),
-    t('<a href="manager_approval/nojs/pick_days/[employee_id]/[id]/[activity_type_id]" class="ctools-use-modal ctools-modal-civihr-default-style fa fa-calendar"></a>'),
-    t('Choose days'),
-    t('1'),
-    t('Action'),
-    t('<div class="manager-approval-main-table__actions"><span id="[id]" class="manager-approval-main-table__actions__action manager-approval-main-table__actions__action--approve fa fa-lg fa-check-circle" aria-hidden="true"></span><span id="[id]" class="manager-approval-main-table__actions__action manager-approval-main-table__actions__action--deny fa fa-lg fa-times-circle" aria-hidden="true"></span></div>
+  t('Master'),
+  t('Manager Absence Approval'),
+  t('more'),
+  t('Apply'),
+  t('Reset'),
+  t('Sort by'),
+  t('Asc'),
+  t('Desc'),
+  t('<a href="manager_approval/nojs/calendar/show" class="ctools-use-modal ctools-modal-civihr-default-style">Open manager calendar</a>'),
+  t('Nothing to approve yet!'),
+  t('Employee CiviCRM Contact ID'),
+  t('.'),
+  t('Main Absence ID'),
+  t('Activity type ID'),
+  t('Employee name'),
+  t('Type'),
+  t('Duration'),
+  t('Dates'),
+  t('[absence_start_date_timestamp] - [absence_end_date_timestamp] ([duration])'),
+  t('Status'),
+  t('<div id="act-id-[id]">[absence_status]</div>'),
+  t('Pick days'),
+  t('<a href="manager_approval/nojs/pick_days/[employee_id]/[id]/[activity_type_id]" class="ctools-use-modal ctools-modal-civihr-custom-large-style fa fa-calendar"></a>'),
+  t('Choose days'),
+  t('1'),
+  t('Action'),
+  t('<div class="manager-approval-main-table__actions"><span id="[id]" class="manager-approval-main-table__actions__action manager-approval-main-table__actions__action--approve fa fa-lg fa-check-circle" aria-hidden="true"></span><span id="[id]" class="manager-approval-main-table__actions__action manager-approval-main-table__actions__action--deny fa fa-lg fa-times-circle" aria-hidden="true"></span></div>
 [tooltip]'),
-    t('All'),
-    t('Approved / Rejected'),
-    t('All Assigned Absences except awaiting approvals'),
-    t('Items per page'),
-    t('- All -'),
-    t('Offset'),
-    t('« first'),
-    t('‹ previous'),
-    t('next ›'),
-    t('last »'),
-    t('Nothing to show yet!'),
-    t('Awaiting Approvals'),
-    t('Awaiting Approvals dashboard block'),
-    t('<a href="manager_approval/nojs/calendar/show" class="ctools-use-modal ctools-modal-civihr-default-style">Open Manager Calendar</a>
-<a href="absence_all/nojs/view" class="ctools-use-modal ctools-modal-civihr-default-style show-all-absences">Show all Absences</a>'),
+  t('Approved / Rejected'),
+  t('All Assigned Absences except awaiting approvals'),
+  t('Items per page'),
+  t('- All -'),
+  t('Offset'),
+  t('« first'),
+  t('‹ previous'),
+  t('next ›'),
+  t('last »'),
+  t('Nothing to show yet!'),
+  t('Awaiting Approvals'),
+  t('Awaiting Approvals dashboard block'),
+  t('<a href="absence_all/nojs/view" class="chr_action--icon--list chr_action--transparent chr_action--icon--responsive ctools-use-modal ctools-modal-civihr-custom-large-style"><span>Show all Absences</span></a><a href="manager_approval/nojs/calendar/show" class="chr_action--icon--calendar chr_action--transparent chr_action--icon--responsive ctools-use-modal ctools-modal-civihr-default-style"><span>Open Calendar</span></a>'),
 );


### PR DESCRIPTION
PR addresses the following issue:
When the manager of a contact is changed, the new manager is not able to view the absences that were assigned to the past manager and hence not able to accept/reject those absences either.