### PR TITLE
PCHR-830: Donot show leave requests for future manager

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5356,5 +5356,6 @@ function _getManagerContacts($contact_id) {
  * @return boolean
  */
 function relationActiveAndCurrent($relation){
-  return $relation['is_active'] == 1 && (strtotime($relation['end_date']) >= time() || empty($relation['end_date']));
+  return $relation['is_active'] == 1 && (strtotime($relation['end_date']) >= time() || empty($relation['end_date']))
+          && (empty($relation['start_date']) || strtotime($relation['start_date']) <= time());
 }


### PR DESCRIPTION
Modified `function relationActiveAndCurrent` to return `true` if start date for relationship is in the past or is empty.