### PR TITLE
PCHR-798: Improve my leave block default absence period to the current one

### DIFF
--- a/civihr_employee_portal/views/includes/civihr_employee_portal_filter_absence_period.inc
+++ b/civihr_employee_portal/views/includes/civihr_employee_portal_filter_absence_period.inc
@@ -22,18 +22,18 @@ class civihr_employee_portal_filter_absence_period extends views_handler_filter_
       $any_label = variable_get('views_exposed_filter_any_label', 'new_any') == 'old_any' ? $old_any : t('- Any -');
       $groups = array('All' => $any_label);
     }
-    
+
     // Get civi defined date periods
     $civi_date_periods = get_civihr_date_periods();
-        
+
     $filter_values = array();
-        
+
     foreach ($civi_date_periods as $civi_date_period) {
-            
+
         $filter_values[$civi_date_period['id']] = array('title' => $civi_date_period['title'], 'operator' => 'between', 'value' => array('type' => 'date', 'value' => '', 'min' => $civi_date_period['start_date'], 'max' => $civi_date_period['end_date']));
-            
+
     }
-    
+
     // Force rewrite default values (from CIVIcrm)
     $this->options['group_info']['group_items'] = $filter_values;
 
@@ -44,8 +44,8 @@ class civihr_employee_portal_filter_absence_period extends views_handler_filter_
     }
 
     if (count($groups)) {
+      variable_set('default_date_period_id', $this->getDefaultDatePeriod($filter_values));
       $value = $this->options['group_info']['identifier'];
-
       $form[$value] = array(
         '#type' => $this->options['group_info']['widget'],
         '#default_value' => variable_get('default_date_period_id', '1'),
@@ -54,6 +54,30 @@ class civihr_employee_portal_filter_absence_period extends views_handler_filter_
 
       $this->options['expose']['label'] = '';
     }
+  }
+
+  /**
+   * Get the default period id from a list of periods based on current time
+   *
+   * @param array $periods_list Filtered absence periods
+   * @return int Absence period database id
+   */
+
+  public static function getDefaultDatePeriod($periods_list) {
+    $current_date = new DateTime();
+    $current_timestamp = $current_date->getTimestamp();
+
+    foreach($periods_list as $period_id => $period) {
+      $start_date = new DateTime($period['value']['min']);
+      $end_date  = new DateTime($period['value']['max']);
+      if ( $current_timestamp > $start_date->getTimestamp() &&
+          $current_timestamp < $end_date->getTimestamp() )  {
+        return $period_id;
+      }
+    }
+
+    return key($periods_list);
+
   }
     
 }


### PR DESCRIPTION
# Problem 

My leave block absence period selector was not pointing to the current period.

<img width="629" alt="1" src="https://cloud.githubusercontent.com/assets/17959662/14018384/726bba3c-f1c5-11e5-8c38-b2967ceefcca.png">


# Solution


I fixed it to set the default option to the current period based on the current date , and in case the current date do not fit into any absence period it will default to the latest period in term of End Date.

![selection_002](https://cloud.githubusercontent.com/assets/17959662/14018683/e311f034-f1c6-11e5-9055-4af530ab4fbd.png)

![selection_001](https://cloud.githubusercontent.com/assets/17959662/14018704/0520bc50-f1c7-11e5-968e-dd424fd26f10.png)
