### PR TITLE
PCHR-851: Removes rejected leaves from My Leave and Manager Absence Approval calendars

### DIFF
--- a/civihr_employee_portal/src/Blocks/ManagerCalendar.php
+++ b/civihr_employee_portal/src/Blocks/ManagerCalendar.php
@@ -22,8 +22,23 @@ class ManagerCalendar {
         $managerData = get_civihr_uf_match_data($uid);
         $managerId = $managerData['contact_id'];
 
-        $result = db_query('SELECT aal.employee_id, aal.id, aal.activity_type_id, aal.absence_title, aal.duration, aal.absence_start_date_timestamp, aal.absence_end_date_timestamp, absence_status,
-        manager_id FROM {absence_approval_list} aal WHERE absence_status != :cancelled AND YEAR(absence_end_date) = YEAR(CURDATE())', array('cancelled' => 3));
+        $absencesQuery = '
+          SELECT
+            aal.employee_id,
+            aal.id,
+            aal.activity_type_id,
+            aal.absence_title,
+            aal.duration,
+            aal.absence_start_date_timestamp,
+            aal.absence_end_date_timestamp,
+            absence_status,
+            manager_id
+          FROM {absence_approval_list} aal
+          WHERE absence_status != :cancelled AND
+            absence_status != :rejected AND
+            YEAR(absence_end_date) = YEAR(CURDATE())';
+
+        $result = db_query($absencesQuery, array('cancelled' => 3, 'rejected' => 9));
 
         // Result is returned as a iterable object that returns a stdClass object on each iteration
         foreach ($result as $record) {

--- a/civihr_employee_portal/views/views_export/views_calendar_absence_list.inc
+++ b/civihr_employee_portal/views/views_export/views_calendar_absence_list.inc
@@ -184,7 +184,13 @@ $handler->display->display_options['filters']['absence_status']['id'] = 'absence
 $handler->display->display_options['filters']['absence_status']['table'] = 'absence_list';
 $handler->display->display_options['filters']['absence_status']['field'] = 'absence_status';
 $handler->display->display_options['filters']['absence_status']['operator'] = '!=';
-$handler->display->display_options['filters']['absence_status']['value'] = '3';
+$handler->display->display_options['filters']['absence_status']['value'] = '3'; // Cancelled status
+$handler->display->display_options['filters']['absence_status_1']['id'] = 'absence_status_1';
+$handler->display->display_options['filters']['absence_status_1']['table'] = 'absence_list';
+$handler->display->display_options['filters']['absence_status_1']['field'] = 'absence_status';
+$handler->display->display_options['filters']['absence_status_1']['operator'] = '!=';
+$handler->display->display_options['filters']['absence_status_1']['value'] = '9'; // Rejected status
+
 $handler->display->display_options['path'] = 'calendar-absence-list';
 $handler->display->display_options['menu']['type'] = 'default tab';
 $handler->display->display_options['menu']['title'] = 'Month';


### PR DESCRIPTION
Both calendars shouldn't display rejected leaves. I've changed the view used to generate the My Leave calendar and the the query used to generate the Manager Absence Approval calendar to filter out those leaves.

Bellow are some screenshots showing the results:

Given 3 leave requests (one rejected, one cancelled and one waiting approval)
![captura de tela 2016-04-01 as 15 50 23](https://cloud.githubusercontent.com/assets/388373/14217013/30425752-f822-11e5-8cf3-66f84af0f682.png)

Before the change, both calendars displayed the rejected requests:
![captura de tela 2016-04-01 as 15 50 15](https://cloud.githubusercontent.com/assets/388373/14217036/4d168236-f822-11e5-9250-f22771b24164.png)
![captura de tela 2016-04-01 as 15 53 42](https://cloud.githubusercontent.com/assets/388373/14217046/56ec011e-f822-11e5-81a9-694bf7a68d4c.png)

After the change, the rejected requests are no longer displayed on both calendars:
![captura de tela 2016-04-01 as 15 52 15](https://cloud.githubusercontent.com/assets/388373/14217074/7c7c9ce0-f822-11e5-9486-aa81efd010c7.png)
![captura de tela 2016-04-01 as 15 49 45](https://cloud.githubusercontent.com/assets/388373/14217077/7d316396-f822-11e5-9b49-61bad7952697.png)


