### PR TITLE
PCHR-938: Add Leave & Absences CiviHR permissions

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -286,6 +286,14 @@ function civihr_employee_portal_permission() {
       'title' => t('Create and edit Tasks'),
       'description' => t('Availability to create and edit Tasks.'),
     ),
+    'access leave and absences in ssp' => array(
+      'title' => t('Access CiviHR Leave and Absences'),
+      'description' => t('Availability for the Staff to access leave block and calendar')
+    ),
+    'manage leave and absences in ssp' => array(
+      'title' => t('Manage CiviHR Leave and Absences'),
+      'description' => t('Availability for the Manager to access leave block and calendar and manage leave requests')
+    ),
   );
 }
 


### PR DESCRIPTION
The following permissions were added:
- Access CiviHR Leave and Absences
- Manage CiviHR Leave and Absences

Here you can see the permissions available on Drupal:
![captura_de_tela_2016-04-19_as_08_40_33](https://cloud.githubusercontent.com/assets/388373/14637862/81633566-060a-11e6-920d-5429ac87dbaf.png)
