### PR TITLE
PCHR-997: new permission - manage roles and Teams

### DIFF
--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.features.user_permission.inc
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.features.user_permission.inc
@@ -644,5 +644,15 @@ function civihr_employee_portal_features_user_default_permissions() {
     'module' => 'civicrm',
   );
 
+  // Exported permission: 'administer roles and teams'.
+  $permissions['administer roles and teams'] = array(
+    'name' => 'administer roles and teams',
+    'roles' => array(
+      'administrator' => 'administrator',
+      'civihr_admin' => 'civihr_admin',
+    ),
+    'module' => 'civicrm',
+  );
+
   return $permissions;
 }

--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.info
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.info
@@ -114,6 +114,7 @@ features[user_permission][] = view all manual batches
 features[user_permission][] = view all notes
 features[user_permission][] = view my contact
 features[user_permission][] = view own manual batches
+features[user_permission][] = administer roles and teams
 features[user_role][] = civihr_admin
 features[user_role][] = civihr_manager
 features[user_role][] = civihr_staff


### PR DESCRIPTION
"**administer roles and teams**" are added to be enabled by default for "**civihr_admin**" and "**administer**" Drupal roles.

![selection_006](https://cloud.githubusercontent.com/assets/6275540/14814313/acb6fc00-0b9d-11e6-9304-74a244975fb6.png)

