### PR TITLE
PCHR-998: View My details menu item to users with newly created roles

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -899,6 +899,12 @@ function get_civihr_contact_data($contact_id = NULL, $user_id = '') {
  * Implementation of hook_menu()
  */
 function civihr_employee_portal_menu() {
+    //get all drupal roles except the default ones (anonymous user) and (authenticated user)
+    $all_roles = user_roles();
+    unset($all_roles[array_search('anonymous user', $all_roles)]);
+    unset($all_roles[array_search('authenticated user', $all_roles)]);
+    $all_roles = array_values($all_roles);
+
     $items = array();
     $items['request_new_account/%ctools_js'] = array(
         'title' => 'Edit Document',
@@ -1162,7 +1168,7 @@ function civihr_employee_portal_menu() {
         'title' => 'My Details',
         'page callback' => 'civihr_employee_portal_my_details',
         'access callback' => '_user_has_role',
-        'access arguments' => array(array('civihr_staff', 'civihr_manager', 'civihr_admin', 'administrator')),
+        'access arguments' => array($all_roles),
         'type' => MENU_NORMAL_ITEM,
         'menu_name' => 'main-menu',
         'weight' => 4


### PR DESCRIPTION
If someone created a new role and added a user to that role , then that user will not be able to see "My details" menu item since the roles allowed to view that menu item is hard-coded to limited set of roles which are :
**('civihr_staff', 'civihr_manager', 'civihr_admin', 'administrator' ) .**

The code changed to fetch all existing roles except the default drupal roles **( 'anonymous user', 'authenticated user' )** and updating "access arguments" for my details menu item to use any of these fetched roles.

**-- Before**
![selection_024](https://cloud.githubusercontent.com/assets/6275540/14859257/4c539194-0c9b-11e6-8d08-caadf4a4a408.png)

**-- After**

![selection_025](https://cloud.githubusercontent.com/assets/6275540/14859266/55da56a8-0c9b-11e6-92d2-2004ca6f6cf5.png)

