### PR TITLE
PCHR-1004: Reports list page

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -79,13 +79,14 @@ function _setup_modals() {
  * @return string             <Module url>
  */
 function getModuleUrl($moduleName) {
+  global $base_url;
+
   $path = CRM_Core_Resources::singleton()->getUrl($moduleName);
 
   // Need to do this to avoid some configurations issues
   // Some environments return /sites/all/modules/civicrm
   // And others return http://localhost:8900/sites/all/modules/civicrm
   if (strstr($path, "$base_url/")) {
-    global $base_url;
     $path = explode("$base_url/", $path)[1];
   }
 

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -447,11 +447,11 @@ function civihr_employee_portal_theme($existing, $type, $theme, $path) {
             'template' => 'templates/civihr-employee-portal-civihr-report-custom',
         ),
 
-        'menu_tree__menu_reports_settings' => array(
+        'menu_tree__hr_reports_settings' => array(
             'render element' => 'block',
             'template' => 'templates/block--menu--reports-settings-menu-tree',
         ),
-        'menu_link__menu_reports_settings' => array(
+        'menu_link__hr_reports_settings' => array(
             'render element' => 'block',
             'template' => 'templates/block--menu--reports-settings-menu-link',
         ),
@@ -5036,6 +5036,15 @@ function civihr_employee_portal_my_details() {
  * CiviHR Report - Landing page
  */
 function civihr_employee_portal_hrreport_landing_page() {
+    $jsOptions = array('type' => 'file', 'scope' => 'footer');
+
+    if (CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Extension', 'org.civicrm.reqangular', 'is_active', 'full_name')) {
+      drupal_add_js(CRM_Core_Resources::singleton()->getUrl('org.civicrm.reqangular') . "dist/reqangular.min.js", $jsOptions);
+    }
+
+    // Base reports.js script
+    drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . '/js/reports.js', $jsOptions);
+
     //$menu = civihr_employee_portal_get_drupal_menu_items('main-menu', 'reports');
     $menu = civihr_employee_portal_get_drupal_menu_items('hr-reports');
     return theme('civihr_employee_portal_civihr_report_landing_page',

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -350,6 +350,9 @@
             .controller('FiltersController', function() {
                 this.format = 'dd/MM/yyyy';
                 this.filtersCollapsed = true;
+            })
+            .controller('SettingsController', function() {
+                this.isCollapsed = true;
             });
 
             angular.bootstrap(document.getElementById('civihrReports'), ['civihrReports']);

--- a/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-landing-page.tpl.php
+++ b/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-landing-page.tpl.php
@@ -1,12 +1,30 @@
 <ul>
 <?php
+
+/**
+ * Split the title on ':' to separate the subtitle
+ * and add the class .chr_panel__header__subtitle to it.
+ *
+ * @param string $originalTitle
+ * @return string
+ */
+function setTitleMarkup($originalTitle) {
+  $position = strpos($originalTitle, ':') + 1;
+  $title = substr($originalTitle, 0, $position);
+  $subtitle = '<span class="chr_panel__header__subtitle">' . substr($originalTitle, $position) . '</span>';
+
+  return $title . $subtitle;
+}
+
 foreach ($menu as $item):
 ?>
-    <li>
+    <li class="panel-pane pane-block chr_panel">
         <a href="<?php print $item['link_path']; ?>">
-            <h2><?php print $item['link_title']; ?></h2>
-            <?php print $item['options']['attributes']['title']; ?>
+            <h2 class="chr_panel__header chr_panel__header--with-border panel-title"><?php print setTitleMarkup($item['link_title']); ?></h2>
         </a>
+        <div>
+            <?php print $item['options']['attributes']['title']; ?>
+        </div>
     </li>
 <?php
 endforeach;

--- a/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-landing-page.tpl.php
+++ b/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-landing-page.tpl.php
@@ -11,7 +11,7 @@
 function setTitleMarkup($originalTitle) {
   $position = strpos($originalTitle, ':') + 1;
   $title = substr($originalTitle, 0, $position);
-  $subtitle = '<span class="chr_panel__header__subtitle">' . substr($originalTitle, $position) . '</span>';
+  $subtitle = '<span class="chr_panel__header-subtitle">' . substr($originalTitle, $position) . '</span>';
 
   return $title . $subtitle;
 }


### PR DESCRIPTION
It was styled the reports list page to be like the PSD and added a collapse effect on 'Reports Settings' block.

**Before**
![image](https://cloud.githubusercontent.com/assets/1280255/15499431/99f6983a-217a-11e6-9503-8f587b55c0c8.png)

**After**
![anim](https://cloud.githubusercontent.com/assets/1280255/15499397/68d4f8dc-217a-11e6-9ec5-84339f74d814.gif)

## civihr-employee-portal-civihr-report-landing-page.tpl.php
It was overridden the markup, and created a method `setTitleMarkup` to set the title markup.

## civihr_employee_portal.module
It was fixed the variable `$base_url` position, it was been using before be defined. And was added the `report.js` and `reqangular.min.js` into /reports

## reports.js
Created a controller for the settings block, with `isCollapsed` property.