### PR TITLE
PCHR-1077: Use permissions instead of roles for blocks and pages

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -277,6 +277,38 @@ function civihr_employee_portal_permission() {
       'title' => t('Manage CiviHR Leave and Absences'),
       'description' => t('Availability for the Manager to access leave block and calendar and manage leave requests')
     ),
+    'view my details' => array(
+      'title' => t('View My Details'),
+      'description' => t('Availability for the user to view my details block and page')
+    ),
+    'view my tasks block' => array(
+      'title' => t('View My Tasks Block'),
+      'description' => t('Availability for the user to view my tasks block')
+    ),
+    'view appraisals' => array(
+      'title' => t('View Appraisals'),
+      'description' => t('Availability for the user to view appraisals block and page')
+    ),
+    'view my leave block' => array(
+      'title' => t('View My Leave Block'),
+      'description' => t('Availability for the user to view my leave block')
+    ),
+    'view my sickness report block' => array(
+      'title' => t('View My Sickness Report Block'),
+      'description' => t('Availability for the user to view my sickness report block')
+    ),
+    'view staff directory' => array(
+      'title' => t('View Staff Directory'),
+      'description' => t('Availability for the user to view staff directory block and page')
+    ),
+    'view hr resources' => array(
+      'title' => t('View HR Resources'),
+      'description' => t('Availability for the user to view hr resources block and page')
+    ),
+    'view vacancies' => array(
+      'title' => t('View Vacancies'),
+      'description' => t('Availability for the user to view vacancies block and page')
+    ),
   );
 }
 
@@ -988,7 +1020,7 @@ function civihr_employee_portal_menu() {
         'access callback' => TRUE,
         'type' => MENU_CALLBACK,
     );
-    
+
     /**
      * Appraisals menu items.
      */
@@ -998,7 +1030,7 @@ function civihr_employee_portal_menu() {
         'access callback' => TRUE,
         'type' => MENU_CALLBACK,
     );
-    
+
     $items['hr-appraisals-manager/%ctools_js/upload/%'] = array(
         'title' => 'Appraisal Upload',
         'page callback' => 'civihr_employee_portal_appraisal_manager_upload',
@@ -1006,7 +1038,7 @@ function civihr_employee_portal_menu() {
         'access callback' => TRUE,
         'type' => MENU_CALLBACK,
     );
-    
+
     $items['hr-appraisals-manager/%ctools_js/view/%'] = array(
         'title' => 'Appraisal View',
         'page callback' => 'civihr_employee_portal_appraisal_manager_view',
@@ -1014,7 +1046,7 @@ function civihr_employee_portal_menu() {
         'access callback' => TRUE,
         'type' => MENU_CALLBACK,
     );
-    
+
     $items['hr-appraisals-employee/%ctools_js/upload/%'] = array(
         'title' => 'Appraisal Upload',
         'page callback' => 'civihr_employee_portal_appraisal_employee_upload',
@@ -1022,7 +1054,7 @@ function civihr_employee_portal_menu() {
         'access callback' => TRUE,
         'type' => MENU_CALLBACK,
     );
-    
+
 
     /**
      * Not used currently
@@ -3044,7 +3076,7 @@ function civihr_employee_portal_civi_tasks_form($form, &$form_state) {
     $form['section_close'] = array(
         '#markup' => '</div>'
     );
-    
+
     if (_task_can_be_edited($id)) {
         $form['save'] = array(
             '#type' => 'submit',
@@ -3403,7 +3435,7 @@ function civihr_employee_portal_appraisal_manager_form($form, &$form_state) {
         '#date_year_range' => '-10:+10',
         '#default_value' => isset($appraisal['meeting_date']) ? strip_tags($appraisal['meeting_date']) : '',
     );
-    
+
     $form['checkboxes'] = array(
         '#type' => 'checkboxes',
         '#prefix' => '<div class="row"><div class="col-md-12">',
@@ -3427,7 +3459,7 @@ function civihr_employee_portal_appraisal_manager_form($form, &$form_state) {
         '#cols' => 100,
         '#default_value' => isset($appraisal['notes']) ? strip_tags($appraisal['notes']) : '',
     );
-    
+
     $form['grade'] = array(
         '#type' => 'textfield',
         '#title' => t('Grade'),
@@ -3479,7 +3511,7 @@ function civihr_employee_portal_appraisal_manager_form_submit($form, &$form_stat
     $meetingApproved = (int)strip_tags($form_state['values']['checkboxes'][2]) ? 1 : 0;
     $notes = strip_tags($form_state['values']['notes']);
     $grade = (int)strip_tags($form_state['values']['grade']);
-    
+
     $params = array(
         'sequential' => 1,
         'id' => $id,
@@ -3491,7 +3523,7 @@ function civihr_employee_portal_appraisal_manager_form_submit($form, &$form_stat
     //TODO: if (has_appraisal_permissions to grade) {
     $params['grade'] = $grade;
     //}
-    
+
     // setting appraisal status to Awaiting Grade:
     $params['status_id'] = 3;
 
@@ -3518,7 +3550,7 @@ function civihr_employee_portal_appraisal_manager_form_submit($form, &$form_stat
 }
 
 function civihr_employee_portal_appraisal_manager_view($ajax, $id) {
-    
+
     $appraisal = civicrm_api3('Appraisal', 'getsingle', array(
         'sequential' => 1,
         'id' => (int)$id,
@@ -3532,7 +3564,7 @@ function civihr_employee_portal_appraisal_manager_view($ajax, $id) {
     $manager = get_civihr_contact_data($appraisal['manager_id']);
     $title = $contact['display_name'] . ' Appraisal';
     $documents = civihr_employee_portal_get_appraisal_documents($appraisal['id']);
-    
+
     $output = theme_render_template(
         drupal_get_path('module', 'civihr_employee_portal') .
         '/templates/civihr-employee-portal-appraisal-manager-view-modal.tpl.php',
@@ -3546,7 +3578,7 @@ function civihr_employee_portal_appraisal_manager_view($ajax, $id) {
             'documents' => $documents,
         )
     );
-    
+
     if ($ajax) {
         ctools_include('ajax');
         ctools_include('modal');
@@ -3716,12 +3748,12 @@ function civihr_employee_portal_appraisal_employee_form_submit($form, &$form_sta
     }
 
     $id = (int)strip_tags($form_state['values']['id']);
-    
+
     $params = array(
         'sequential' => 1,
         'id' => $id,
     );
-    
+
     // setting appraisal status to Awaiting Manager Appraisal:
     $params['status_id'] = 2;
 
@@ -3748,7 +3780,7 @@ function civihr_employee_portal_appraisal_employee_form_submit($form, &$form_sta
 }
 
 function civihr_employee_portal_get_appraisal_documents($appraisalId) {
-    
+
     $documents = array();
     $selfAppraisalFiles = CRM_Appraisals_Page_Files::fileList(array(
         'entityTable' => 'civicrm_appraisal-self',
@@ -3766,7 +3798,7 @@ function civihr_employee_portal_get_appraisal_documents($appraisalId) {
         $file['appraisalFileTypeLabel'] = 'Manager Appraisal';
         $documents['managerAppraisal'] = $file;
     }
-    
+
     return $documents;
 }
 

--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.features.user_permission.inc
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.features.user_permission.inc
@@ -654,5 +654,101 @@ function civihr_employee_portal_features_user_default_permissions() {
     'module' => 'civicrm',
   );
 
+  // Exported permission: 'view my details'.
+  $permissions['view my details'] = array(
+    'name' => 'view my details',
+    'roles' => array(
+      'administrator' => 'administrator',
+      'civihr_admin' => 'civihr_admin',
+      'civihr_manager' => 'civihr_manager',
+      'civihr_staff' => 'civihr_staff',
+    ),
+    'module' => 'civihr_employee_portal',
+  );
+
+  // Exported permission: 'view my tasks block'.
+  $permissions['view my tasks block'] = array(
+    'name' => 'view my tasks block',
+    'roles' => array(
+      'administrator' => 'administrator',
+      'civihr_admin' => 'civihr_admin',
+      'civihr_manager' => 'civihr_manager',
+      'civihr_staff' => 'civihr_staff',
+    ),
+    'module' => 'civihr_employee_portal',
+  );
+
+  // Exported permission: 'view appraisals'.
+  $permissions['view appraisals'] = array(
+    'name' => 'view appraisals',
+    'roles' => array(
+      'administrator' => 'administrator',
+      'civihr_admin' => 'civihr_admin',
+      'civihr_manager' => 'civihr_manager',
+      'civihr_staff' => 'civihr_staff',
+    ),
+    'module' => 'civihr_employee_portal',
+  );
+
+  // Exported permission: 'view my leave block'.
+  $permissions['view my leave block'] = array(
+    'name' => 'view my leave block',
+    'roles' => array(
+      'administrator' => 'administrator',
+      'civihr_admin' => 'civihr_admin',
+      'civihr_manager' => 'civihr_manager',
+      'civihr_staff' => 'civihr_staff',
+    ),
+    'module' => 'civihr_employee_portal',
+  );
+
+  // Exported permission: 'view my sickness report block'.
+  $permissions['view my sickness report block'] = array(
+    'name' => 'view my sickness report block',
+    'roles' => array(
+      'administrator' => 'administrator',
+      'civihr_admin' => 'civihr_admin',
+      'civihr_manager' => 'civihr_manager',
+      'civihr_staff' => 'civihr_staff',
+    ),
+    'module' => 'civihr_employee_portal',
+  );
+
+  // Exported permission: 'view staff directory'.
+  $permissions['view staff directory'] = array(
+    'name' => 'view staff directory',
+    'roles' => array(
+      'administrator' => 'administrator',
+      'civihr_admin' => 'civihr_admin',
+      'civihr_manager' => 'civihr_manager',
+      'civihr_staff' => 'civihr_staff',
+    ),
+    'module' => 'civihr_employee_portal',
+  );
+
+  // Exported permission: 'view hr resources'.
+  $permissions['view hr resources'] = array(
+    'name' => 'view hr resources',
+    'roles' => array(
+      'administrator' => 'administrator',
+      'civihr_admin' => 'civihr_admin',
+      'civihr_manager' => 'civihr_manager',
+      'civihr_staff' => 'civihr_staff',
+    ),
+    'module' => 'civihr_employee_portal',
+  );
+
+  // Exported permission: 'view vacancies'.
+  $permissions['view vacancies'] = array(
+    'name' => 'view vacancies',
+    'roles' => array(
+      'administrator' => 'administrator',
+      'civihr_admin' => 'civihr_admin',
+      'civihr_manager' => 'civihr_manager',
+      'civihr_staff' => 'civihr_staff',
+    ),
+    'module' => 'civihr_employee_portal',
+  );
+
   return $permissions;
 }

--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.pages_default.inc
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.pages_default.inc
@@ -203,13 +203,9 @@ function civihr_employee_portal_features_default_page_manager_pages() {
     $pane->access = array(
       'plugins' => array(
         0 => array(
-          'name' => 'role',
+          'name' => 'perm',
           'settings' => array(
-            'rids' => array(
-              0 => 55120974,
-              1 => 17087012,
-              2 => 57573969,
-            ),
+            'perm' => 'view my details',
           ),
           'context' => 'logged-in-user',
           'not' => FALSE,
@@ -339,7 +335,18 @@ function civihr_employee_portal_features_default_page_manager_pages() {
     $pane->type = 'block';
     $pane->subtype = 'civihr_employee_portal-leave';
     $pane->shown = TRUE;
-    $pane->access = array();
+    $pane->access = array(
+      'plugins' => array(
+        0 => array(
+          'name' => 'perm',
+          'settings' => array(
+            'perm' => 'view my leave block',
+          ),
+          'context' => 'logged-in-user',
+          'not' => FALSE,
+        ),
+      ),
+    );
     $pane->configuration = array(
       'override_title' => 1,
       'override_title_text' => '<none>',
@@ -386,7 +393,18 @@ function civihr_employee_portal_features_default_page_manager_pages() {
     $pane->type = 'block';
     $pane->subtype = 'civihr_employee_portal-sick';
     $pane->shown = TRUE;
-    $pane->access = array();
+    $pane->access = array(
+      'plugins' => array(
+        0 => array(
+          'name' => 'perm',
+          'settings' => array(
+            'perm' => 'view my sickness report block',
+          ),
+          'context' => 'logged-in-user',
+          'not' => FALSE,
+        ),
+      ),
+    );
     $pane->configuration = array(
       'override_title' => 1,
       'override_title_text' => '<none>',
@@ -411,13 +429,9 @@ function civihr_employee_portal_features_default_page_manager_pages() {
     $pane->access = array(
       'plugins' => array(
         0 => array(
-          'name' => 'role',
+          'name' => 'perm',
           'settings' => array(
-            'rids' => array(
-              0 => 55120974,
-              1 => 17087012,
-              2 => 57573969,
-            ),
+            'perm' => 'view staff directory',
           ),
           'context' => 'logged-in-user',
           'not' => FALSE,

--- a/civihr_employee_portal/views/views_export/views_abence_entitlement.inc
+++ b/civihr_employee_portal/views/views_export/views_abence_entitlement.inc
@@ -20,12 +20,8 @@ $view->disabled = FALSE; /* Edit this to true to make a default view disabled in
 $handler = $view->new_display('default', 'Master', 'default');
 $handler->display->display_options['title'] = 'Absence Entitlement';
 $handler->display->display_options['use_more_always'] = FALSE;
-$handler->display->display_options['access']['type'] = 'role';
-$handler->display->display_options['access']['role'] = array(
-  55120974 => '55120974',
-  57573969 => '57573969',
-  17087012 => '17087012',
-);
+$handler->display->display_options['access']['type'] = 'perm';
+$handler->display->display_options['access']['perm'] = 'view my leave block';
 $handler->display->display_options['cache']['type'] = 'none';
 $handler->display->display_options['query']['type'] = 'views_query';
 $handler->display->display_options['query']['options']['json_file'] = $base_url . '/absence_entitlement_json/';

--- a/civihr_employee_portal/views/views_export/views_absence_list.inc
+++ b/civihr_employee_portal/views/views_export/views_absence_list.inc
@@ -20,12 +20,7 @@ $handler->display->display_options['title'] = 'Absence List';
 $handler->display->display_options['css_class'] = 'view--w-table';
 $handler->display->display_options['use_ajax'] = TRUE;
 $handler->display->display_options['use_more_always'] = FALSE;
-$handler->display->display_options['access']['type'] = 'role';
-$handler->display->display_options['access']['role'] = array(
-  55120974 => '55120974',
-  57573969 => '57573969',
-  17087012 => '17087012',
-);
+$handler->display->display_options['access']['type'] = 'perm';
 $handler->display->display_options['cache']['type'] = 'none';
 $handler->display->display_options['query']['type'] = 'views_query';
 $handler->display->display_options['exposed_form']['type'] = 'basic';
@@ -185,6 +180,9 @@ $handler->display->display_options['filters']['absence_start_date_timestamp']['g
 
 /* Display: Leave report */
 $handler = $view->new_display('page', 'Leave report', 'page');
+$handler->display->display_options['defaults']['access'] = FALSE;
+$handler->display->display_options['access']['type'] = 'perm';
+$handler->display->display_options['access']['perm'] = 'view my leave block';
 $handler->display->display_options['defaults']['style_plugin'] = FALSE;
 $handler->display->display_options['style_plugin'] = 'table';
 $handler->display->display_options['style_options']['columns'] = array(
@@ -205,13 +203,13 @@ $handler->display->display_options['style_options']['columns'] = array(
 foreach ($absenceTypes as $absenceType) {
 
     if (isset($absenceType['id']) && $absenceType['is_active'] == 1) {
-        
+
         // Should have a settings somewhere that the Sick type is our special case, which we need to display in different block
         if ($absenceType['name'] != 'Sick') {
             $handler->display->display_options['style_options']['columns']['duration_' . $absenceType['id']] = 'duration_' . $absenceType['id'];
         }
     }
-    
+
 }
 
 /**
@@ -273,7 +271,7 @@ $handler->display->display_options['style_options']['info'] = array(
     'align' => '',
     'separator' => '',
     'empty_column' => 0,
-  ) 
+  )
 );
 
 
@@ -284,7 +282,7 @@ $handler->display->display_options['style_options']['info'] = array(
 foreach ($absenceTypes as $absenceType) {
 
     if (isset($absenceType['id']) && $absenceType['is_active'] == 1) {
-        
+
         // Should have a settings somewhere that the Sick type is our special case, which we need to display in different block
         if ($absenceType['name'] != 'Sick') {
             $handler->display->display_options['style_options']['info']['duration_' . $absenceType['id']] = array(
@@ -296,7 +294,7 @@ foreach ($absenceTypes as $absenceType) {
             );
         }
     }
-    
+
 }
 
 /**
@@ -394,8 +392,8 @@ $handler->display->display_options['fields']['absence_status']['element_label_co
 foreach ($absenceTypes as $absenceType) {
 
     if (isset($absenceType['id']) && $absenceType['is_active'] == 1) {
-        
-        
+
+
         // Store the debit / credit activity type IDs as well
         $suffix = '';
 
@@ -406,7 +404,7 @@ foreach ($absenceTypes as $absenceType) {
         if (isset($absenceType['allow_credits']) && $absenceType['allow_credits'] == '1') {
             $suffix .= '_' . $absenceType['credit_activity_type_id'];
         }
-            
+
 
         // Should have a settings somewhere that the Sick type is our special case, which we need to display in different block
         if ($absenceType['name'] != 'Sick') {
@@ -460,8 +458,8 @@ $handler->display->display_options['filters']['absence_start_date_period_filter'
       'min' => $current_year . '-01-01 00:00:00',
       'max' => $current_year . '-12-31 23:59:59',
     ),
-  )   
-    
+  )
+
 );
 
 /**
@@ -480,6 +478,9 @@ $handler->display->display_options['path'] = 'absence-list';
 
 /* Display: Sickness report */
 $handler = $view->new_display('page', 'Sickness report', 'page_1');
+$handler->display->display_options['defaults']['access'] = FALSE;
+$handler->display->display_options['access']['type'] = 'perm';
+$handler->display->display_options['access']['perm'] = 'view my sickness report block';
 $handler->display->display_options['exposed_block'] = TRUE;
 $handler->display->display_options['defaults']['footer'] = FALSE;
 $handler->display->display_options['defaults']['fields'] = FALSE;
@@ -578,8 +579,8 @@ $handler->display->display_options['filters']['absence_start_date_period_filter'
       'min' => $current_year . '-01-01 00:00:00',
       'max' => $current_year . '-12-31 23:59:59',
     ),
-  )   
-    
+  )
+
 );
 
 /**
@@ -600,6 +601,9 @@ $handler->display->display_options['defaults']['title'] = FALSE;
 $handler->display->display_options['title'] = 'Print Leave Report';
 $handler->display->display_options['defaults']['css_class'] = FALSE;
 $handler->display->display_options['css_class'] = 'print-leave-report-view';
+$handler->display->display_options['defaults']['access'] = FALSE;
+$handler->display->display_options['access']['type'] = 'perm';
+$handler->display->display_options['access']['perm'] = 'view my leave block';
 $handler->display->display_options['defaults']['pager'] = FALSE;
 $handler->display->display_options['pager']['type'] = 'none';
 $handler->display->display_options['pager']['options']['offset'] = '0';

--- a/civihr_employee_portal/views/views_export/views_appraisals.inc
+++ b/civihr_employee_portal/views/views_export/views_appraisals.inc
@@ -117,11 +117,8 @@ $handler = $view->new_display('page', 'Page', 'appraisals_manager');
 $handler->display->display_options['defaults']['title'] = FALSE;
 $handler->display->display_options['title'] = 'Appraisals';
 $handler->display->display_options['defaults']['access'] = FALSE;
-$handler->display->display_options['access']['type'] = 'role';
-$handler->display->display_options['access']['role'] = array(
-  3 => '3',
-  57573969 => '57573969',
-);
+$handler->display->display_options['access']['type'] = 'perm';
+$handler->display->display_options['access']['perm'] = 'view appraisals';
 $handler->display->display_options['defaults']['fields'] = FALSE;
 /* Field: Json: Appraisal Employee */
 $handler->display->display_options['fields']['appraisal_employee']['id'] = 'appraisal_employee';

--- a/civihr_employee_portal/views/views_export/views_hr_documents.inc
+++ b/civihr_employee_portal/views/views_export/views_hr_documents.inc
@@ -18,12 +18,8 @@ $view->disabled = FALSE; /* Edit this to true to make a default view disabled in
 $handler = $view->new_display('default', 'Master', 'default');
 $handler->display->display_options['title'] = 'HR Resources';
 $handler->display->display_options['use_more_always'] = FALSE;
-$handler->display->display_options['access']['type'] = 'role';
-$handler->display->display_options['access']['role'] = array(
-  55120974 => '55120974',
-  57573969 => '57573969',
-  17087012 => '17087012',
-);
+$handler->display->display_options['access']['type'] = 'perm';
+$handler->display->display_options['access']['perm'] = 'view hr resources';
 $handler->display->display_options['cache']['type'] = 'none';
 $handler->display->display_options['query']['type'] = 'views_query';
 $handler->display->display_options['exposed_form']['type'] = 'basic';

--- a/civihr_employee_portal/views/views_export/views_hr_staff_directory.inc
+++ b/civihr_employee_portal/views/views_export/views_hr_staff_directory.inc
@@ -20,12 +20,8 @@ $handler->display->display_options['title'] = 'Staff Directory';
 $handler->display->display_options['css_class'] = 'view-hr-staff-directory';
 $handler->display->display_options['use_ajax'] = TRUE;
 $handler->display->display_options['use_more_always'] = FALSE;
-$handler->display->display_options['access']['type'] = 'role';
-$handler->display->display_options['access']['role'] = array(
-  55120974 => '55120974',
-  57573969 => '57573969',
-  17087012 => '17087012',
-);
+$handler->display->display_options['access']['type'] = 'perm';
+$handler->display->display_options['access']['perm'] = 'view staff directory';
 $handler->display->display_options['cache']['type'] = 'none';
 $handler->display->display_options['query']['type'] = 'views_query';
 $handler->display->display_options['query']['options']['distinct'] = TRUE;

--- a/civihr_employee_portal/views/views_export/views_hr_vacancies.inc
+++ b/civihr_employee_portal/views/views_export/views_hr_vacancies.inc
@@ -20,12 +20,8 @@ $view->disabled = FALSE; /* Edit this to true to make a default view disabled in
 $handler = $view->new_display('default', 'Master', 'default');
 $handler->display->display_options['title'] = 'HR Vacancies';
 $handler->display->display_options['use_more_always'] = FALSE;
-$handler->display->display_options['access']['type'] = 'role';
-$handler->display->display_options['access']['role'] = array(
-  55120974 => '55120974',
-  57573969 => '57573969',
-  17087012 => '17087012',
-);
+$handler->display->display_options['access']['type'] = 'perm';
+$handler->display->display_options['access']['perm'] = 'view vacancies';
 $handler->display->display_options['cache']['type'] = 'none';
 $handler->display->display_options['query']['type'] = 'views_query';
 $handler->display->display_options['query']['options']['json_file'] = $base_url . '/civihr_vacancies/';

--- a/civihr_employee_portal/views/views_export/views_my_details_block.inc
+++ b/civihr_employee_portal/views/views_export/views_my_details_block.inc
@@ -18,12 +18,8 @@ $view->disabled = FALSE; /* Edit this to true to make a default view disabled in
 $handler = $view->new_display('default', 'Master', 'default');
 $handler->display->display_options['title'] = 'My Details Block';
 $handler->display->display_options['use_more_always'] = FALSE;
-$handler->display->display_options['access']['type'] = 'role';
-$handler->display->display_options['access']['role'] = array(
-  55120974 => '55120974',
-  57573969 => '57573969',
-  17087012 => '17087012',
-);
+$handler->display->display_options['access']['type'] = 'perm';
+$handler->display->display_options['access']['perm'] = 'view my details';
 $handler->display->display_options['cache']['type'] = 'none';
 $handler->display->display_options['query']['type'] = 'views_query';
 $handler->display->display_options['query']['options']['distinct'] = TRUE;

--- a/civihr_employee_portal/views/views_export/views_tasks.inc
+++ b/civihr_employee_portal/views/views_export/views_tasks.inc
@@ -17,13 +17,8 @@ $handler = $view->new_display('default', 'Master', 'default');
 $handler->display->display_options['title'] = 'Tasks';
 $handler->display->display_options['use_ajax'] = TRUE;
 $handler->display->display_options['use_more_always'] = FALSE;
-$handler->display->display_options['access']['type'] = 'role';
-$handler->display->display_options['access']['role'] = array(
-  3 => '3',
-  55120974 => '55120974',
-  57573969 => '57573969',
-  17087012 => '17087012',
-);
+$handler->display->display_options['access']['type'] = 'perm';
+$handler->display->display_options['access']['perm'] = 'view my tasks block';
 $handler->display->display_options['cache']['type'] = 'none';
 $handler->display->display_options['query']['type'] = 'views_query';
 $handler->display->display_options['query']['options']['json_file'] = $base_url . '/civi_tasks/';


### PR DESCRIPTION
Currently most of the views and pages are tied to roles in SSP ( https://compucorp.atlassian.net/wiki/display/PCHR/Configuring+a+newly+created+user+role ) .... But we need  things to be more simpler instead of configuring every view and page each time a new role created ..  so I defined a set on new permissions which are :

    'view my details' => array(
      'title' => t('View My Details'),
      'description' => t('Availability for the user to view my details block and page')
    ),
    'view my tasks block' => array(
      'title' => t('View My Tasks Block'),
      'description' => t('Availability for the user to view my tasks block')
    ),
    'view appraisals' => array(
      'title' => t('View Appraisals'),
      'description' => t('Availability for the user to view appraisals block and page')
    ),
    'view my leave block' => array(
      'title' => t('View My Leave Block'),
      'description' => t('Availability for the user to view my leave block')
    ),
    'view my sickness report block' => array(
      'title' => t('View My Sickness Report Block'),
      'description' => t('Availability for the user to view my sickness report block')
    ),
    'view staff directory' => array(
      'title' => t('View Staff Directory'),
      'description' => t('Availability for the user to view staff directory block and page')
    ),
    'view hr resources' => array(
      'title' => t('View HR Resources'),
      'description' => t('Availability for the user to view hr resources block and page')
    ),
    'view vacancies' => array(
      'title' => t('View Vacancies'),
      'description' => t('Availability for the user to view vacancies block and page')
    )

and changed all the views and pages to rely on these permissions instead of using  hardcored roles.