### PR TITLE
PCHR-1136: Handle sickness absence with different name

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -1317,7 +1317,7 @@ function _get_civicrm_contact_id_by_drupal_uid($uid) {
 
 /**
  * Get node ID (nid) by its title and type. If no node is found, return null.
- * 
+ *
  * @param string $title
  * @param string $type
  * @return int|NULL
@@ -4787,7 +4787,7 @@ function civihr_employee_portal_directory_block_form_submit($form, &$form_state)
 
 /**
  * Implement hook_node_view().
- * 
+ *
  * @param object $node
  * @param string $view_mode
  * @param string $langcode
@@ -4918,7 +4918,7 @@ function civihr_employee_portal_form_alter(&$form, &$form_state, $form_id) {
 
 /**
  * Get a recalculated State/Province form field for Emergency Contact 1.
- * 
+ *
  * @param array $form
  * @param array $form_state
  * @return array
@@ -4929,7 +4929,7 @@ function civihr_employee_portal_state_province_contact1_callback($form, $form_st
 
 /**
  * Get a recalculated State/Province form field for Emergency Contact 2.
- * 
+ *
  * @param array $form
  * @param array $form_state
  * @return array
@@ -4941,7 +4941,7 @@ function civihr_employee_portal_state_province_contact2_callback($form, $form_st
 /**
  * Get a form select field for given emergency contact containing
  * State/Province list of selected Country.
- * 
+ *
  * @param array $form
  * @param int $emergency_contact
  * @return array
@@ -4957,7 +4957,7 @@ function _get_emergency_contact_state_province_webform_field($form, $emergency_c
 
 /**
  * Return an array containing fieldset list of Emergency Contact webform.
- * 
+ *
  * @return array
  */
 function _get_emergency_contact_fieldset_list() {
@@ -4970,7 +4970,7 @@ function _get_emergency_contact_fieldset_list() {
 /**
  * Get an assotiative array containing IDs of State/Province as keys
  * and labels of State/Province as values.
- * 
+ *
  * @param int $country_id
  * @return array
  */
@@ -5473,6 +5473,20 @@ function civihr_employee_portal_civicrm_post($op, $objectName, $objectId, &$obje
             _clear_json_cache();
         }
     }
+}
+
+/**
+ * Checks if the given absence is of the "Sick" type
+ *
+ * There is no other way currently to check if an absence type is of the
+ * "Sick" type other than checking its title, so we have to resort to a
+ * simple regex match on the title string, looking for the "sick" word
+ *
+ * @param  string $absenceName
+ * @return boolean
+ */
+function civihr_employee_portal_is_sick_absence($absenceName) {
+  return preg_match('/^sick/i', $absenceName);
 }
 
 /**

--- a/civihr_employee_portal/src/Forms/AbsenceRequestForm.php
+++ b/civihr_employee_portal/src/Forms/AbsenceRequestForm.php
@@ -146,12 +146,12 @@ class AbsenceRequestForm {
                 if ($mk_time_start_timestamp > strtotime('today') && $this->form_state['values']['absence_type'] == "sick") {
                     form_set_error('absence_request_date_from', t('You are not allowed to report Sickness in advance!'));
                 }
-                
+
                 // If we requested leave with dates that have already been requested before (duplicate dates)
                 if($this->duplicate_dates_exist($mk_time_start_timestamp, $mk_time_end_timestamp)){
                     form_set_error('form', t('You have already requested leave for this date.'));
                 }
-                
+
                 // Check if we have enough leave left to request this leave (only if leave type is DEBIT or CREDIT_USE) -> deducting days
                 if (isset($this->form_state['values']['absence_type']) && ($this->form_state['values']['absence_type'] == 'debit' || $this->form_state['values']['absence_type'] == 'credit_use')) {
                     $leave = $this->leave_data();
@@ -221,19 +221,19 @@ class AbsenceRequestForm {
                 }
 
                 // If debit type is allowed show debit types (only if the employee clicked -> Request Leave)
-                if ($absence_type['allow_debits'] == '1' && $this->absence_type() == 'debit' && $absence_type['allow_credits'] !== '1' && $absence_type['title'] != 'Sick') {
+                if ($absence_type['allow_debits'] == '1' && $this->absence_type() == 'debit' && $absence_type['allow_credits'] !== '1' && !civihr_employee_portal_is_sick_absence($absence_type['title'])) {
                   // Default debit types
                     $options[$absence_type['debit_activity_type_id']] = $absence_type['title'];
                 }
 
                 // If Use TOIL is clicked show only debit types, which has credit type allowed too
-                if ($absence_type['allow_debits'] == '1' && $absence_type['allow_credits'] == '1' && $this->absence_type() == 'credit_use' && $absence_type['title'] != 'Sick') {
+                if ($absence_type['allow_debits'] == '1' && $absence_type['allow_credits'] == '1' && $this->absence_type() == 'credit_use' && !civihr_employee_portal_is_sick_absence($absence_type['title'])) {
                     // Default debit types which has credit type too
                     $options[$absence_type['debit_activity_type_id']] = $absence_type['title'];
                 }
 
                 // If Report New Sickness is clicked, show the debit types which are selected as the Sickness Absence Type @TODO -> currently hardcoded based on absence title
-                if ($absence_type['allow_debits'] == '1' && $this->absence_type() == 'sick' && $absence_type['title'] == 'Sick') {
+                if ($absence_type['allow_debits'] == '1' && $this->absence_type() == 'sick' && civihr_employee_portal_is_sick_absence($absence_type['title'])) {
                     // Default debit types which has credit type too
                     $options[$absence_type['debit_activity_type_id']] = $absence_type['title'];
                 }
@@ -402,7 +402,7 @@ class AbsenceRequestForm {
 
         return $q->execute()->fetchField();
     }
-    
+
     /**
      * Check if the dates requested for leaves are already requested for other leaves before
      *
@@ -438,12 +438,12 @@ class AbsenceRequestForm {
             else if($startTimestamp >= $requestedStartTimestamp && $endTimestamp <= $requestedEndTimestamp) {
                 $dateExists = true;
             }
-            
+
             if($dateExists == true) {
                 break;
             }
         }
-        
+
         return $dateExists;
     }
 

--- a/civihr_employee_portal/views/includes/civihr_employee_portal_handler_area_totals.inc
+++ b/civihr_employee_portal/views/includes/civihr_employee_portal_handler_area_totals.inc
@@ -4,15 +4,15 @@
  */
 class civihr_employee_portal_handler_area_totals extends views_handler_area {
   function render($empty = FALSE) {
-           
+
     // Get the absence types
     $absenceTypes = get_civihr_absence_types();
-    
+
     $results = array();
-    
+
     $header = array();
     $rows = array();
-    
+
     /**
      * Date filters
      */
@@ -23,36 +23,36 @@ class civihr_employee_portal_handler_area_totals extends views_handler_area {
         // Set default period
         $request_date = variable_get('default_date_period_id', '1');
     }
-    
+
     // Build the query
     $query = db_select('civicrm_hrabsence_entitlement', 'che')
         ->fields('che', array('contact_id', 'period_id'))
         ->orderBy('che.contact_id');
-    
+
     // Add the where query
     $query->where('(che.contact_id = :c_id)', array(':c_id' => $_SESSION['CiviCRM']['userID']));
     $query->where('(che.period_id = :period_id)', array(':period_id' => $request_date));
-    
+
     // Add the concat
     $query->addExpression("CONCAT_WS('||', GROUP_CONCAT(amount SEPARATOR '@@'), GROUP_CONCAT(type_id SEPARATOR '@@'))", "entitlement_type");
-    
+
     // Add the group by
     $query->groupBy('che.contact_id, che.period_id');
-     
+
     $result = $query->execute();
-    
+
     $result_output = array();
-    
+
     // Loop and prepare the array
     while($record = $result->fetchAssoc()) {
         $result_output['data'][] = $record;
     }
-    
+
     $header[] = t('Balance: ');
     $header[] = t('');
 
     if (isset($result_output['data'])) {
-        
+
         // Get the entitlement for the employee, add it to the basic / totals count
         $value_explode = explode("||", $result_output['data'][0]['entitlement_type']);
 
@@ -63,7 +63,7 @@ class civihr_employee_portal_handler_area_totals extends views_handler_area {
 
             $results[$absenceType['id']] = 0;
 
-            if (isset($absenceType['is_active']) && $absenceType['is_active'] == '1' && $absenceType['title'] != 'Sick') {
+            if (isset($absenceType['is_active']) && $absenceType['is_active'] == '1' && !civihr_employee_portal_is_sick_absence($absenceType['title'])) {
 
                 foreach ($absence_ids as $absence_array_key => $absence_id) {
 
@@ -99,12 +99,12 @@ class civihr_employee_portal_handler_area_totals extends views_handler_area {
                  * Populate the table
                  */
                 $header[] = $results[$absenceType['id']];
-                
+
             }
         }
     }
-    
+
     return theme('table', array('header' => $header));
-    
+
   }
 }

--- a/civihr_employee_portal/views/views_export/views_abence_entitlement.inc
+++ b/civihr_employee_portal/views/views_export/views_abence_entitlement.inc
@@ -96,7 +96,7 @@ foreach ($absenceTypes as $absenceType) {
     if (isset($absenceType['id']) && $absenceType['is_active'] == 1) {
 
         // Should have a settings somewhere that the Sick type is our special case, which we need to display in different block
-        if ($absenceType['name'] != 'Sick') {
+        if (!civihr_employee_portal_is_sick_absence($absenceType['name'])) {
             /* Field: entitlement_type: Absence entitlement value */
             $handler->display->display_options['fields']['absence_entitlement_' . $absenceType['id']]['id'] = 'absence_entitlement_' . $absenceType['id'];
             $handler->display->display_options['fields']['absence_entitlement_' . $absenceType['id']]['table'] = 'json';

--- a/civihr_employee_portal/views/views_export/views_absence_list.inc
+++ b/civihr_employee_portal/views/views_export/views_absence_list.inc
@@ -205,7 +205,7 @@ foreach ($absenceTypes as $absenceType) {
     if (isset($absenceType['id']) && $absenceType['is_active'] == 1) {
 
         // Should have a settings somewhere that the Sick type is our special case, which we need to display in different block
-        if ($absenceType['name'] != 'Sick') {
+        if (!civihr_employee_portal_is_sick_absence($absenceType['name'])) {
             $handler->display->display_options['style_options']['columns']['duration_' . $absenceType['id']] = 'duration_' . $absenceType['id'];
         }
     }
@@ -284,7 +284,7 @@ foreach ($absenceTypes as $absenceType) {
     if (isset($absenceType['id']) && $absenceType['is_active'] == 1) {
 
         // Should have a settings somewhere that the Sick type is our special case, which we need to display in different block
-        if ($absenceType['name'] != 'Sick') {
+        if (!civihr_employee_portal_is_sick_absence($absenceType['name'])) {
             $handler->display->display_options['style_options']['info']['duration_' . $absenceType['id']] = array(
                 'sortable' => 0,
                 'default_sort_order' => 'asc',
@@ -407,7 +407,7 @@ foreach ($absenceTypes as $absenceType) {
 
 
         // Should have a settings somewhere that the Sick type is our special case, which we need to display in different block
-        if ($absenceType['name'] != 'Sick') {
+        if (!civihr_employee_portal_is_sick_absence($absenceType['name'])) {
             /* Field: Absence entity: Absence type row value (Duration) */
             $handler->display->display_options['fields']['duration_' . $absenceType['id']]['id'] = 'duration_' . $absenceType['id'];
             $handler->display->display_options['fields']['duration_' . $absenceType['id']]['table'] = 'absence_list';
@@ -471,7 +471,7 @@ $handler->display->display_options['filters']['absence_start_date_period_filter'
 $handler->display->display_options['filters']['absence_title']['id'] = 'absence_title';
 $handler->display->display_options['filters']['absence_title']['table'] = 'absence_list';
 $handler->display->display_options['filters']['absence_title']['field'] = 'absence_title';
-$handler->display->display_options['filters']['absence_title']['operator'] = '!=';
+$handler->display->display_options['filters']['absence_title']['operator'] = 'not';
 $handler->display->display_options['filters']['absence_title']['value'] = 'Sick';
 $handler->display->display_options['filters']['absence_title']['group'] = 1;
 $handler->display->display_options['path'] = 'absence-list';
@@ -591,6 +591,7 @@ $handler->display->display_options['filters']['absence_start_date_period_filter'
 $handler->display->display_options['filters']['absence_title']['id'] = 'absence_title';
 $handler->display->display_options['filters']['absence_title']['table'] = 'absence_list';
 $handler->display->display_options['filters']['absence_title']['field'] = 'absence_title';
+$handler->display->display_options['filters']['absence_title']['operator'] = 'contains';
 $handler->display->display_options['filters']['absence_title']['value'] = 'Sick';
 $handler->display->display_options['filters']['absence_title']['group'] = 1;
 $handler->display->display_options['path'] = 'sickness-report';
@@ -629,7 +630,7 @@ foreach ($absenceTypes as $absenceType) {
     if (isset($absenceType['id']) && $absenceType['is_active'] == 1) {
 
         // Should have a settings somewhere that the Sick type is our special case, which we need to display in different block
-        if ($absenceType['name'] != 'Sick') {
+        if (!civihr_employee_portal_is_sick_absence($absenceType['name'])) {
             $handler->display->display_options['style_options']['columns']['duration_' . $absenceType['id']] = 'duration_' . $absenceType['id'];
         }
     }
@@ -707,7 +708,7 @@ foreach ($absenceTypes as $absenceType) {
     if (isset($absenceType['id']) && $absenceType['is_active'] == 1) {
 
         // Should have a settings somewhere that the Sick type is our special case, which we need to display in different block
-        if ($absenceType['name'] != 'Sick') {
+        if (!civihr_employee_portal_is_sick_absence($absenceType['name'])) {
             $handler->display->display_options['style_options']['info']['duration_' . $absenceType['id']] = array(
                 'sortable' => 0,
                 'default_sort_order' => 'asc',
@@ -827,7 +828,7 @@ foreach ($absenceTypes as $absenceType) {
 
 
         // Should have a settings somewhere that the Sick type is our special case, which we need to display in different block
-        if ($absenceType['name'] != 'Sick') {
+        if (!civihr_employee_portal_is_sick_absence($absenceType['name'])) {
             /* Field: Absence entity: Absence type row value (Duration) */
             $handler->display->display_options['fields']['duration_' . $absenceType['id']]['id'] = 'duration_' . $absenceType['id'];
             $handler->display->display_options['fields']['duration_' . $absenceType['id']]['table'] = 'absence_list';
@@ -891,7 +892,7 @@ $handler->display->display_options['filters']['absence_start_date_period_filter'
 $handler->display->display_options['filters']['absence_title']['id'] = 'absence_title';
 $handler->display->display_options['filters']['absence_title']['table'] = 'absence_list';
 $handler->display->display_options['filters']['absence_title']['field'] = 'absence_title';
-$handler->display->display_options['filters']['absence_title']['operator'] = '!=';
+$handler->display->display_options['filters']['absence_title']['operator'] = 'not';
 $handler->display->display_options['filters']['absence_title']['value'] = 'Sick';
 $handler->display->display_options['filters']['absence_title']['group'] = 1;
 $handler->display->display_options['path'] = 'print-leave-report';


### PR DESCRIPTION
#### Problem
The "Sick" absence type is a special case of an absence, as it is displayed separately from the other types and it has a dedicated modal to request it.

The problem is that in order to distinguish it from the other types, we rely on its name, which is always assumed to be "Sick"

```php
if ($absence_type['title'] == 'Sick') {
  // ...
}
```
That means that the moment someone changes the name even slightly, say from "Sick" to "Sick Leave", the system breaks

![before](https://cloud.githubusercontent.com/assets/6400898/16333257/9df31736-39fa-11e6-9031-44273c120448.gif)

#### Solution
The solution is still temporary, and only because we have a new Leave&Absences system coming in the near future. Basically instead of checking for the exact "Sick" name, we just check if "Sick" is present
```php
return preg_match('/^sick/i', $absenceName);
```
Also some views had to have the filters updated to make them less strict about the absence type name

![after](https://cloud.githubusercontent.com/assets/6400898/16333264/a179f21c-39fa-11e6-9f3b-bf5b0b28a3ad.gif)

