### PR TITLE
PCHR-1160 - Fixing anonymous user notice messages and Tasks contacts view handler empty ID warnings.

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5208,33 +5208,33 @@ function _absence_start_date_period_change_submit(&$form, &$form_state) {
  * @param $vars
  */
 function civihr_employee_portal_preprocess_page(&$vars) {
-
     global $user;
     global $base_url;
 
-    $contact_data['display_name'] = t('Anonymus');
+    $display_name = t('Anonymus');
+    $edit_account_link = '';
+    $logout_link = '';
+    $image_url = $base_url . '/' . drupal_get_path('module', 'civihr_employee_portal') . '/images/profile-default.png';
 
-    // Set empty image URL
-    $vars['image_url'] = $base_url . '/' . drupal_get_path('module', 'civihr_employee_portal') . '/images/profile-default.png';
-
-    if (isset($_SESSION['CiviCRM'])) {
+    if (isset($_SESSION['CiviCRM']) && $user->uid) {
+        $edit_account_link = l('<i class="fa fa-edit"></i>' . t('Edit Account'), 'user/' . $user->uid . '/edit', array('html' => true));
+        $logout_link = l('<i class="fa fa-sign-out"></i>' . t('Log Out'), 'user/logout', array('html' => true));
 
         // Get the contact data
         $contact_data = get_civihr_contact_data($_SESSION['CiviCRM']['userID']);
-
-        if (isset($contact_data['image_URL']) && !empty($contact_data['image_URL'])) {
-
-            // Set the profile image URL
-            $vars['image_url'] = $contact_data['image_URL'];
-
+        if (!empty($contact_data['display_name'])) {
+            $display_name = $contact_data['display_name'];
         }
-
+        if (isset($contact_data['image_URL']) && !empty($contact_data['image_URL'])) {
+            $image_url = $contact_data['image_URL'];
+        }
     }
 
     // This values will be used in the template by Drupal
-    $vars['user_name'] = $contact_data['display_name'];
-    $vars['edit_account'] = l('<i class="fa fa-edit"></i>' . t('Edit Account'), 'user/' . $user->uid . '/edit', array('html' => true));
-    $vars['logout_link'] = l('<i class="fa fa-sign-out"></i>' . t('Log Out'), 'user/logout', array('html' => true));
+    $vars['user_name'] = $display_name;
+    $vars['image_url'] = $image_url;
+    $vars['edit_account'] = $edit_account_link;
+    $vars['logout_link'] = $logout_link;
 
 }
 

--- a/civihr_employee_portal/views/includes/civihr_employee_portal_handler_task_contacts.inc
+++ b/civihr_employee_portal/views/includes/civihr_employee_portal_handler_task_contacts.inc
@@ -20,9 +20,10 @@ class civihr_employee_portal_handler_task_contacts extends views_json_query_hand
 
       // Get the contact data based on the contact ID
       $contact_data = get_civihr_contact_data($id);
+      $fieldValue = !empty($contact_data['id']) ? $contact_data['id'] : '';
 
       // Pass the display name to the render_field
-      return $this->render_field($contact_data['id']);
+      return $this->render_field($fieldValue);
 
   }
 


### PR DESCRIPTION
Fixing Dashboard error appearing when some of the Tasks have no Contact ID:
Notice: Undefined index: id in civihr_employee_portal_handler_task_contacts->render() (line 25 of /var/www/civicrm-buildkit/build/hr15-develop/sites/all/modules/civihr-custom/civihr_employee_portal/views/includes/civihr_employee_portal_handler_task_contacts.inc).

- Task Contacts view handler was trying to get Contact data basing on provided contact_id which was empty in some cases. Currently the handler doesn't try to fetch Contact data if contact_id is empty.
Also I've added an activity contact fields (source contact, assignee contact and target contact) as mandatory fields in Task and Document entities so the values should be specified when creating Tasks / Documents (Pull Request: https://github.com/compucorp/civihr-tasks-assignments/pull/65).


Fixing error messages when accessing the system as an anonymous user:
Notice: Undefined index: userID in civihr_employee_portal_preprocess_page() (line 5053 of /vagrant/hr16/sites/all/modules/civihr-custom/civihr_employee_portal/civihr_employee_portal.module).
Notice: Undefined index: display_name in civihr_employee_portal_preprocess_page() (line 5065 of /vagrant/hr16/sites/all/modules/civihr-custom/civihr_employee_portal/civihr_employee_portal.module).

- This doesn't happen normally but if we allowed access CiviCRM for anonymous user then SSP preprocess_page hook was trying to render user data (such as display name, edit profile link and image url) for not logged user so the data didn't exist. I've changed the function to not force load not logged user's data.