### PR TITLE
Pchr 1176 ssp task block enter name filter not working

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5556,3 +5556,76 @@ function relationActiveAndCurrent($relation){
   return $relation['is_active'] == 1 && (strtotime($endDate) >= time() || empty($endDate))
           && (empty($relation['start_date']) || strtotime($relation['start_date']) <= time());
 }
+
+function _get_task_filter_by_date($date) {
+  $today = date('Y-m-d');
+  $tomorrow = new DateTime('tomorrow');
+  $nbDay = date('N', strtotime($today));
+  $sunday = new DateTime($today);
+  $sunday->modify('+' . (7 - $nbDay) . ' days');
+  $weekEnd = $sunday->format('Y-m-d');
+  $taskDate = date('Y-m-d', strtotime(strip_tags($date)));
+
+  if ($taskDate < $today) {
+      return PAST_DAY;
+  }
+  if ($taskDate == $today) {
+      return TODAY;
+  }
+  if ($taskDate > $weekEnd) {
+      return DAY_AFTER_WEEKEND;
+  }
+  if ($taskDate == $tomorrow->format('Y-m-d')){
+      return TOMORROW;
+  }
+  return ANY_OTHER_DAY;
+}
+
+/**
+ * Creates an associative array, mapping each task id to its contact target name
+ * @param  array  $taskIds The task IDs to consider
+ * @param  object $user    The current user
+ * @return array           associative array, mapping each task id to its contact target name
+ */
+function getTaskTargets($taskIds, $user) {
+  $currentContactId = get_civihr_uf_match_data($user->uid)['contact_id'];
+  $contactIdsRelatedToCurrentManager = null;
+  if(_user_has_role(array('civihr_manager'))) {
+    $contactIdsRelatedToCurrentManager = array_map(function($item) {
+      return $item['contact_id_a'];
+    }, civicrm_api3('Relationship', 'get', array(
+      'sequential' => 1,
+      'relationship_type_id' => 16, // "Line Manager is"
+      'contact_id_b' => $currentContactId,
+      'options' => array('limit' => 0)
+    ))['values']);
+    // Consider the manager's id as well
+    $contactIdsRelatedToCurrentManager[] = $currentContactId;
+  }
+
+  $targetIdByTaskId = civicrm_api3('Task', 'get', array(
+      'sequential' => 1,
+      'id' => array('IN' => $taskIds),
+      'return' => "target_contact_id",
+    ))['values'];
+
+  $targetIds = array_unique(array_reduce($targetIdByTaskId, function ($result, $task) use ($contactIdsRelatedToCurrentManager) {
+      if($contactIdsRelatedToCurrentManager !== null) {
+        $task['target_contact_id'] = array_intersect($task['target_contact_id'], $contactIdsRelatedToCurrentManager);
+      }
+      return array_merge($result, $task['target_contact_id']);
+    }, array()));
+
+  $contactNamesById = civicrm_api3('Contact', 'get', array(
+      'id' => array('IN' => $targetIds),
+      'return' => "sort_name",
+    ))['values'];
+
+  return array_reduce($targetIdByTaskId, function ($result, $task) use ($contactNamesById) {
+      $targetNames = array_map(function($targetId) use ($contactNamesById) {
+        return strtolower($contactNamesById[$targetId]['sort_name']);
+      }, $task['target_contact_id']);
+      $result[$task['id']] = implode('; ', $targetNames);
+      return $result;
+    }, array());
+}

--- a/civihr_employee_portal/views/templates/views-view-table--Tasks--block.tpl.php
+++ b/civihr_employee_portal/views/templates/views-view-table--Tasks--block.tpl.php
@@ -44,7 +44,7 @@ $taskFilters = array(
 $taskFiltersCount = array_combine(array_keys($taskFilters), array_fill(0, count($taskFilters), 0));
 $contactsIds = array();
 $contacts = array();
-$contactsFilterValues = array();
+$taskIds = array();
 
 foreach ($rows as $row):
     $rowType = null;
@@ -60,15 +60,26 @@ foreach ($rows as $row):
     $contactsIds[strip_tags($row['task_contacts'])] = 1;
     $taskFiltersCount[_get_task_filter_by_date($row['activity_date_time'])]++;
     $taskFiltersCount[0]++;
+    $taskIds[] = $row['id'];
 endforeach;
 
 $contactsResult = civicrm_api3('Contact', 'get', array(
   'id' => array('IN' => array_keys($contactsIds)),
   'return' => "sort_name",
 ));
-foreach ($contactsResult['values'] as $key => $value) {
-    $contactsFilterValues[$key] = $value['sort_name'];
-}
+
+// Create an associative array, mapping each task id to its target
+$taskTargets = array_reduce(civicrm_api3('Task', 'get', array(
+    'sequential' => 1,
+    'id' => array('IN' => $taskIds),
+    'return' => "target_contact_id",
+  ))['values'], function ($result, $item) use ($contactsResult) {
+    $targetNames = array_map(function($targetId) use ($contactsResult) {
+      return $contactsResult['values'][$targetId]['sort_name'];
+    }, $item['target_contact_id']);
+    $result[$item['id']] = implode('; ', $targetNames);
+    return $result;
+  }, array());
 
 function _get_task_filter_by_date($date) {
     $today = date('Y-m-d');
@@ -165,7 +176,7 @@ function isFieldName($field){
                     $rowContacts = strip_tags($row['task_contacts']) . ',' . strip_tags($row['task_contacts_1']) . ',' . strip_tags($row['task_contacts_2']);
                     ?>
                     <?php $class = 'task-row task-filter-id-' . _get_task_filter_by_date($row['activity_date_time']) . ' ' . $rowType; ?>
-                    <tr id="row-task-id-<?php print strip_tags($row['id']); ?>" <?php if ($row_classes[$row_count] || $class) { print 'class="' . implode(' ', $row_classes[$row_count]) . ' ' . $class . '"';  } ?> data-row-contacts="<?php print $contactsFilterValues[strip_tags($row['task_contacts'])]; ?>">
+                    <tr id="row-task-id-<?php print strip_tags($row['id']); ?>" <?php if ($row_classes[$row_count] || $class) { print 'class="' . implode(' ', $row_classes[$row_count]) . ' ' . $class . '"';  } ?> data-row-contacts="<?php print $taskTargets[strip_tags($row['id'])]; ?>">
                         <?php
                           foreach ($row as $field => $content):
                             if (isFieldName($field)) {
@@ -328,8 +339,10 @@ function isFieldName($field){
         buildTaskContactFilter();
 
         function showFilteredTaskRows() {
-            $tableDocStaffRows.hide();
-            $tableDocStaffRows.removeClass('selected-by-type').removeClass('selected-by-filter');
+            $tableDocStaffRows
+              .removeClass('selected-by-type')
+              .removeClass('selected-by-filter')
+              .hide();
             $selectedRowType.addClass('selected-by-type');
             $selectedRowFilter.addClass('selected-by-filter');
             $('.selected-by-type.selected-by-filter.selected-by-contact', $tableDocStaff).show();
@@ -344,24 +357,23 @@ function isFieldName($field){
             }
             $('#nav-tasks-filter .task-counter-filter-0').text(sum);
         }
-        
+
         function buildTaskContactFilter() {
             $tableDocStaffRows.addClass('selected-by-contact');
             $('#task-filter-contact').on("keyup", function() {
                 var value = $(this).val();
-                
+
                 $tableDocStaffRows.removeClass('selected-by-contact');
                 $("#tasks-dashboard-table-staff > tbody > tr.task-row").each(function(index) {
                     var $row = $(this);
                     var text = $row.data('rowContacts');
-                    
-                    if (!text) {
-                        $tableDocStaffRows.addClass('selected-by-contact');
+                    // Case insensitive search
+                    var matchedIndex = text.toLowerCase().indexOf(value.toLowerCase());
+
+                    if (value.length === 0 || matchedIndex === 0) {
+                      $row.addClass('selected-by-contact');
                     } else {
-                        var matchedIndex = text.indexOf(value);
-                        if (matchedIndex === 0) {
-                            $(this).addClass('selected-by-contact');
-                        }
+                      $row.removeClass('selected-by-contact');
                     }
                 });
                 showFilteredTaskRows();


### PR DESCRIPTION
The "Enter Name" filter wasn't working properly:
![before](https://cloud.githubusercontent.com/assets/18520391/16654742/6cdb3c02-4457-11e6-8d9f-ae273779a924.gif)

It's been fixed and refactored to consider case insensitive searches as well:
![after](https://cloud.githubusercontent.com/assets/18520391/16655345/284ba25e-445a-11e6-96dd-003d88a76154.gif)

Also, when the user is in the _civihr_manager_ role, the filter will only show reportees (people that have "Line Manager" relationships with the current user).