### PR TITLE
PCHR-860: View leave type title instead of name

### DIFF
--- a/civihr_employee_portal/views/views_export/views_abence_entitlement.inc
+++ b/civihr_employee_portal/views/views_export/views_abence_entitlement.inc
@@ -101,7 +101,7 @@ foreach ($absenceTypes as $absenceType) {
             $handler->display->display_options['fields']['absence_entitlement_' . $absenceType['id']]['id'] = 'absence_entitlement_' . $absenceType['id'];
             $handler->display->display_options['fields']['absence_entitlement_' . $absenceType['id']]['table'] = 'json';
             $handler->display->display_options['fields']['absence_entitlement_' . $absenceType['id']]['field'] = 'absence_entitlement';
-            $handler->display->display_options['fields']['absence_entitlement_' . $absenceType['id']]['label'] = $absenceType['name'];
+            $handler->display->display_options['fields']['absence_entitlement_' . $absenceType['id']]['label'] = $absenceType['title'];
             $handler->display->display_options['fields']['absence_entitlement_' . $absenceType['id']]['key'] = 'entitlement_type';
             $handler->display->display_options['fields']['absence_entitlement_' . $absenceType['id']]['duration_type'] = $absenceType['id'];
         }


### PR DESCRIPTION
My leave block was viewing the name of leave types ( which may contain underscores ) instead of their titles 

**Before :**

![selection_068](https://cloud.githubusercontent.com/assets/6275540/16656856/e8454a8e-4468-11e6-9322-20e6db6e8f7d.png)

and now it's fixed 

**Now :**

![selection_069](https://cloud.githubusercontent.com/assets/6275540/16656955/4ca5553c-4469-11e6-9966-38160e88cffd.png)
