### PR TITLE
PCHR-1005: Fix datepicker

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5553,7 +5553,7 @@ function setInputDatepickerForm($title) {
       '#title' => $title,
       '#type' => 'textfield',
       '#size' => '10',
-      '#description' => getCalendarButtonMarkup(),
+      '#description' => getCalendarButtonMarkup($idxKey),
       '#date_label_position' => 'within',
       '#attributes' => array(
           'ng-init' => "$idxKey = false",
@@ -5571,12 +5571,13 @@ function setInputDatepickerForm($title) {
 /**
  * Return the calendar button HTML markup
  *
+ * @param $idKey id generated on setInputDatepickerForm to set the ng-click
  */
-function getCalendarButtonMarkup() {
-  return '
-    <button type="button" class="btn btn-default">
-      <i class="fa fa-calendar"></i>
-    </button>';
+function getCalendarButtonMarkup($idxKey) {
+  return "
+    <button type=\"button\" class=\"btn btn-default\" ng-click=\"filters.$idxKey = !filters.$idxKey\">
+      <i class=\"fa fa-calendar\"></i>
+    </button>";
 }
 
 function _absence_start_date_period_change_submit(&$form, &$form_state) {

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -106,7 +106,7 @@ function civihr_employee_portal_init() {
 
     // Add our additional css libraries
     drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/css/custom.css");
-    drupal_add_css(getModuleUrl('org.civicrm.bootstrapcivicrm') . 'css/bootstrap-civicrm-style.css');
+    drupal_add_css(getModuleUrl('org.civicrm.bootstrapcivicrm') . 'css/bootstrap.css');
     drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/lib/sweetalert/sweet-alert.css");
     drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/lib/tablesaw/tablesaw.css");
     drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/css/documents.css");

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5558,7 +5558,7 @@ function setInputDatepickerForm($title) {
       '#attributes' => array(
           'ng-init' => "$idxKey = false",
           'placeholder' => '{{filters.format}}',
-          'datepicker-popup' => '{{filters.format}}',
+          'uib-datepicker-popup' => '{{filters.format}}',
           'close-text' => 'Close',
           'date-input' => '',
           'ng-model' => "filters.dt$idxKey",

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -106,7 +106,7 @@ function civihr_employee_portal_init() {
 
     // Add our additional css libraries
     drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/css/custom.css");
-    drupal_add_css(getModuleUrl('org.civicrm.bootstrapcivicrm') . 'css/bootstrap.css');
+    drupal_add_css(getModuleUrl('org.civicrm.bootstrapcivicrm') . 'css/bootstrap-civicrm-style.css');
     drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/lib/sweetalert/sweet-alert.css");
     drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/lib/tablesaw/tablesaw.css");
     drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/css/documents.css");

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5557,7 +5557,7 @@ function setInputDatepickerForm($title) {
       '#date_label_position' => 'within',
       '#attributes' => array(
           'ng-init' => "$idxKey = false",
-          'placeholder' => '{{filters.format}}',
+          'placeholder' => '{{filters.placeholderFormat}}',
           'uib-datepicker-popup' => '{{filters.format}}',
           'close-text' => 'Close',
           'date-input' => '',

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -53,7 +53,7 @@
     /**
      * Return an object containing set of Pivot Table aggregators extended with
      * our custom ones.
-     * 
+     *
      * @returns {jQuery.pivotUtilities.aggregators|_$.pivotUtilities.aggregators|aggregators}
      */
     HRReport.prototype.getAggregators = function() {
@@ -291,7 +291,7 @@
                 'ui.bootstrap',
                 'common.angularDate'
             ])
-            .directive('datepickerPopupWrap', function sectionDirective() {
+            .directive('uibDatepickerPopupWrap', function sectionDirective() {
                 return({
                     link: function(scope, element, attributes) {
                         return $(element[0]).wrap('<span id="bootstrap-theme" />');

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -300,6 +300,7 @@
       })
       .controller('FiltersController', function() {
         this.format = 'yyyy-MM-dd';
+        this.placeholderFormat = 'yyyy-mm-dd';
         this.filtersCollapsed = true;
       })
       .controller('SettingsController', function() {

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -1,335 +1,334 @@
 (function($) {
-    'use strict';
+  'use strict';
 
-    /**
-     * Define HRReport object.
-     */
-    function HRReport() {
-        var data = [];
-        var pivotTableContainer = jQuery("#reportPivotTable");
-        var derivedAttributes = {};
+  /**
+   * Define HRReport object.
+   */
+  function HRReport() {
+    var data = [];
+    var pivotTableContainer = jQuery("#reportPivotTable");
+    var derivedAttributes = {};
 
-        this.initScrollbarFallback();
-    }
+    this.initScrollbarFallback();
+  }
 
-    /**
-     * Initialization function.
-     *
-     * @param {JSON} options - Settings for the object.
-     */
-    HRReport.prototype.init = function (options) {
-        $.extend(this, options);
-    };
+  /**
+   * Initialization function.
+   *
+   * @param {JSON} options - Settings for the object.
+   */
+  HRReport.prototype.init = function (options) {
+    $.extend(this, options);
+  };
 
-    /**
-     * Init PivotTable.js library
-     */
-    HRReport.prototype.initPivotTable = function() {
-        var that = this;
-        this.pivotTableContainer.pivotUI(this.data, {
-            rendererName: "Table",
-            renderers: CRM.$.extend(
-                jQuery.pivotUtilities.renderers,
-                jQuery.pivotUtilities.c3_renderers,
-                jQuery.pivotUtilities.export_renderers
-            ),
-            vals: ["Total"],
-            rows: ["Employee gender"],
-            cols: ["Contract location"],
-            aggregatorName: "Count",
-            unusedAttrsVertical: false,
-            aggregators: that.getAggregators(),
-            derivedAttributes: this.derivedAttributes,
+  /**
+   * Init PivotTable.js library
+   */
+  HRReport.prototype.initPivotTable = function() {
+    var that = this;
+    this.pivotTableContainer.pivotUI(this.data, {
+      rendererName: "Table",
+      renderers: CRM.$.extend(
+        jQuery.pivotUtilities.renderers,
+        jQuery.pivotUtilities.c3_renderers,
+        jQuery.pivotUtilities.export_renderers
+      ),
+      vals: ["Total"],
+      rows: ["Employee gender"],
+      cols: ["Contract location"],
+      aggregatorName: "Count",
+      unusedAttrsVertical: false,
+      aggregators: that.getAggregators(),
+      derivedAttributes: this.derivedAttributes,
 
-            // It's necessary to make all the DOM changes here
-            // because the library doesn't have support to custom template
-            // https://github.com/nicolaskruchten/pivottable/issues/484
-            onRefresh: function () {
-                Drupal.behaviors.civihr_employee_portal_reports.instance.updateCustomTemplate();
+      // It's necessary to make all the DOM changes here
+      // because the library doesn't have support to custom template
+      // https://github.com/nicolaskruchten/pivottable/issues/484
+      onRefresh: function () {
+        Drupal.behaviors.civihr_employee_portal_reports.instance.updateCustomTemplate();
+      }
+    }, false);
+  }
+
+  /**
+   * Return an object containing set of Pivot Table aggregators extended with
+   * our custom ones.
+   *
+   * @returns {jQuery.pivotUtilities.aggregators|_$.pivotUtilities.aggregators|aggregators}
+   */
+  HRReport.prototype.getAggregators = function() {
+    var aggregators = $.pivotUtilities.aggregators;
+    var ordered = {};
+
+    // Create custom Aggregator behaving like 'Count Unique Values' but
+    // not counting NULL, 0 or empty strings.
+    aggregators["Count Unique Values excluding null, 0 or empty"] = function(attributeArray) {
+      var attribute = attributeArray[0];
+      return function(data, rowKey, colKey) {
+        return {
+          uniq: [],
+          push: function(record) {
+            var _ref = record[attribute];
+            if (!!+_ref && this.uniq.indexOf(_ref) < 0) {
+              this.uniq.push(record[attribute]);
             }
-        }, false);
-    }
-
-    /**
-     * Return an object containing set of Pivot Table aggregators extended with
-     * our custom ones.
-     *
-     * @returns {jQuery.pivotUtilities.aggregators|_$.pivotUtilities.aggregators|aggregators}
-     */
-    HRReport.prototype.getAggregators = function() {
-        var aggregators = $.pivotUtilities.aggregators;
-        var ordered = {};
-
-        // Create custom Aggregator behaving like 'Count Unique Values' but
-        // not counting NULL, 0 or empty strings.
-        aggregators["Count Unique Values excluding null, 0 or empty"] = function(attributeArray) {
-            var attribute = attributeArray[0];
-            return function(data, rowKey, colKey) {
-                return {
-                    uniq: [],
-                    push: function(record) {
-                        var _ref = record[attribute];
-                        if (!!+_ref && this.uniq.indexOf(_ref) < 0) {
-                            this.uniq.push(record[attribute]);
-                        }
-                    },
-                    value: function() { return this.uniq.length; },
-                    format: function(x) { return x; },
-                    numInputs: 1
-                };
-            };
+          },
+          value: function() { return this.uniq.length; },
+          format: function(x) { return x; },
+          numInputs: 1
         };
-
-        // Sort aggregators by keys.
-        Object.keys(aggregators).sort().forEach(function(key) {
-            ordered[key] = aggregators[key];
-        });
-        return ordered;
-    }
-
-    /**
-     * Update the pivot table dropdown and filter box
-     *
-     */
-    HRReport.prototype.updateCustomTemplate = function() {
-        this.updateDropdown();
-        this.updateFilterbox();
+      };
     };
 
-    /**
-     * Update the pivot table dropdown to look like CiviHR style
-     *
-     */
-    HRReport.prototype.updateDropdown = function() {
-        $('.pvtUi select').each(function () {
-            var selectClass = 'chr_custom-select chr_custom-select--full';
+    // Sort aggregators by keys.
+    Object.keys(aggregators).sort().forEach(function(key) {
+      ordered[key] = aggregators[key];
+    });
+    return ordered;
+  }
 
-            if (!$(this).parent().hasClass('chr_custom-select')) {
-                if ($(this).hasClass('pvtAggregator')) {
-                    selectClass += ' chr_custom-select--transparent';
-                }
+  /**
+   * Update the pivot table dropdown and filter box
+   *
+   */
+  HRReport.prototype.updateCustomTemplate = function() {
+    this.updateDropdown();
+    this.updateFilterbox();
+  };
 
-                $(this).wrap('<div class="' + selectClass + '"></div>');
-            }
-        });
+  /**
+   * Update the pivot table dropdown to look like CiviHR style
+   *
+   */
+  HRReport.prototype.updateDropdown = function() {
+    $('.pvtUi select').each(function () {
+      var selectClass = 'chr_custom-select chr_custom-select--full';
 
-        $('.pvtVals .chr_custom-select').each(function () {
-            if ($(this).find('select').length === 0) {
-                $(this).remove();
-            }
-        });
-    };
-
-    /**
-     * Update the filter box adding some classes to styling
-     * the checkboxes and add a new checkbox to check all options
-     *
-     */
-    HRReport.prototype.updateFilterbox = function() {
-        $('.pvtFilterBox').each(function () {
-            $(this).find('.pvtSearch').removeClass('pvtSearch').addClass('form-text');
-            $(this).find('button').addClass('btn btn-primary btn-default btn-block');
-
-            if ($(this).find('.pvtFilterSelectAllWrap').length === 0) {
-                var filters = $(this).find(".pvtFilter");
-
-                $(this).find('.pvtFilterSelectAllWrap').remove();
-                $(this).find('.pvtCheckContainer').prepend(`<p class="pvtFilterSelectAllWrap"><label><input type="checkbox" class="pvtFilterSelectAll" checked="checked"><span>Select All</span></label></p>`);
-
-                $(this).find('.pvtFilterSelectAll').on('click', function () {
-                    filters.prop("checked", $(this).is(':checked'));
-                });
-
-                $(this).find('.pvtCheckContainer p').addClass('chr_custom-checkbox');
-            }
-        });
-    };
-
-    /**
-     * Shows the Report
-     */
-    HRReport.prototype.show = function () {
-        this.initPivotTable();
-        this.bindFilters();
-    };
-
-    /**
-     * Init the scrollbar fallback
-     *
-     */
-    HRReport.prototype.initScrollbarFallback = function() {
-        var el = document.querySelector('.chr_custom-scrollbar');
-
-        if (el) {
-          Ps.initialize(el);
-        }
-    };
-
-    /**
-     * Refresh JSON data and Pivot Tables using provided filter values
-     *
-     * @param string filterValues
-     */
-    HRReport.prototype.refreshJson = function(filterValues) {
-        var that = this;
-        if (!this.jsonUrl) {
-            return;
-        }
-        CRM.$.ajax({
-            url: this.jsonUrl + filterValues,
-            error: function () {
-                console.log('Error refreshing Report JSON data.');
-            },
-            success: function (data) {
-                // Refreshing Pivot Table:
-                that.pivotTableContainer.pivotUI(data, {
-                    rendererName: "Table",
-                    renderers: CRM.$.extend(
-                        jQuery.pivotUtilities.renderers,
-                        jQuery.pivotUtilities.c3_renderers
-                    ),
-                    unusedAttrsVertical: false
-                }, false);
-            },
-            type: 'GET'
-        });
-    }
-
-    /**
-     * Refresh data table using provided filter values
-     *
-     * @param string filterValues
-     */
-    HRReport.prototype.refreshTable = function(filterValues) {
-        var that = this;
-        if (!this.tableUrl) {
-            return;
-        }
-        var tableDomId = this.getReportTableDomID();
-        CRM.$.ajax({
-            url: that.tableUrl + filterValues,
-            error: function () {
-                console.log('Error refreshing Report data table.');
-            },
-            success: function (data) {
-                that.tableContainer.html(data);
-                that.refreshReportTableViewInstance(tableDomId);
-                that.initScrollbarFallback();
-            },
-            type: 'GET'
-        });
-    }
-
-    /**
-     * Return unique Drupal View's DOM ID of data table
-     */
-    HRReport.prototype.getReportTableDomID = function() {
-        var reportTableDiv = CRM.$('#reportTable > div.view:first');
-        var reportTableClasses = reportTableDiv.attr('class').split(' ');
-        for (var i in reportTableClasses) {
-            if (reportTableClasses[i].substring(0, 12) === 'view-dom-id-') {
-                return reportTableClasses[i].substr(12);
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Reinitialize View instance of data table for given View's DOM ID
-     *
-     * @param string viewReportDataTableId
-     */
-    HRReport.prototype.refreshReportTableViewInstance = function(viewReportDataTableId) {
-        var viewReportDataTableSettings = Drupal.settings.views.ajaxViews['views_dom_id:' + viewReportDataTableId];
-        var viewReportDataTableNewId = this.getReportTableDomID();
-
-        delete Drupal.settings.views.ajaxViews['views_dom_id:' + viewReportDataTableId];
-        delete Drupal.views.instances['views_dom_id:' + viewReportDataTableId];
-
-        viewReportDataTableSettings.view_dom_id = viewReportDataTableNewId;
-        Drupal.settings.views.ajaxViews['views_dom_id:' + viewReportDataTableNewId] = viewReportDataTableSettings;
-        Drupal.views.instances['views_dom_id:' + viewReportDataTableNewId] = new Drupal.views.ajaxView(Drupal.settings.views.ajaxViews['views_dom_id:' + viewReportDataTableNewId]);
-    }
-
-    /**
-     * Bind filters UI events
-     */
-    HRReport.prototype.bindFilters = function() {
-        // Filters bindings
-        var that = this;
-        if (!this.filters) {
-            return;
+      if (!$(this).parent().hasClass('chr_custom-select')) {
+        if ($(this).hasClass('pvtAggregator')) {
+          selectClass += ' chr_custom-select--transparent';
         }
 
-        CRM.$('#report-filters input[type="submit"]').bind('click', function(e) {
-            e.preventDefault();
-            var formSerialize = CRM.$('#report-filters form:first').formSerialize();
-            if (that.jsonUrl) {
-                that.refreshJson('?' + formSerialize);
-            }
-            if (that.tableUrl) {
-                that.refreshTable('?' + formSerialize);
-            }
+        $(this).wrap('<div class="' + selectClass + '"></div>');
+      }
+    });
+
+    $('.pvtVals .chr_custom-select').each(function () {
+      if ($(this).find('select').length === 0) {
+        $(this).remove();
+      }
+    });
+  };
+
+  /**
+   * Update the filter box adding some classes to styling
+   * the checkboxes and add a new checkbox to check all options
+   *
+   */
+  HRReport.prototype.updateFilterbox = function() {
+    $('.pvtFilterBox').each(function () {
+      $(this).find('.pvtSearch').removeClass('pvtSearch').addClass('form-text');
+      $(this).find('button').addClass('btn btn-primary btn-default btn-block');
+
+      if ($(this).find('.pvtFilterSelectAllWrap').length === 0) {
+        var filters = $(this).find(".pvtFilter");
+
+        $(this).find('.pvtFilterSelectAllWrap').remove();
+        $(this).find('.pvtCheckContainer').prepend(`<p class="pvtFilterSelectAllWrap"><label><input type="checkbox" class="pvtFilterSelectAll" checked="checked"><span>Select All</span></label></p>`);
+
+        $(this).find('.pvtFilterSelectAll').on('click', function () {
+          filters.prop("checked", $(this).is(':checked'));
         });
+
+        $(this).find('.pvtCheckContainer p').addClass('chr_custom-checkbox');
+      }
+    });
+  };
+
+  /**
+   * Shows the Report
+   */
+  HRReport.prototype.show = function () {
+    this.initPivotTable();
+    this.bindFilters();
+  };
+
+  /**
+   * Init the scrollbar fallback
+   *
+   */
+  HRReport.prototype.initScrollbarFallback = function() {
+    var el = document.querySelector('.chr_custom-scrollbar');
+
+    if (el) {
+      Ps.initialize(el);
+    }
+  };
+
+  /**
+   * Refresh JSON data and Pivot Tables using provided filter values
+   *
+   * @param string filterValues
+   */
+  HRReport.prototype.refreshJson = function(filterValues) {
+    var that = this;
+    if (!this.jsonUrl) {
+      return;
+    }
+    CRM.$.ajax({
+      url: this.jsonUrl + filterValues,
+      error: function () {
+        console.log('Error refreshing Report JSON data.');
+      },
+      success: function (data) {
+        // Refreshing Pivot Table:
+        that.pivotTableContainer.pivotUI(data, {
+          rendererName: "Table",
+          renderers: CRM.$.extend(
+            jQuery.pivotUtilities.renderers,
+            jQuery.pivotUtilities.c3_renderers
+          ),
+          unusedAttrsVertical: false
+        }, false);
+      },
+      type: 'GET'
+    });
+  }
+
+  /**
+   * Refresh data table using provided filter values
+   *
+   * @param string filterValues
+   */
+  HRReport.prototype.refreshTable = function(filterValues) {
+    var that = this;
+    if (!this.tableUrl) {
+      return;
+    }
+    var tableDomId = this.getReportTableDomID();
+    CRM.$.ajax({
+      url: that.tableUrl + filterValues,
+      error: function () {
+        console.log('Error refreshing Report data table.');
+      },
+      success: function (data) {
+        that.tableContainer.html(data);
+        that.refreshReportTableViewInstance(tableDomId);
+        that.initScrollbarFallback();
+      },
+      type: 'GET'
+    });
+  }
+
+  /**
+   * Return unique Drupal View's DOM ID of data table
+   */
+  HRReport.prototype.getReportTableDomID = function() {
+    var reportTableDiv = CRM.$('#reportTable > div.view:first');
+    var reportTableClasses = reportTableDiv.attr('class').split(' ');
+    for (var i in reportTableClasses) {
+      if (reportTableClasses[i].substring(0, 12) === 'view-dom-id-') {
+        return reportTableClasses[i].substr(12);
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Reinitialize View instance of data table for given View's DOM ID
+   *
+   * @param string viewReportDataTableId
+   */
+  HRReport.prototype.refreshReportTableViewInstance = function(viewReportDataTableId) {
+    var viewReportDataTableSettings = Drupal.settings.views.ajaxViews['views_dom_id:' + viewReportDataTableId];
+    var viewReportDataTableNewId = this.getReportTableDomID();
+
+    delete Drupal.settings.views.ajaxViews['views_dom_id:' + viewReportDataTableId];
+    delete Drupal.views.instances['views_dom_id:' + viewReportDataTableId];
+
+    viewReportDataTableSettings.view_dom_id = viewReportDataTableNewId;
+    Drupal.settings.views.ajaxViews['views_dom_id:' + viewReportDataTableNewId] = viewReportDataTableSettings;
+    Drupal.views.instances['views_dom_id:' + viewReportDataTableNewId] = new Drupal.views.ajaxView(Drupal.settings.views.ajaxViews['views_dom_id:' + viewReportDataTableNewId]);
+  }
+
+  /**
+   * Bind filters UI events
+   */
+  HRReport.prototype.bindFilters = function() {
+    // Filters bindings
+    var that = this;
+    if (!this.filters) {
+      return;
     }
 
-    /**
-     * Init angular in reports custom page,
-     * and add the calendar icon
-     *
-     */
-    HRReport.prototype.initAngular = function() {
-        require([
-            'common/angular',
-            'common/services/angular-date/date-format',
-            'common/directives/angular-date/date-input',
-            'common/moment',
-            'common/filters/angular-date/format-date'
-        ], function() {
-            angular.module('civihrReports', [
-                'ngAnimate',
-                'ui.bootstrap',
-                'common.angularDate'
-            ])
-            .directive('uibDatepickerPopupWrap', function sectionDirective() {
-                return({
-                    link: function(scope, element, attributes) {
-                        return $(element[0]).wrap('<span id="bootstrap-theme" />');
-                    }
-                });
-            })
-            .controller('FiltersController', function() {
-                //this.format = 'dd/MM/yyyy';
-		this.format = 'yyyy-MM-dd';
-                this.filtersCollapsed = true;
-            })
-            .controller('SettingsController', function() {
-                this.isCollapsed = true;
-            });
+    CRM.$('#report-filters input[type="submit"]').bind('click', function(e) {
+      e.preventDefault();
+      var formSerialize = CRM.$('#report-filters form:first').formSerialize();
+      if (that.jsonUrl) {
+        that.refreshJson('?' + formSerialize);
+      }
+      if (that.tableUrl) {
+        that.refreshTable('?' + formSerialize);
+      }
+    });
+  }
 
-            angular.bootstrap(document.getElementById('civihrReports'), ['civihrReports']);
+  /**
+   * Init angular in reports custom page,
+   * and add the calendar icon
+   *
+   */
+  HRReport.prototype.initAngular = function() {
+    require([
+      'common/angular',
+      'common/services/angular-date/date-format',
+      'common/directives/angular-date/date-input',
+      'common/moment',
+      'common/filters/angular-date/format-date'
+    ], function() {
+      angular.module('civihrReports', [
+        'ngAnimate',
+        'ui.bootstrap',
+        'common.angularDate'
+      ])
+      .directive('uibDatepickerPopupWrap', function sectionDirective() {
+        return({
+          link: function(scope, element, attributes) {
+            return $(element[0]).wrap('<span id="bootstrap-theme" />');
+          }
         });
-    };
+      })
+      .controller('FiltersController', function() {
+        this.format = 'yyyy-MM-dd';
+        this.filtersCollapsed = true;
+      })
+      .controller('SettingsController', function() {
+        this.isCollapsed = true;
+      });
 
-    /**
-     * Main Reports object instance
-     */
-    Drupal.behaviors.civihr_employee_portal_reports = {
-        instance: null,
-        attach: function (context, settings) {
-            this.instance = new HRReport();
+      angular.bootstrap(document.getElementById('civihrReports'), ['civihrReports']);
+    });
+  };
 
-            this.instance.initAngular();
+  /**
+   * Main Reports object instance
+   */
+  Drupal.behaviors.civihr_employee_portal_reports = {
+    instance: null,
+    attach: function (context, settings) {
+      this.instance = new HRReport();
 
-            // Tabs bindings
-            CRM.$('.report-tabs a').bind('click', function(e) {
-                e.preventDefault();
-                CRM.$('.report-tabs li').removeClass('active');
-                CRM.$(this).parent().addClass('active');
-                CRM.$('.report-block').addClass('hidden');
-                CRM.$('.report-block.' + CRM.$(this).data('tab')).removeClass('hidden');
-            });
-            CRM.$('.report-tabs a:first').click();
-        }
+      this.instance.initAngular();
+
+      // Tabs bindings
+      CRM.$('.report-tabs a').bind('click', function(e) {
+        e.preventDefault();
+        CRM.$('.report-tabs li').removeClass('active');
+        CRM.$(this).parent().addClass('active');
+        CRM.$('.report-block').addClass('hidden');
+        CRM.$('.report-block.' + CRM.$(this).data('tab')).removeClass('hidden');
+      });
+      CRM.$('.report-tabs a:first').click();
     }
+  }
 })(jQuery);


### PR DESCRIPTION
This PR update:
- the datepicker identifiers to work with the newest version;
- fix the bootstrapcivicrm path which is responsible to add the SSP style;
- add a different placeholder on the input, `yyyy-mm-dd` instead of `yyyy-MM-dd`;
- add the `ng-click` directivetive on the calendar icon;
- also it was updated the code indentation on `reports.js` to uses 2 spaces.

***Before***
![image](https://cloud.githubusercontent.com/assets/1280255/16734512/306206e0-475c-11e6-892e-352e12868a5c.png)


***After***
![image](https://cloud.githubusercontent.com/assets/1280255/16734338/897f9efa-475b-11e6-9e74-8aa34b2b4acd.png)
