### PR TITLE
PCHR-1403: Remove reference to civihr_admin_theme

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -484,21 +484,6 @@ function civihr_employee_portal_theme($existing, $type, $theme, $path) {
 }
 
 /**
- * Implements hook_custom_theme()
- * @return string
- */
-function civihr_employee_portal_custom_theme() {
-
-    // Set the civihr_reports related pages to use the custom civihr admin theme and not the self service theme
-    $whitelist_urls = [];
-
-    // Check if the URL is whitelisted, if yes apply the civihr_admin_theme
-    if (in_array(arg(0), $whitelist_urls)) {
-        return 'civihr_admin_theme';
-    }
-}
-
-/**
  * Implements hook_views_default_views().
  */
 function civihr_employee_portal_views_default_views() {


### PR DESCRIPTION
The civihr_admin_theme is being deleted, so any reference to it doesn't serve any purpose anymore (and the whitelist was empty to begin with)
