### PR TITLE
PCHR-1316: Modify Bootstrap filename

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -109,8 +109,6 @@ function civihr_employee_portal_init() {
     drupal_add_css(getModuleUrl('org.civicrm.bootstrapcivicrm') . 'css/bootstrap-civicrm-style.css');
     drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/lib/sweetalert/sweet-alert.css");
     drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/lib/tablesaw/tablesaw.css");
-    drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/css/documents.css");
-    drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/css/tasks.css");
 
     // Check the variable and decide if we need to rebuild the absence_list mysql view
     $rebuild_absence_list_view = variable_get('rebuild_absence_list_view', 'TRUE');

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -106,7 +106,7 @@ function civihr_employee_portal_init() {
 
     // Add our additional css libraries
     drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/css/custom.css");
-    drupal_add_css(getModuleUrl('org.civicrm.bootstrapcivicrm') . 'css/bootstrap-civicrm-style.css');
+    drupal_add_css(getModuleUrl('org.civicrm.bootstrapcivicrm') . 'css/bootstrap.css');
     drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/lib/sweetalert/sweet-alert.css");
     drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/lib/tablesaw/tablesaw.css");
 


### PR DESCRIPTION
Problem: "bootstrap-civicrm-style.css" does not exist any more.
Fix: Changed it to 'bootstrap.css'