### PR TITLE
PCHR-1452: Skipping API GET call on Contact if there is an empty array of Contact IDs.

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5,6 +5,12 @@ use Drupal\civihr_employee_portal\Blocks\Leave;
 use Drupal\civihr_employee_portal\Forms\AbsenceRequestForm;
 use Drupal\civihr_employee_portal\Helpers\HelperClass;
 
+define('TASK_PAST_DAY', 1);
+define('TASK_TODAY', 2);
+define('TASK_DAY_AFTER_WEEKEND', 4);
+define('TASK_TOMORROW', 5);
+define('TASK_ANY_OTHER_DAY', 3);
+
 /**
  * Implements hook_css_alter().
  */
@@ -6308,27 +6314,25 @@ function _get_contacts_filter_values(array $contactsIds) {
  * @return int
  */
 function _get_task_filter_by_date($date) {
-    $today = date('Y-m-d');
-    $tomorrow = new DateTime('tomorrow');
-    $nbDay = date('N', strtotime($today));
-    $sunday = new DateTime($today);
-    $sunday->modify('+' . (7 - $nbDay) . ' days');
-    $weekEnd = $sunday->format('Y-m-d');
-    $taskDate = date('Y-m-d', strtotime(strip_tags($date)));
+    $today = (new DateTime())->format('Y-m-d');
+    $tomorrow = (new DateTime('tomorrow'))->format('Y-m-d');
+    $nbDay = (new DateTime())->format('N');
+    $weekEnd = (new DateTime())->modify('+' . (7 - $nbDay) . ' days')->format('Y-m-d');
+    $taskDate = (new DateTime())->setTimestamp(strtotime(strip_tags($date)))->format('Y-m-d');
 
     if ($taskDate < $today) {
-        return 1;
+        return TASK_PAST_DAY;
     }
     if ($taskDate == $today) {
-        return 2;
+        return TASK_TODAY;
     }
     if ($taskDate > $weekEnd) {
-        return 4;
+        return TASK_DAY_AFTER_WEEKEND;
     }
-    if ($taskDate == $tomorrow->format('Y-m-d')){
-        return 5;
+    if ($taskDate == $tomorrow){
+        return TASK_TOMORROW;
     }
-    return 3;
+    return TASK_ANY_OTHER_DAY;
 }
 
 /**

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -6273,3 +6273,71 @@ function _is_hrreports_data_table_view($viewName) {
     }
     return FALSE;
 }
+
+/**
+ * Return an array containing string values for given Contacts IDs.
+ * Used in Tasks block template for create Contact javascript filter.
+ * 
+ * @param array $contactsIds
+ * @return array
+ */
+function _get_contacts_filter_values(array $contactsIds) {
+    $result = array();
+    if (!empty($contactsIds)) {
+        $contactsResult = civicrm_api3('Contact', 'get', array(
+          'id' => array('IN' => array_keys($contactsIds)),
+          'return' => "sort_name",
+        ));
+        foreach ($contactsResult['values'] as $key => $value) {
+            $result[$key] = $value['sort_name'];
+        }
+    }
+    return $result;
+}
+
+/**
+ * Return an integer value of task filter by given date.
+ * 1 - PAST_DAY
+ * 2 - TODAY
+ * 4 - DAY_AFTER_WEEKEND
+ * 5 - TOMORROW
+ * 3 - ANY_OTHER_DAY
+ * Used in Tasks block template.
+ * 
+ * @param string $date
+ * @return int
+ */
+function _get_task_filter_by_date($date) {
+    $today = date('Y-m-d');
+    $tomorrow = new DateTime('tomorrow');
+    $nbDay = date('N', strtotime($today));
+    $sunday = new DateTime($today);
+    $sunday->modify('+' . (7 - $nbDay) . ' days');
+    $weekEnd = $sunday->format('Y-m-d');
+    $taskDate = date('Y-m-d', strtotime(strip_tags($date)));
+
+    if ($taskDate < $today) {
+        return 1;
+    }
+    if ($taskDate == $today) {
+        return 2;
+    }
+    if ($taskDate > $weekEnd) {
+        return 4;
+    }
+    if ($taskDate == $tomorrow->format('Y-m-d')){
+        return 5;
+    }
+    return 3;
+}
+
+/**
+ * Check if given field is one of Task contacts fields.
+ * Used in Tasks block template.
+ * 
+ * @param string $field
+ * @return bool
+ */
+function _is_field_task_contact($field) {
+   return $field == 'task_contacts' || $field == 'task_contacts_1' || $field == 'task_contacts_2';
+}

--- a/civihr_employee_portal/views/templates/views-view-table--Tasks--block.tpl.php
+++ b/civihr_employee_portal/views/templates/views-view-table--Tasks--block.tpl.php
@@ -21,12 +21,6 @@
 
 global $user;
 
-define('PAST_DAY', 1);
-define('TODAY', 2);
-define('DAY_AFTER_WEEKEND', 4);
-define('TOMORROW', 5);
-define('ANY_OTHER_DAY', 3);
-
 $civiUser = get_civihr_uf_match_data($user->uid);
 
 $typeResult = civicrm_api3('Activity', 'getoptions', array(
@@ -143,11 +137,11 @@ $contactsFilterValues = _get_contacts_filter_values($contactsIds);
                               $taskDate = strtotime(strip_tags($content));
                               $dateFilter = _get_task_filter_by_date(date('Y-m-d', $taskDate));
 
-                              if($dateFilter == TOMORROW){
+                              if ($dateFilter == TASK_TOMORROW) {
                                 $content = 'Tomorrow';
-                              }else if($dateFilter == TODAY){
+                              } else if ($dateFilter == TASK_TODAY) {
                                 $content = 'Today';
-                              }else{
+                              } else {
                                 $content = date('m/d/Y', $taskDate);
                               }
                             }

--- a/civihr_employee_portal/views/templates/views-view-table--Tasks--block.tpl.php
+++ b/civihr_employee_portal/views/templates/views-view-table--Tasks--block.tpl.php
@@ -44,7 +44,6 @@ $taskFilters = array(
 $taskFiltersCount = array_combine(array_keys($taskFilters), array_fill(0, count($taskFilters), 0));
 $contactsIds = array();
 $contacts = array();
-$contactsFilterValues = array();
 
 foreach ($rows as $row):
     $rowType = null;
@@ -62,43 +61,7 @@ foreach ($rows as $row):
     $taskFiltersCount[0]++;
 endforeach;
 
-if (!empty($contactsIds)) {
-    $contactsResult = civicrm_api3('Contact', 'get', array(
-      'id' => array('IN' => array_keys($contactsIds)),
-      'return' => "sort_name",
-    ));
-    foreach ($contactsResult['values'] as $key => $value) {
-        $contactsFilterValues[$key] = $value['sort_name'];
-    }
-}
-
-function _get_task_filter_by_date($date) {
-    $today = date('Y-m-d');
-    $tomorrow = new DateTime('tomorrow');
-    $nbDay = date('N', strtotime($today));
-    $sunday = new DateTime($today);
-    $sunday->modify('+' . (7 - $nbDay) . ' days');
-    $weekEnd = $sunday->format('Y-m-d');
-    $taskDate = date('Y-m-d', strtotime(strip_tags($date)));
-
-    if ($taskDate < $today) {
-        return PAST_DAY;
-    }
-    if ($taskDate == $today) {
-        return TODAY;
-    }
-    if ($taskDate > $weekEnd) {
-        return DAY_AFTER_WEEKEND;
-    }
-    if ($taskDate == $tomorrow->format('Y-m-d')){
-        return TOMORROW;
-    }
-    return ANY_OTHER_DAY;
-}
-
-function isFieldName($field){
-   return $field == 'task_contacts' || $field == 'task_contacts_1' || $field == 'task_contacts_2';
-}
+$contactsFilterValues = _get_contacts_filter_values($contactsIds);
 
 ?>
 
@@ -140,7 +103,7 @@ function isFieldName($field){
                         <tr>
                         <?php
                           foreach ($header as $field => $label):
-                            if (isFieldName($field)) {
+                            if (_is_field_task_contact($field)) {
                               continue;
                             }
                         ?>
@@ -172,7 +135,7 @@ function isFieldName($field){
                     <tr id="row-task-id-<?php print strip_tags($row['id']); ?>" <?php if ($row_classes[$row_count] || $class) { print 'class="' . implode(' ', $row_classes[$row_count]) . ' ' . $class . '"';  } ?> data-row-contacts="<?php print $contactsFilterValue; ?>">
                         <?php
                           foreach ($row as $field => $content):
-                            if (isFieldName($field)) {
+                            if (_is_field_task_contact($field)) {
                               continue;
                             }
 

--- a/civihr_employee_portal/views/templates/views-view-table--Tasks--block.tpl.php
+++ b/civihr_employee_portal/views/templates/views-view-table--Tasks--block.tpl.php
@@ -62,12 +62,14 @@ foreach ($rows as $row):
     $taskFiltersCount[0]++;
 endforeach;
 
-$contactsResult = civicrm_api3('Contact', 'get', array(
-  'id' => array('IN' => array_keys($contactsIds)),
-  'return' => "sort_name",
-));
-foreach ($contactsResult['values'] as $key => $value) {
-    $contactsFilterValues[$key] = $value['sort_name'];
+if (!empty($contactsIds)) {
+    $contactsResult = civicrm_api3('Contact', 'get', array(
+      'id' => array('IN' => array_keys($contactsIds)),
+      'return' => "sort_name",
+    ));
+    foreach ($contactsResult['values'] as $key => $value) {
+        $contactsFilterValues[$key] = $value['sort_name'];
+    }
 }
 
 function _get_task_filter_by_date($date) {
@@ -162,10 +164,12 @@ function isFieldName($field){
                     if (!$rowType):
                         continue;
                     endif;
-                    $rowContacts = strip_tags($row['task_contacts']) . ',' . strip_tags($row['task_contacts_1']) . ',' . strip_tags($row['task_contacts_2']);
+
+                    $class = 'task-row task-filter-id-' . _get_task_filter_by_date($row['activity_date_time']) . ' ' . $rowType;
+                    $targetKey = strip_tags($row['task_contacts']);
+                    $contactsFilterValue = !empty($contactsFilterValues[$targetKey]) ? $contactsFilterValues[$targetKey] : '';
                     ?>
-                    <?php $class = 'task-row task-filter-id-' . _get_task_filter_by_date($row['activity_date_time']) . ' ' . $rowType; ?>
-                    <tr id="row-task-id-<?php print strip_tags($row['id']); ?>" <?php if ($row_classes[$row_count] || $class) { print 'class="' . implode(' ', $row_classes[$row_count]) . ' ' . $class . '"';  } ?> data-row-contacts="<?php print $contactsFilterValues[strip_tags($row['task_contacts'])]; ?>">
+                    <tr id="row-task-id-<?php print strip_tags($row['id']); ?>" <?php if ($row_classes[$row_count] || $class) { print 'class="' . implode(' ', $row_classes[$row_count]) . ' ' . $class . '"';  } ?> data-row-contacts="<?php print $contactsFilterValue; ?>">
                         <?php
                           foreach ($row as $field => $content):
                             if (isFieldName($field)) {


### PR DESCRIPTION
The issue appears on CiviCRM 4.7 (regarding to API changes) and causes an error when using
'id' => array('IN' => array())
API parameters with empty array (while CiviCRM 4.5 works fine with it).
I've added an additional check and now there is no call executed if ID array is empty.
Also I've removed '$rowContacts' variable initialization as it wasn't used in the script.