### PR TITLE
PCHR-1318 - Setting default colour code to '#ffffff' if it's not set in Views settings.

### DIFF
--- a/civihr_employee_portal/src/Blocks/ManagerCalendar.php
+++ b/civihr_employee_portal/src/Blocks/ManagerCalendar.php
@@ -146,7 +146,7 @@ class ManagerCalendar {
                                 
                                 if ($activity['start_month'] == $activity['end_month']) {
                                     if ($s >= $activity['start_day'] && $s <= $activity['end_day']) {
-                                        $colour_code = !empty($colour_codes[$activity['type']]) ? $colour_codes[$activity['type']] : '#ffffff';
+                                        $colour_code = !empty($colour_codes[$activity['type']]) ? $colour_codes[$activity['type']] : '#999999';
                                         $rows[$employeeId][$s]['class'] = 'chr_calendar--manager__date chr_calendar--manager__date--filled';
                                         $rows[$employeeId][$s]['style'] = 'background-color: ' . $colour_code . ';';
                                         $rows[$employeeId][$s]['data'] = '<div style="color: #ffffff;" class="views-tooltip stripe" tooltip-content="' . $activity['title'] . ': ' . $activity['duration'] . '">'  . date('D', strtotime($current_year . '/' . $activity['start_month'] . '/' . $s)) . '</div></div>';

--- a/civihr_employee_portal/src/Blocks/ManagerCalendar.php
+++ b/civihr_employee_portal/src/Blocks/ManagerCalendar.php
@@ -146,8 +146,9 @@ class ManagerCalendar {
                                 
                                 if ($activity['start_month'] == $activity['end_month']) {
                                     if ($s >= $activity['start_day'] && $s <= $activity['end_day']) {
+                                        $colour_code = !empty($colour_codes[$activity['type']]) ? $colour_codes[$activity['type']] : '#ffffff';
                                         $rows[$employeeId][$s]['class'] = 'chr_calendar--manager__date chr_calendar--manager__date--filled';
-                                        $rows[$employeeId][$s]['style'] = 'background-color: ' . $colour_codes[$activity['type']] . ';';
+                                        $rows[$employeeId][$s]['style'] = 'background-color: ' . $colour_code . ';';
                                         $rows[$employeeId][$s]['data'] = '<div style="color: #ffffff;" class="views-tooltip stripe" tooltip-content="' . $activity['title'] . ': ' . $activity['duration'] . '">'  . date('D', strtotime($current_year . '/' . $activity['start_month'] . '/' . $s)) . '</div></div>';
                                     }
                                     else {


### PR DESCRIPTION
On civihr-dev server there was a few of 
_Notice: Undefined offset: 62 in Drupal\civihr_employee_portal\Blocks\ManagerCalendar->generateBlock() (line 150 of /var/www/civicrm-buildkit/build/hr16-develop/sites/all/modules/civihr-custom/civihr_employee_portal/src/Blocks/ManagerCalendar.php)._
notices, caused by empty $colour_codes array for some of absence types. The absence types colours are defined in calendar_absence_list Drupal View for all default absence types. But if there are any new absence types created then the absence types don't have any default colour and this cause the issue.
I've modified ManagerCalendar class to set a default colour for an absence type if it's not set.

BTW. The colours can be managed in:
http://civihr-dev.civihrhosting.co.uk/admin/structure/views/view/calendar_absence_list/edit
Show:Calendar Entities | **Settings** -> LEGEND COLORS section.