### PR TITLE
PCHR-1497: Fix count of "Tomorrow" tasks in SSP block

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5,12 +5,6 @@ use Drupal\civihr_employee_portal\Blocks\Leave;
 use Drupal\civihr_employee_portal\Forms\AbsenceRequestForm;
 use Drupal\civihr_employee_portal\Helpers\HelperClass;
 
-define('TASK_PAST_DAY', 1);
-define('TASK_TODAY', 2);
-define('TASK_THIS_WEEK', 3);
-define('TASK_TOMORROW', 3);
-define('TASK_LATER', 4);
-
 /**
  * Implements hook_css_alter().
  */
@@ -6353,16 +6347,11 @@ function _get_contacts_filter_values(array $contactsIds) {
 }
 
 /**
- * Return an integer value of task filter by given date.
- * 1 - PAST_DAY
- * 2 - TODAY
- * 4 - DAY_AFTER_WEEKEND
- * 5 - TOMORROW
- * 3 - ANY_OTHER_DAY
+ * Return a key of the task filter by given date.
  * Used in Tasks block template.
  *
  * @param string $date
- * @return int
+ * @return string
  */
 function _get_task_filter_by_date($date) {
   $today = (new DateTime())->format('Y-m-d');
@@ -6372,22 +6361,22 @@ function _get_task_filter_by_date($date) {
   $taskDate = (new DateTime())->setTimestamp(strtotime(strip_tags($date)))->format('Y-m-d');
 
   if ($taskDate < $today) {
-    return TASK_PAST_DAY;
+    return 'overdue';
   }
 
   if ($taskDate == $today) {
-    return TASK_TODAY;
+    return 'today';
   }
 
   if ($taskDate > $weekEnd) {
-    return TASK_LATER;
+    return 'later';
   }
 
   if ($taskDate == $tomorrow){
-    return TASK_TOMORROW;
+    return 'tomorrow';
   }
 
-  return TASK_THIS_WEEK;
+  return 'week';
 }
 
 /**

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -7,9 +7,9 @@ use Drupal\civihr_employee_portal\Helpers\HelperClass;
 
 define('TASK_PAST_DAY', 1);
 define('TASK_TODAY', 2);
-define('TASK_DAY_AFTER_WEEKEND', 4);
-define('TASK_TOMORROW', 5);
-define('TASK_ANY_OTHER_DAY', 3);
+define('TASK_THIS_WEEK', 3);
+define('TASK_TOMORROW', 3);
+define('TASK_LATER', 4);
 
 /**
  * Implements hook_css_alter().
@@ -6365,25 +6365,29 @@ function _get_contacts_filter_values(array $contactsIds) {
  * @return int
  */
 function _get_task_filter_by_date($date) {
-    $today = (new DateTime())->format('Y-m-d');
-    $tomorrow = (new DateTime('tomorrow'))->format('Y-m-d');
-    $nbDay = (new DateTime())->format('N');
-    $weekEnd = (new DateTime())->modify('+' . (7 - $nbDay) . ' days')->format('Y-m-d');
-    $taskDate = (new DateTime())->setTimestamp(strtotime(strip_tags($date)))->format('Y-m-d');
+  $today = (new DateTime())->format('Y-m-d');
+  $tomorrow = (new DateTime('tomorrow'))->format('Y-m-d');
+  $nbDay = (new DateTime())->format('N');
+  $weekEnd = (new DateTime())->modify('+' . (7 - $nbDay) . ' days')->format('Y-m-d');
+  $taskDate = (new DateTime())->setTimestamp(strtotime(strip_tags($date)))->format('Y-m-d');
 
-    if ($taskDate < $today) {
-        return TASK_PAST_DAY;
-    }
-    if ($taskDate == $today) {
-        return TASK_TODAY;
-    }
-    if ($taskDate > $weekEnd) {
-        return TASK_DAY_AFTER_WEEKEND;
-    }
-    if ($taskDate == $tomorrow){
-        return TASK_TOMORROW;
-    }
-    return TASK_ANY_OTHER_DAY;
+  if ($taskDate < $today) {
+    return TASK_PAST_DAY;
+  }
+
+  if ($taskDate == $today) {
+    return TASK_TODAY;
+  }
+
+  if ($taskDate > $weekEnd) {
+    return TASK_LATER;
+  }
+
+  if ($taskDate == $tomorrow){
+    return TASK_TOMORROW;
+  }
+
+  return TASK_THIS_WEEK;
 }
 
 /**

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -6351,32 +6351,37 @@ function _get_contacts_filter_values(array $contactsIds) {
  * Used in Tasks block template.
  *
  * @param string $date
+ * @param boolean $normalize
+ *   normalize the filter to match the list of filters offered
+ *   in the UI ('tomorrow' and 'week' are grouped together)
  * @return string
  */
-function _get_task_filter_by_date($date) {
+function _get_task_filter_by_date($date, $normalize = false) {
   $today = (new DateTime())->format('Y-m-d');
   $tomorrow = (new DateTime('tomorrow'))->format('Y-m-d');
   $nbDay = (new DateTime())->format('N');
   $weekEnd = (new DateTime())->modify('+' . (7 - $nbDay) . ' days')->format('Y-m-d');
   $taskDate = (new DateTime())->setTimestamp(strtotime(strip_tags($date)))->format('Y-m-d');
 
+  $filter = 'week';
+
   if ($taskDate < $today) {
-    return 'overdue';
+    $filter = 'overdue';
   }
 
   if ($taskDate == $today) {
-    return 'today';
+    $filter = 'today';
   }
 
   if ($taskDate > $weekEnd) {
-    return 'later';
+    $filter = 'later';
   }
 
   if ($taskDate == $tomorrow){
-    return 'tomorrow';
+    $filter = 'tomorrow';
   }
 
-  return 'week';
+  return $normalize ? ($filter == 'tomorrow' ? 'week' : $filter) : $filter;
 }
 
 /**

--- a/civihr_employee_portal/js/tasks.js
+++ b/civihr_employee_portal/js/tasks.js
@@ -103,7 +103,9 @@
             $selectedRowType = $tableTaskStaff.find('.task-row'),
             selectedRowFilterSelector = null;
 
-          $navTaskFilter.find('a').bind('click', function(e) {
+          var chk = CRM.$('.checkbox-task-completed');
+
+          $navTaskFilter.find('a').bind('click', function (e) {
             e.preventDefault();
 
             var $this = $(this),
@@ -112,7 +114,7 @@
             $navTaskFilter.find('> li').removeClass('active');
             $this.parent().addClass('active');
 
-            if (!taskFilter) {
+            if (taskFilter === 'all') {
               $selectedRowFilter = $tableTaskStaff.find('.task-row');
               selectedRowFilterSelector = '.task-row';
             } else {
@@ -126,7 +128,7 @@
           $dropdownFilter.on('change', function (e) {
             var taskFilter = $(this).val();
 
-            if (parseInt(taskFilter, 10) === 0) {
+            if (taskFilter === 'all') {
               $selectedRowFilter = $tableTaskStaff.find('.task-row');
               selectedRowFilterSelector = '.task-row';
             } else {
@@ -137,17 +139,18 @@
             showFilteredTaskRows();
           });
 
-          var chk = CRM.$('.checkbox-task-completed');
           chk.unbind('change').bind('change', function(e) {
             var checkedTaskId = $(this).val();
+
             $.ajax({
               url: '/civi_tasks/ajax/complete/' + checkedTaskId,
-              success: function(result) {
+              success: function (result) {
                 if (!result.success) {
                   CRM.alert(result.message, 'Error', 'error');
                   return;
                 }
-                $('#row-task-id-' + checkedTaskId).fadeOut(500, function() {
+
+                $('#row-task-id-' + checkedTaskId).fadeOut(500, function () {
                   $(this).remove();
                   refreshTasksCounter();
                 });
@@ -162,38 +165,54 @@
               .hide()
               .removeClass('selected-by-type')
               .removeClass('selected-by-filter');
+
             $selectedRowType.addClass('selected-by-type');
             $selectedRowFilter.addClass('selected-by-filter');
+
             $('.selected-by-type.selected-by-filter.selected-by-contact', $tableTaskStaff).show();
           }
 
           function refreshTasksCounter() {
             var sum = 0;
-            var taskFilterLength = $navTaskFilter.find('> li').length;
 
-            for (var i = 1; i < taskFilterLength; i++) {
-              var counter = $('.task-filter-id-' + i, $tableTaskStaff).length;
-              sum += counter;
-              $('#nav-tasks-filter .task-counter-filter-' + i).text(counter);
-            }
-            $('#nav-tasks-filter .task-counter-filter-0').text(sum);
+            $navTaskFilter
+              .find('[data-task-filter]')
+              .not('[data-task-filter="all"]')
+              .each(function (i, filter) {
+                var $filter = $(filter),
+                  type = $filter.data('taskFilter'),
+                  count = $('.task-filter-id-' + type, $tableTaskStaff).length;
+
+                sum += count;
+
+                $filter.find('.task-counter-filter').text(count);
+              });
+
+            $navTaskFilter
+              .find('[data-task-filter="all"]')
+              .find('.task-counter-filter').text(sum);
           }
 
           function buildTaskContactFilter() {
             $tableTaskStaffRows.addClass('selected-by-contact');
-            $('#task-filter-contact').on("keyup", function() {
+
+            $('#task-filter-contact').on("keyup", function () {
               var value = $(this).val().toLowerCase();
+
               $tableTaskStaffRows.removeClass('selected-by-contact');
-              $("#tasks-dashboard-table-staff > tbody > tr.task-row").each(function(index) {
+
+              $("#tasks-dashboard-table-staff > tbody > tr.task-row").each(function (index) {
                 var $row = $(this);
                 var text = $row.data('rowContacts') || '';
                 var matchedIndex = text.toLowerCase().indexOf(value);
+
                 if (value.length === 0 || matchedIndex !== -1) {
                   $row.addClass('selected-by-contact');
                 } else {
                   $row.removeClass('selected-by-contact');
                 }
               });
+
               showFilteredTaskRows();
             });
           }

--- a/civihr_employee_portal/views/templates/views-view-table--Tasks--block.tpl.php
+++ b/civihr_employee_portal/views/templates/views-view-table--Tasks--block.tpl.php
@@ -45,11 +45,11 @@ $taskFilters = array(
     3 => 'Due This Week',
     4 => 'Later',
 );
-$taskFiltersCount = array_combine(array_keys($taskFilters), array_fill(0, count($taskFilters), 0));
+$taskFiltersCount = array_fill(0, count($taskFilters), 0);
 $contactsIds = array();
 $contacts = array();
 
-foreach ($rows as $row):
+foreach ($rows as $row) {
   if (taskAssignedToUser($row, $civiUser['contact_id'])) {
     continue;
   }
@@ -57,10 +57,9 @@ foreach ($rows as $row):
   $contactsIds[strip_tags($row['task_contacts'])] = 1;
   $taskFiltersCount[_get_task_filter_by_date($row['activity_date_time'])]++;
   $taskFiltersCount[0]++;
-endforeach;
+}
 
 $contactsFilterValues = _get_contacts_filter_values($contactsIds);
-
 ?>
 
 <div class="chr_table-w-filters row">

--- a/civihr_employee_portal/views/templates/views-view-table--Tasks--block.tpl.php
+++ b/civihr_employee_portal/views/templates/views-view-table--Tasks--block.tpl.php
@@ -75,32 +75,32 @@ $contactsFilterValues = _get_contacts_filter_values($contactsIds);
 
 <div class="chr_table-w-filters row">
     <div class="chr_table-w-filters__filters col-md-3">
-        <div class="chr_table-w-filters__filters__dropdown-wrapper">
-            <div class="chr_custom-select chr_custom-select--full">
-                <select id="select-tasks-filter" class="chr_table-w-filters__filters__dropdown skip-js-custom-select">
-                    <?php foreach ($taskFilters as $key => $filter): ?>
-                        <option value="<?php print $key; ?>"><?php print $filter['label']; ?>
-                          (<?php print $filter['count']; ?>)
-                        </option>
-                    <?php endforeach; ?>
-                </select>
-            </div>
-        </div>
-        <ul id="nav-tasks-filter" class="chr_table-w-filters__filters__nav">
-            <?php $classActive = ' class="active"'; ?>
+      <div class="chr_table-w-filters__filters__dropdown-wrapper">
+        <div class="chr_custom-select chr_custom-select--full">
+          <select id="select-tasks-filter" class="chr_table-w-filters__filters__dropdown skip-js-custom-select">
             <?php foreach ($taskFilters as $key => $filter): ?>
-                <?php $badgeType = $key == 'overdue' ? 'danger' : 'primary'; ?>
-                <li<?php print $classActive; ?>>
-                    <a href data-task-filter="<?php print $key; ?>">
-                        <?php print $filter['label']; ?>
-                        <span class="badge badge-<?php print $badgeType; ?> pull-right task-counter-filter">
-                            <?php print $filter['count']; ?>
-                        </span>
-                    </a>
-                </li>
-                <?php $classActive = ''; ?>
+              <option value="<?php print $key; ?>"><?php print $filter['label']; ?>
+                (<?php print $filter['count']; ?>)
+              </option>
             <?php endforeach; ?>
-        </ul>
+          </select>
+        </div>
+      </div>
+      <ul id="nav-tasks-filter" class="chr_table-w-filters__filters__nav">
+        <?php $classActive = ' class="active"'; ?>
+        <?php foreach ($taskFilters as $key => $filter): ?>
+          <?php $badgeType = $key == 'overdue' ? 'danger' : 'primary'; ?>
+          <li<?php print $classActive; ?>>
+            <a href data-task-filter="<?php print $key; ?>">
+              <?php print $filter['label']; ?>
+              <span class="badge badge-<?php print $badgeType; ?> pull-right task-counter-filter">
+                <?php print $filter['count']; ?>
+              </span>
+            </a>
+          </li>
+          <?php $classActive = ''; ?>
+        <?php endforeach; ?>
+      </ul>
     </div>
     <div class="chr_table-w-filters__table-wrapper col-md-9">
         <div class="chr_table-w-filters__table">
@@ -128,52 +128,52 @@ $contactsFilterValues = _get_contacts_filter_values($contactsIds);
                 <tbody>
                 <?php foreach ($rows as $row_count => $row): ?>
                     <?php
-                    if (taskAssignedToUser($row, $civiUser['contact_id'])) {
-                      continue;
-                    }
+                      if (taskAssignedToUser($row, $civiUser['contact_id'])) {
+                        continue;
+                      }
 
-                    $class = 'task-row task-filter-id-' . taskFilterByDate($row['activity_date_time'], true);
-                    $targetKey = strip_tags($row['task_contacts']);
-                    $contactsFilterValue = !empty($contactsFilterValues[$targetKey]) ? $contactsFilterValues[$targetKey] : '';
+                      $class = 'task-row task-filter-id-' . taskFilterByDate($row['activity_date_time'], true);
+                      $targetKey = strip_tags($row['task_contacts']);
+                      $contactsFilterValue = !empty($contactsFilterValues[$targetKey]) ? $contactsFilterValues[$targetKey] : '';
                     ?>
                     <tr id="row-task-id-<?php print strip_tags($row['id']); ?>" <?php if ($row_classes[$row_count] || $class) { print 'class="' . implode(' ', $row_classes[$row_count]) . ' ' . $class . '"';  } ?> data-row-contacts="<?php print $contactsFilterValue; ?>">
+                      <?php
+                        foreach ($row as $field => $content):
+                          if (_is_field_task_contact($field)) {
+                            continue;
+                          }
+
+                          if($field == 'activity_date_time') {
+                            $taskDate = strtotime(strip_tags($content));
+                            $dateFilter = taskFilterByDate(date('Y-m-d', $taskDate));
+
+                            if ($dateFilter == 'tomorrow') {
+                              $content = 'Tomorrow';
+                            } else if ($dateFilter == 'today') {
+                              $content = 'Today';
+                            } else {
+                              $content = date('m/d/Y', $taskDate);
+                            }
+                          }
+                      ?>
+                      <td <?php if ($field_classes[$field][$row_count]) { print 'class="'. $field_classes[$field][$row_count] . '" '; } ?><?php print drupal_attributes($field_attributes[$field][$row_count]); ?>>
+                        <a
+                          href="/civi_tasks/nojs/edit/<?php print strip_tags($row['id']); ?>"
+                          class="ctools-use-modal ctools-modal-civihr-custom-style ctools-use-modal-processed">
+                          <?php print strip_tags(html_entity_decode($content)); ?>
+                        </a>
+                      </td>
+                      <?php endforeach; ?>
+                      <td>
                         <?php
-                          foreach ($row as $field => $content):
-                            if (_is_field_task_contact($field)) {
-                              continue;
-                            }
-
-                            if($field == 'activity_date_time') {
-                              $taskDate = strtotime(strip_tags($content));
-                              $dateFilter = taskFilterByDate(date('Y-m-d', $taskDate));
-
-                              if ($dateFilter == 'tomorrow') {
-                                $content = 'Tomorrow';
-                              } else if ($dateFilter == 'today') {
-                                $content = 'Today';
-                              } else {
-                                $content = date('m/d/Y', $taskDate);
-                              }
-                            }
+                          $checked = '';
+                          $disabled = '';
+                          if (!_task_can_be_marked_as_complete($row['id'])):
+                            $disabled = ' disabled="disabled" ';
+                          endif;
                         ?>
-                          <td <?php if ($field_classes[$field][$row_count]) { print 'class="'. $field_classes[$field][$row_count] . '" '; } ?><?php print drupal_attributes($field_attributes[$field][$row_count]); ?>>
-                            <a
-                              href="/civi_tasks/nojs/edit/<?php print strip_tags($row['id']); ?>"
-                              class="ctools-use-modal ctools-modal-civihr-custom-style ctools-use-modal-processed">
-                              <?php print strip_tags(html_entity_decode($content)); ?>
-                            </a>
-                          </td>
-                        <?php endforeach; ?>
-                            <td>
-                                <?php
-                                $checked = '';
-                                $disabled = '';
-                                if (!_task_can_be_marked_as_complete($row['id'])):
-                                    $disabled = ' disabled="disabled" ';
-                                endif;
-                                ?>
-                                <input type="checkbox" id="task-completed[<?php print strip_tags($row['id']); ?>" class="checkbox-task-completed" value="<?php print strip_tags($row['id']); ?>"<?php print $checked . $disabled; ?> />
-                            </td>
+                        <input type="checkbox" id="task-completed[<?php print strip_tags($row['id']); ?>" class="checkbox-task-completed" value="<?php print strip_tags($row['id']); ?>"<?php print $checked . $disabled; ?> />
+                      </td>
                     </tr>
                 <?php endforeach; ?>
                 </tbody>

--- a/civihr_employee_portal/views/templates/views-view-table--Tasks--block.tpl.php
+++ b/civihr_employee_portal/views/templates/views-view-table--Tasks--block.tpl.php
@@ -31,20 +31,6 @@ function taskAssignedToUser($task, $user_id) {
   return strip_tags($task['task_contacts_1']) != $user_id;
 }
 
-/**
- * Wraps the original function that fetches the filter type by task date so that
- * the resulting filter, if necessary, can be normalized to match the list of filters
- * offered in the UI ('tomorrow' and 'week' are grouped together)
- *
- * @param  [type] $filter [description]
- * @return [type]         [description]
- */
-function taskFilterByDate($taskDate, $normalize = false) {
-  $filter = _get_task_filter_by_date($taskDate);
-
-  return $normalize ? ($filter == 'tomorrow' ? 'week' : $filter) : $filter;
-}
-
 $contacts = array();
 $contactsIds = array();
 
@@ -67,7 +53,7 @@ foreach ($rows as $row) {
   $contactsIds[strip_tags($row['task_contacts'])] = 1;
 
   $taskFilters['all']['count']++;
-  $taskFilters[taskFilterByDate($row['activity_date_time'], true)]['count']++;
+  $taskFilters[_get_task_filter_by_date($row['activity_date_time'], true)]['count']++;
 }
 
 $contactsFilterValues = _get_contacts_filter_values($contactsIds);
@@ -132,7 +118,7 @@ $contactsFilterValues = _get_contacts_filter_values($contactsIds);
                         continue;
                       }
 
-                      $class = 'task-row task-filter-id-' . taskFilterByDate($row['activity_date_time'], true);
+                      $class = 'task-row task-filter-id-' . _get_task_filter_by_date($row['activity_date_time'], true);
                       $targetKey = strip_tags($row['task_contacts']);
                       $contactsFilterValue = !empty($contactsFilterValues[$targetKey]) ? $contactsFilterValues[$targetKey] : '';
                     ?>
@@ -145,7 +131,7 @@ $contactsFilterValues = _get_contacts_filter_values($contactsIds);
 
                           if($field == 'activity_date_time') {
                             $taskDate = strtotime(strip_tags($content));
-                            $dateFilter = taskFilterByDate(date('Y-m-d', $taskDate));
+                            $dateFilter = _get_task_filter_by_date(date('Y-m-d', $taskDate));
 
                             if ($dateFilter == 'tomorrow') {
                               $content = 'Tomorrow';


### PR DESCRIPTION
## Problem
Tasks that had a due date of tomorrow weren't show in the "Due This Week" section of the "My Tasks" block in the SSP

This was due to the fact that the constant (`TASK_TOMORROW`) used to identify the filter type that a given task belonged to referenced an index (`5`) that didn't match any of the available filters:
```php
$taskFilters = array(
  0 => 'All',
  1 => 'Overdue',
  2 => 'Due Today',
  3 => 'Due This Week',
  4 => 'Later',
);
```
because "tomorrow" tasks are not grouped in a specific section, but are put together with the "Due This Week" tasks

## Solution
Initially I simply made `TASK_TOMORROW` reference the "Due This Week" index, `3`.

I thought went on and refactored this part a bit, by removing the `TASK_` constants altogether and by making the `$taskFilter` array more expressive in terms of key, and by putting both the label and the count of each type within it:
```php
$taskFilters = array(
  'all'       => array('label' => 'All', 'count' => 0),
  'overdue'   => array('label' => 'Overdue', 'count' => 0),
  'today'     => array('label' => 'Due Today', 'count' => 0),
  'week'      => array('label' => 'Due This Week', 'count' => 0),
  'later'     => array('label' => 'Later', 'count' => 0)
);
```
this made other optimizations/adjustments follow, both in php and js