### PR TITLE
PCHR-1457: Fix the Print Leave Report button on "My Leave" block

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -1630,7 +1630,18 @@ function civihr_employee_portal_make_link($link_text, $link_type = 'debit', $nid
         ) . '';
     }
 
-    if ($link_type == 'hr-resource') {
+    if ($link_type == 'leave_report') {
+      return '' . l("<span>$link_text</span>", 'print-leave-report/',
+        array(
+          'query' => array('absence_start_date_period_filter' => $nid),
+          'attributes' => array('class' => "chr_action--icon--print $class", 'target'=>'_blank'),
+          'html' => true
+        )
+      ) . '';
+    }
+
+
+  if ($link_type == 'hr-resource') {
         return '' . l($link_text, 'hr_resources/nojs/resource/' . $nid,
             array('attributes' => array('class' => "ctools-use-modal ctools-modal-civihr-custom-style $class"))
         ) . '';


### PR DESCRIPTION
During the merge of the Reports branch, this button was broken and
clicking on it would throw an alert message about an ajax error:

![captura de tela 2016-08-26 as 00 09 46](https://cloud.githubusercontent.com/assets/388373/17992945/f8a197c2-6b21-11e6-85b8-4ba8413000ea.png)

To fix that, I copied the piece of code from before the merge that was responsible to create the link. This also fixed the link icon:

| Before | After |
|--------|-------|
| ![captura_de_tela_2016-08-26_as_00_19_45](https://cloud.githubusercontent.com/assets/388373/17993068/1dc38b9a-6b23-11e6-9108-90ad8e6b00fb.png)| ![captura_de_tela_2016-08-26_as_00_20_44](https://cloud.githubusercontent.com/assets/388373/17993071/23515e16-6b23-11e6-83c3-8358eeb14b86.png)|