### PR TITLE
PCHR-1458: Fix error 500 when using the keywords filtes on HR Resources

### DIFF
--- a/civihr_employee_portal/views/views_export/views_hr_documents.inc
+++ b/civihr_employee_portal/views/views_export/views_hr_documents.inc
@@ -292,7 +292,7 @@ $handler->display->display_options['filters']['combine']['expose']['remember_rol
 );
 $handler->display->display_options['filters']['combine']['fields'] = array(
     'title' => 'title',
-    'body' => 'body',
+    'field_short_description' => 'field_short_description',
 );
 /* Filter criterion: Content: Resource type (field_resource_type) */
 $handler->display->display_options['filters']['field_resource_type_tid']['id'] = 'field_resource_type_tid';


### PR DESCRIPTION
**Problem:**
Trying to search for HR Resources using a keyword would result on a blank page and a response with status code 500.

The source of this problem is the commit 8427db4c. On it, the hr_resources view was changed to load the short description instead of the body of the node, but the view's combine filter was still trying to use the old body field, resulting on the error.

**Solution**:
The combine filter was updated to use the short description field instead of the body.

Here you can see the filter working after the fix:
![hr_resources](https://cloud.githubusercontent.com/assets/388373/18104327/08014b92-6ed1-11e6-8596-6ed19e1b5174.gif)
