### PR TITLE
PCHR-1398: My details menu permission fix

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -434,6 +434,10 @@ function civihr_employee_portal_permission() {
       'title' => t('View HR Resources'),
       'description' => t('Availability for the user to view hr resources block and page')
     ),
+    'change document status' => array(
+      'title' => t('Change Document Status'),
+      'description' => t('Availability for the user to change document status')
+    ),
     'view vacancies' => array(
       'title' => t('View Vacancies'),
       'description' => t('Availability for the user to view vacancies block and page')
@@ -1225,9 +1229,8 @@ function civihr_employee_portal_menu() {
     $items['civi_documents/ajax/change_document_status/%/%'] = array(
         'title' => 'Change Document Status',
         'page callback' => 'civihr_employee_portal_change_document_status',
-		'access arguments' => array(array('civihr_manager', 'civihr_admin', 'administrator')),
+		    'access arguments' => array('change document status'),
         'page arguments' => array(3, 4),
-        'access callback' => '_user_has_role',
         'type' => MENU_CALLBACK,
     );
 
@@ -2508,10 +2511,7 @@ function _document_can_be_modified($document_id, $user_id = NULL) {
         $user = user_load($user_id);
     }
 
-    //TODO: change permission check to new permission for document modification after Kacper implements it
-    if (in_array('civihr_admin', $user->roles) || in_array('administrator', $user->roles)) {
-        $res = TRUE;
-    } else if (in_array('civihr_manager', $user->roles)) {
+    if (user_access('change document status')) {
         try {
             $result = civicrm_api3('Document', 'get', array(
                 'sequential' => 1,

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -1417,8 +1417,7 @@ function civihr_employee_portal_menu() {
     $items['hr-details'] = array(
         'title' => 'My Details',
         'page callback' => 'civihr_employee_portal_my_details',
-        'access callback' => '_user_has_role',
-        'access arguments' => array(array('civihr_staff', 'civihr_manager', 'civihr_admin', 'administrator')),
+        'access arguments' => array('view my details'),
         'type' => MENU_NORMAL_ITEM,
         'menu_name' => 'main-menu',
         'weight' => 4

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -1427,8 +1427,7 @@ function civihr_employee_portal_menu() {
         'title' => 'Quick Approve Leave',
         'page callback' => '_ajax_quick_email_notify',
         'page arguments' => array(2, 3),
-        'access callback' => '_user_has_role',
-        'access arguments' => array(array('civihr_staff', 'civihr_manager', 'civihr_admin', 'administrator')),
+        'access arguments' => array('access manager approval screen'),
     );
 
     $items['reports'] = array(

--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.features.user_permission.inc
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.features.user_permission.inc
@@ -752,6 +752,17 @@ function civihr_employee_portal_features_user_default_permissions() {
     'module' => 'civihr_employee_portal',
   );
 
+  // Exported permission: 'change document status'.
+  $permissions['change document status'] = array(
+    'name' => 'change document status',
+    'roles' => array(
+      'administrator' => 'administrator',
+      'civihr_admin' => 'civihr_admin',
+      'civihr_manager' => 'civihr_manager',
+    ),
+    'module' => 'civihr_employee_portal',
+  );
+
   // Exported permission: 'view vacancies'.
   $permissions['view vacancies'] = array(
     'name' => 'view vacancies',


### PR DESCRIPTION
## Problem 

When removing (View My Details) from a specific role , it will still be able to see ( My details ) menu and access it .


![selection_112](https://cloud.githubusercontent.com/assets/6275540/18169588/783a0c80-7063-11e6-8f1b-cd65142df701.png)

## Solution 

Unlike other menu items which is controlled by views , (My Details ) view menu item is defined inside civihr_employee_portal_menu and the permission is given to it was based on roles instead of permission . So I'v changed it and it can be controlled by (View My Details) permission only.

I also fixed the access arguments for (Quick Approve Leave) ajax call which used to generate emails when leave request get approved , so now emails will get generated when an absence get approved by any user with  (access manager approval screen) permission.

Finaly , I've added a new permission ( change document status ) and who have it can change documents status on SPP in case the (document assignee ID) == user ID 