### PR TITLE
PCHR-1483: Fix missing job contract/roles fields on My Details and Staff Directory views

### DIFF
--- a/civihr_employee_portal/views/views_export/views_hr_staff_directory.inc
+++ b/civihr_employee_portal/views/views_export/views_hr_staff_directory.inc
@@ -210,19 +210,20 @@ $handler->display->display_options['header']['result']['content'] = '@total';
 $handler->display->display_options['footer']['area_text_custom']['id'] = 'area_text_custom';
 $handler->display->display_options['footer']['area_text_custom']['table'] = 'views';
 $handler->display->display_options['footer']['area_text_custom']['field'] = 'area_text_custom';
-/* Relationship: CiviCRM Contacts: HRJobContract Details entity */
-$handler->display->display_options['relationships']['hrjc_details']['id'] = 'hrjc_details';
-$handler->display->display_options['relationships']['hrjc_details']['table'] = 'civicrm_contact';
-$handler->display->display_options['relationships']['hrjc_details']['field'] = 'hrjc_details';
-$handler->display->display_options['relationships']['hrjc_details']['required'] = TRUE;
-/* Relationship: CiviCRM Contacts: HRJobContract Role entity */
-$handler->display->display_options['relationships']['hrjc_role']['id'] = 'hrjc_role';
-$handler->display->display_options['relationships']['hrjc_role']['table'] = 'civicrm_contact';
-$handler->display->display_options['relationships']['hrjc_role']['field'] = 'hrjc_role';
-/* Relationship: CiviCRM Relationships: Contact ID B */
-$handler->display->display_options['relationships']['contact_id_b_']['id'] = 'contact_id_b_';
-$handler->display->display_options['relationships']['contact_id_b_']['table'] = 'civicrm_relationship';
-$handler->display->display_options['relationships']['contact_id_b_']['field'] = 'contact_id_b_';
+/* Relationship: CiviCRM Contacts: HRJobContract Revision entity */
+$handler->display->display_options['relationships']['hrjc_revision']['id'] = 'hrjc_revision';
+$handler->display->display_options['relationships']['hrjc_revision']['table'] = 'civicrm_contact';
+$handler->display->display_options['relationships']['hrjc_revision']['field'] = 'hrjc_revision';
+/* Relationship: HRJobContract Revision entity: Details_revision_id */
+$handler->display->display_options['relationships']['details_revision_id']['id'] = 'details_revision_id';
+$handler->display->display_options['relationships']['details_revision_id']['table'] = 'hrjc_revision';
+$handler->display->display_options['relationships']['details_revision_id']['field'] = 'details_revision_id';
+$handler->display->display_options['relationships']['details_revision_id']['relationship'] = 'hrjc_revision';
+/* Relationship: HRJobContract Revision entity: Role_jobcontract_id */
+$handler->display->display_options['relationships']['role_jobcontract_id']['id'] = 'role_jobcontract_id';
+$handler->display->display_options['relationships']['role_jobcontract_id']['table'] = 'hrjc_revision';
+$handler->display->display_options['relationships']['role_jobcontract_id']['field'] = 'role_jobcontract_id';
+$handler->display->display_options['relationships']['role_jobcontract_id']['relationship'] = 'hrjc_revision';
 /* Relationship: CiviCRM Contacts: CiviCRM Relationship (starting from contact A) */
 $handler->display->display_options['relationships']['relationship_id_a']['id'] = 'relationship_id_a';
 $handler->display->display_options['relationships']['relationship_id_a']['table'] = 'civicrm_contact';
@@ -286,7 +287,7 @@ $handler->display->display_options['fields']['phone_ext']['phone_type'] = '0';
 $handler->display->display_options['fields']['title']['id'] = 'title';
 $handler->display->display_options['fields']['title']['table'] = 'hrjc_details';
 $handler->display->display_options['fields']['title']['field'] = 'title';
-$handler->display->display_options['fields']['title']['relationship'] = 'hrjc_details';
+$handler->display->display_options['fields']['title']['relationship'] = 'details_revision_id';
 $handler->display->display_options['fields']['title']['label'] = 'Job Title';
 /* Field: CiviCRM Email: Email Address */
 $handler->display->display_options['fields']['email']['id'] = 'email';
@@ -300,18 +301,19 @@ $handler->display->display_options['fields']['email']['is_primary'] = 0;
 $handler->display->display_options['fields']['location']['id'] = 'location';
 $handler->display->display_options['fields']['location']['table'] = 'hrjc_details';
 $handler->display->display_options['fields']['location']['field'] = 'location';
-$handler->display->display_options['fields']['location']['relationship'] = 'hrjc_details';
+$handler->display->display_options['fields']['location']['relationship'] = 'details_revision_id';
 /* Field: HRJobContract Details entity: Contract_type */
 $handler->display->display_options['fields']['contract_type']['id'] = 'contract_type';
 $handler->display->display_options['fields']['contract_type']['table'] = 'hrjc_details';
 $handler->display->display_options['fields']['contract_type']['field'] = 'contract_type';
-$handler->display->display_options['fields']['contract_type']['relationship'] = 'hrjc_details';
+$handler->display->display_options['fields']['contract_type']['relationship'] = 'details_revision_id';
 $handler->display->display_options['fields']['contract_type']['label'] = ' Contract Type ';
 /* Field: HRJobContract Role entity: Department */
 $handler->display->display_options['fields']['department']['id'] = 'department';
 $handler->display->display_options['fields']['department']['table'] = 'hrjc_role';
-$handler->display->display_options['fields']['department']['field'] = 'department';
-$handler->display->display_options['fields']['department']['relationship'] = 'hrjc_role';
+$handler->display->display_options['fields']['department']['field'] = 'role_department';
+$handler->display->display_options['fields']['department']['relationship'] = 'role_jobcontract_id';
+$handler->display->display_options['fields']['department']['label'] = 'Department';
 /* Field: CiviCRM Relationships: End Date */
 $handler->display->display_options['fields']['end_date']['id'] = 'end_date';
 $handler->display->display_options['fields']['end_date']['table'] = 'civicrm_relationship';
@@ -335,14 +337,14 @@ $handler->display->display_options['fields']['start_date']['second_date_format']
 /* Field: HRJobContract Role entity: End_date */
 $handler->display->display_options['fields']['end_date_1']['id'] = 'end_date_1';
 $handler->display->display_options['fields']['end_date_1']['table'] = 'hrjc_role';
-$handler->display->display_options['fields']['end_date_1']['field'] = 'end_date';
-$handler->display->display_options['fields']['end_date_1']['relationship'] = 'hrjc_role';
+$handler->display->display_options['fields']['end_date_1']['field'] = 'role_end_date';
+$handler->display->display_options['fields']['end_date_1']['relationship'] = 'role_jobcontract_id';
 $handler->display->display_options['fields']['end_date_1']['exclude'] = TRUE;
 /* Field: HRJobContract Role entity: Start_date */
 $handler->display->display_options['fields']['start_date_1']['id'] = 'start_date_1';
 $handler->display->display_options['fields']['start_date_1']['table'] = 'hrjc_role';
-$handler->display->display_options['fields']['start_date_1']['field'] = 'start_date';
-$handler->display->display_options['fields']['start_date_1']['relationship'] = 'hrjc_role';
+$handler->display->display_options['fields']['start_date_1']['field'] = 'role_star_date';
+$handler->display->display_options['fields']['start_date_1']['relationship'] = 'role_jobcontract_id';
 $handler->display->display_options['fields']['start_date_1']['exclude'] = TRUE;
 /* Field: CiviCRM Contacts: First Name */
 $handler->display->display_options['fields']['first_name_1']['id'] = 'first_name_1';
@@ -414,7 +416,7 @@ $handler->display->display_options['filters']['display_name']['expose']['autocom
 $handler->display->display_options['filters']['title']['id'] = 'title';
 $handler->display->display_options['filters']['title']['table'] = 'hrjc_details';
 $handler->display->display_options['filters']['title']['field'] = 'title';
-$handler->display->display_options['filters']['title']['relationship'] = 'hrjc_details';
+$handler->display->display_options['filters']['title']['relationship'] = 'details_revision_id';
 $handler->display->display_options['filters']['title']['operator'] = 'contains';
 $handler->display->display_options['filters']['title']['group'] = 1;
 $handler->display->display_options['filters']['title']['exposed'] = TRUE;
@@ -492,8 +494,8 @@ $handler->display->display_options['filters']['email']['expose']['autocomplete_d
 /* Filter criterion: HRJobContract Role entity: Department */
 $handler->display->display_options['filters']['department']['id'] = 'department';
 $handler->display->display_options['filters']['department']['table'] = 'hrjc_role';
-$handler->display->display_options['filters']['department']['field'] = 'department';
-$handler->display->display_options['filters']['department']['relationship'] = 'hrjc_role';
+$handler->display->display_options['filters']['department']['field'] = 'role_department';
+$handler->display->display_options['filters']['department']['relationship'] = 'role_jobcontract_id';
 $handler->display->display_options['filters']['department']['operator'] = 'contains';
 $handler->display->display_options['filters']['department']['group'] = 1;
 $handler->display->display_options['filters']['department']['exposed'] = TRUE;
@@ -520,7 +522,7 @@ $handler->display->display_options['filters']['department']['expose']['autocompl
 $handler->display->display_options['filters']['location']['id'] = 'location';
 $handler->display->display_options['filters']['location']['table'] = 'hrjc_details';
 $handler->display->display_options['filters']['location']['field'] = 'location';
-$handler->display->display_options['filters']['location']['relationship'] = 'hrjc_details';
+$handler->display->display_options['filters']['location']['relationship'] = 'details_revision_id';
 $handler->display->display_options['filters']['location']['operator'] = 'contains';
 $handler->display->display_options['filters']['location']['group'] = 1;
 $handler->display->display_options['filters']['location']['exposed'] = TRUE;
@@ -574,7 +576,7 @@ $handler->display->display_options['filters']['display_name_1']['expose']['autoc
 $handler->display->display_options['filters']['is_primary']['id'] = 'is_primary';
 $handler->display->display_options['filters']['is_primary']['table'] = 'hrjc_details';
 $handler->display->display_options['filters']['is_primary']['field'] = 'is_primary';
-$handler->display->display_options['filters']['is_primary']['relationship'] = 'hrjc_details';
+$handler->display->display_options['filters']['is_primary']['relationship'] = 'details_revision_id';
 $handler->display->display_options['filters']['is_primary']['value']['value'] = '1';
 $handler->display->display_options['filters']['is_primary']['group'] = 1;
 /* Filter criterion: CiviCRM Relationships: Relationship Type A-to-B */
@@ -606,6 +608,46 @@ $handler->display->display_options['pager']['options']['tags']['first'] = 'First
 $handler->display->display_options['pager']['options']['tags']['previous'] = 'Previous';
 $handler->display->display_options['pager']['options']['tags']['next'] = 'Next';
 $handler->display->display_options['pager']['options']['tags']['last'] = 'Last';
+$handler->display->display_options['defaults']['arguments'] = FALSE;
+/* Contextual filter: HRJobContract Details entity: Period start date */
+$handler->display->display_options['arguments']['period_start_date']['id'] = 'period_start_date';
+$handler->display->display_options['arguments']['period_start_date']['table'] = 'hrjc_details';
+$handler->display->display_options['arguments']['period_start_date']['field'] = 'period_start_date';
+$handler->display->display_options['arguments']['period_start_date']['relationship'] = 'details_revision_id';
+$handler->display->display_options['arguments']['period_start_date']['default_action'] = 'default';
+$handler->display->display_options['arguments']['period_start_date']['default_argument_type'] = 'php';
+$handler->display->display_options['arguments']['period_start_date']['default_argument_options']['code'] = 'return date(\'Y-m-d\');';
+$handler->display->display_options['arguments']['period_start_date']['summary']['number_of_records'] = '0';
+$handler->display->display_options['arguments']['period_start_date']['summary']['format'] = 'default_summary';
+$handler->display->display_options['arguments']['period_start_date']['summary_options']['items_per_page'] = '25';
+$handler->display->display_options['arguments']['period_start_date']['civihr_range'] = '<=';
+$handler->display->display_options['arguments']['period_start_date']['civihr_range_empty'] = '0';
+/* Contextual filter: HRJobContract Details entity: Period end date */
+$handler->display->display_options['arguments']['period_end_date']['id'] = 'period_end_date';
+$handler->display->display_options['arguments']['period_end_date']['table'] = 'hrjc_details';
+$handler->display->display_options['arguments']['period_end_date']['field'] = 'period_end_date';
+$handler->display->display_options['arguments']['period_end_date']['relationship'] = 'details_revision_id';
+$handler->display->display_options['arguments']['period_end_date']['default_action'] = 'default';
+$handler->display->display_options['arguments']['period_end_date']['default_argument_type'] = 'php';
+$handler->display->display_options['arguments']['period_end_date']['default_argument_options']['code'] = 'return date(\'Y-m-d\');';
+$handler->display->display_options['arguments']['period_end_date']['summary']['number_of_records'] = '0';
+$handler->display->display_options['arguments']['period_end_date']['summary']['format'] = 'default_summary';
+$handler->display->display_options['arguments']['period_end_date']['summary_options']['items_per_page'] = '25';
+$handler->display->display_options['arguments']['period_end_date']['civihr_range'] = '>=';
+$handler->display->display_options['arguments']['period_end_date']['civihr_range_empty'] = '1';
+/* Contextual filter: HRJobContract Revision entity: Effective_end_date */
+$handler->display->display_options['arguments']['effective_end_date']['id'] = 'effective_end_date';
+$handler->display->display_options['arguments']['effective_end_date']['table'] = 'hrjc_revision';
+$handler->display->display_options['arguments']['effective_end_date']['field'] = 'effective_end_date';
+$handler->display->display_options['arguments']['effective_end_date']['relationship'] = 'hrjc_revision';
+$handler->display->display_options['arguments']['effective_end_date']['default_action'] = 'default';
+$handler->display->display_options['arguments']['effective_end_date']['default_argument_type'] = 'php';
+$handler->display->display_options['arguments']['effective_end_date']['default_argument_options']['code'] = 'return date(\'Y-m-d\');';
+$handler->display->display_options['arguments']['effective_end_date']['summary']['number_of_records'] = '0';
+$handler->display->display_options['arguments']['effective_end_date']['summary']['format'] = 'default_summary';
+$handler->display->display_options['arguments']['effective_end_date']['summary_options']['items_per_page'] = '25';
+$handler->display->display_options['arguments']['effective_end_date']['civihr_range'] = '>=';
+$handler->display->display_options['arguments']['effective_end_date']['civihr_range_empty'] = '1';
 $handler->display->display_options['merge_rows'] = TRUE;
 $handler->display->display_options['field_config'] = array(
   'id' => array(

--- a/civihr_employee_portal/views/views_export/views_my_details_block.inc
+++ b/civihr_employee_portal/views/views_export/views_my_details_block.inc
@@ -33,11 +33,15 @@ $handler->display->display_options['row_plugin'] = 'fields';
 $handler->display->display_options['relationships']['drupal_id']['id'] = 'drupal_id';
 $handler->display->display_options['relationships']['drupal_id']['table'] = 'civicrm_contact';
 $handler->display->display_options['relationships']['drupal_id']['field'] = 'drupal_id';
-/* Relationship: CiviCRM Contacts: HRJobContract Details entity */
-$handler->display->display_options['relationships']['hrjc_details']['id'] = 'hrjc_details';
-$handler->display->display_options['relationships']['hrjc_details']['table'] = 'civicrm_contact';
-$handler->display->display_options['relationships']['hrjc_details']['field'] = 'hrjc_details';
-$handler->display->display_options['relationships']['hrjc_details']['relationship'] = 'drupal_id';
+/* Relationship: CiviCRM Contacts: HRJobContract Revision entity */
+$handler->display->display_options['relationships']['hrjc_revision']['id'] = 'hrjc_revision';
+$handler->display->display_options['relationships']['hrjc_revision']['table'] = 'civicrm_contact';
+$handler->display->display_options['relationships']['hrjc_revision']['field'] = 'hrjc_revision';
+/* Relationship: HRJobContract Revision entity: Details_revision_id */
+$handler->display->display_options['relationships']['details_revision_id']['id'] = 'details_revision_id';
+$handler->display->display_options['relationships']['details_revision_id']['table'] = 'hrjc_revision';
+$handler->display->display_options['relationships']['details_revision_id']['field'] = 'details_revision_id';
+$handler->display->display_options['relationships']['details_revision_id']['relationship'] = 'hrjc_revision';
 /* Field: CiviCRM Contacts: Contact ID */
 $handler->display->display_options['fields']['id']['id'] = 'id';
 $handler->display->display_options['fields']['id']['table'] = 'civicrm_contact';
@@ -71,15 +75,20 @@ $handler->display->display_options['defaults']['relationships'] = FALSE;
 $handler->display->display_options['relationships']['drupal_id']['id'] = 'drupal_id';
 $handler->display->display_options['relationships']['drupal_id']['table'] = 'civicrm_contact';
 $handler->display->display_options['relationships']['drupal_id']['field'] = 'drupal_id';
-/* Relationship: CiviCRM Contacts: HRJobContract Details entity */
-$handler->display->display_options['relationships']['hrjc_details']['id'] = 'hrjc_details';
-$handler->display->display_options['relationships']['hrjc_details']['table'] = 'civicrm_contact';
-$handler->display->display_options['relationships']['hrjc_details']['field'] = 'hrjc_details';
-$handler->display->display_options['relationships']['hrjc_details']['relationship'] = 'drupal_id';
-/* Relationship: CiviCRM Contacts: HRJobContract Role entity */
-$handler->display->display_options['relationships']['hrjc_role']['id'] = 'hrjc_role';
-$handler->display->display_options['relationships']['hrjc_role']['table'] = 'civicrm_contact';
-$handler->display->display_options['relationships']['hrjc_role']['field'] = 'hrjc_role';
+/* Relationship: CiviCRM Contacts: HRJobContract Revision entity */
+$handler->display->display_options['relationships']['hrjc_revision']['id'] = 'hrjc_revision';
+$handler->display->display_options['relationships']['hrjc_revision']['table'] = 'civicrm_contact';
+$handler->display->display_options['relationships']['hrjc_revision']['field'] = 'hrjc_revision';
+/* Relationship: HRJobContract Revision entity: Details_revision_id */
+$handler->display->display_options['relationships']['details_revision_id']['id'] = 'details_revision_id';
+$handler->display->display_options['relationships']['details_revision_id']['table'] = 'hrjc_revision';
+$handler->display->display_options['relationships']['details_revision_id']['field'] = 'details_revision_id';
+$handler->display->display_options['relationships']['details_revision_id']['relationship'] = 'hrjc_revision';
+/* Relationship: HRJobContract Revision entity: Role_jobcontract_id */
+$handler->display->display_options['relationships']['role_jobcontract_id']['id'] = 'role_jobcontract_id';
+$handler->display->display_options['relationships']['role_jobcontract_id']['table'] = 'hrjc_revision';
+$handler->display->display_options['relationships']['role_jobcontract_id']['field'] = 'role_jobcontract_id';
+$handler->display->display_options['relationships']['role_jobcontract_id']['relationship'] = 'hrjc_revision';
 $handler->display->display_options['defaults']['fields'] = FALSE;
 /* Field: CiviCRM Contacts: Contact ID */
 $handler->display->display_options['fields']['id']['id'] = 'id';
@@ -93,7 +102,7 @@ $handler->display->display_options['fields']['display_name']['table'] = 'civicrm
 $handler->display->display_options['fields']['display_name']['field'] = 'display_name';
 $handler->display->display_options['fields']['display_name']['label'] = 'Name';
 $handler->display->display_options['fields']['display_name']['link_to_civicrm_contact'] = 0;
-/* Field: CiviCRM Phone Details: Phone Number */
+/* Field: CiviCRM Phone Details: Phone */
 $handler->display->display_options['fields']['phone']['id'] = 'phone';
 $handler->display->display_options['fields']['phone']['table'] = 'civicrm_phone';
 $handler->display->display_options['fields']['phone']['field'] = 'phone';
@@ -131,31 +140,72 @@ $handler->display->display_options['fields']['email']['is_primary'] = 0;
 $handler->display->display_options['fields']['title']['id'] = 'title';
 $handler->display->display_options['fields']['title']['table'] = 'hrjc_details';
 $handler->display->display_options['fields']['title']['field'] = 'title';
-$handler->display->display_options['fields']['title']['relationship'] = 'hrjc_details';
+$handler->display->display_options['fields']['title']['relationship'] = 'details_revision_id';
 $handler->display->display_options['fields']['title']['label'] = 'Designation';
 /* Field: HRJobContract Details entity: Location */
 $handler->display->display_options['fields']['location']['id'] = 'location';
 $handler->display->display_options['fields']['location']['table'] = 'hrjc_details';
 $handler->display->display_options['fields']['location']['field'] = 'location';
-$handler->display->display_options['fields']['location']['relationship'] = 'hrjc_details';
-/* Field: HRJobContract Role entity: Title */
-$handler->display->display_options['fields']['title_1']['id'] = 'title_1';
-$handler->display->display_options['fields']['title_1']['table'] = 'hrjc_role';
-$handler->display->display_options['fields']['title_1']['field'] = 'title';
-$handler->display->display_options['fields']['title_1']['relationship'] = 'hrjc_role';
-$handler->display->display_options['fields']['title_1']['label'] = 'Role title';
-/* Field: HRJobContract Role entity: Department */
-$handler->display->display_options['fields']['department']['id'] = 'department';
-$handler->display->display_options['fields']['department']['table'] = 'hrjc_role';
-$handler->display->display_options['fields']['department']['field'] = 'department';
-$handler->display->display_options['fields']['department']['relationship'] = 'hrjc_role';
-$handler->display->display_options['fields']['department']['label'] = 'Role Department';
+$handler->display->display_options['fields']['location']['relationship'] = 'details_revision_id';
+$handler->display->display_options['fields']['location']['label'] = 'Location';
+/* Field: HRJobContract Role entity: Role_title */
+$handler->display->display_options['fields']['role_title']['id'] = 'role_title';
+$handler->display->display_options['fields']['role_title']['table'] = 'hrjc_role';
+$handler->display->display_options['fields']['role_title']['field'] = 'role_title';
+$handler->display->display_options['fields']['role_title']['relationship'] = 'role_jobcontract_id';
+$handler->display->display_options['fields']['role_title']['label'] = 'Role title';
+/* Field: HRJobContract Role entity: Role_department */
+$handler->display->display_options['fields']['role_department']['id'] = 'role_department';
+$handler->display->display_options['fields']['role_department']['table'] = 'hrjc_role';
+$handler->display->display_options['fields']['role_department']['field'] = 'role_department';
+$handler->display->display_options['fields']['role_department']['relationship'] = 'role_jobcontract_id';
+$handler->display->display_options['fields']['role_department']['label'] = 'Role Department';
 /* Field: CiviCRM Custom: Emergency Contacts: Name */
 $handler->display->display_options['fields']['name_80']['id'] = 'name_80';
 $handler->display->display_options['fields']['name_80']['table'] = 'civicrm_value_emergency_contacts_21';
 $handler->display->display_options['fields']['name_80']['field'] = 'name_80';
 $handler->display->display_options['fields']['name_80']['label'] = 'Emergency Contact';
 $handler->display->display_options['fields']['name_80']['alter']['strip_tags'] = TRUE;
+$handler->display->display_options['defaults']['arguments'] = FALSE;
+/* Contextual filter: HRJobContract Details entity: Period start date */
+$handler->display->display_options['arguments']['period_start_date']['id'] = 'period_start_date';
+$handler->display->display_options['arguments']['period_start_date']['table'] = 'hrjc_details';
+$handler->display->display_options['arguments']['period_start_date']['field'] = 'period_start_date';
+$handler->display->display_options['arguments']['period_start_date']['relationship'] = 'details_revision_id';
+$handler->display->display_options['arguments']['period_start_date']['default_action'] = 'default';
+$handler->display->display_options['arguments']['period_start_date']['default_argument_type'] = 'php';
+$handler->display->display_options['arguments']['period_start_date']['default_argument_options']['code'] = 'return date(\'Y-m-d\');';
+$handler->display->display_options['arguments']['period_start_date']['summary']['number_of_records'] = '0';
+$handler->display->display_options['arguments']['period_start_date']['summary']['format'] = 'default_summary';
+$handler->display->display_options['arguments']['period_start_date']['summary_options']['items_per_page'] = '25';
+$handler->display->display_options['arguments']['period_start_date']['civihr_range'] = '<=';
+$handler->display->display_options['arguments']['period_start_date']['civihr_range_empty'] = '0';
+/* Contextual filter: HRJobContract Details entity: Period end date */
+$handler->display->display_options['arguments']['period_end_date']['id'] = 'period_end_date';
+$handler->display->display_options['arguments']['period_end_date']['table'] = 'hrjc_details';
+$handler->display->display_options['arguments']['period_end_date']['field'] = 'period_end_date';
+$handler->display->display_options['arguments']['period_end_date']['relationship'] = 'details_revision_id';
+$handler->display->display_options['arguments']['period_end_date']['default_action'] = 'default';
+$handler->display->display_options['arguments']['period_end_date']['default_argument_type'] = 'php';
+$handler->display->display_options['arguments']['period_end_date']['default_argument_options']['code'] = 'return date(\'Y-m-d\');';
+$handler->display->display_options['arguments']['period_end_date']['summary']['number_of_records'] = '0';
+$handler->display->display_options['arguments']['period_end_date']['summary']['format'] = 'default_summary';
+$handler->display->display_options['arguments']['period_end_date']['summary_options']['items_per_page'] = '25';
+$handler->display->display_options['arguments']['period_end_date']['civihr_range'] = '>=';
+$handler->display->display_options['arguments']['period_end_date']['civihr_range_empty'] = '1';
+/* Contextual filter: HRJobContract Revision entity: Effective_end_date */
+$handler->display->display_options['arguments']['effective_end_date']['id'] = 'effective_end_date';
+$handler->display->display_options['arguments']['effective_end_date']['table'] = 'hrjc_revision';
+$handler->display->display_options['arguments']['effective_end_date']['field'] = 'effective_end_date';
+$handler->display->display_options['arguments']['effective_end_date']['relationship'] = 'hrjc_revision';
+$handler->display->display_options['arguments']['effective_end_date']['default_action'] = 'default';
+$handler->display->display_options['arguments']['effective_end_date']['default_argument_type'] = 'php';
+$handler->display->display_options['arguments']['effective_end_date']['default_argument_options']['code'] = 'return date(\'Y-m-d\');';
+$handler->display->display_options['arguments']['effective_end_date']['summary']['number_of_records'] = '0';
+$handler->display->display_options['arguments']['effective_end_date']['summary']['format'] = 'default_summary';
+$handler->display->display_options['arguments']['effective_end_date']['summary_options']['items_per_page'] = '25';
+$handler->display->display_options['arguments']['effective_end_date']['civihr_range'] = '>=';
+$handler->display->display_options['arguments']['effective_end_date']['civihr_range_empty'] = '1';
 
 /* Display: My address */
 $handler = $view->new_display('block', 'My address', 'my_address_block');
@@ -172,7 +222,7 @@ $handler->display->display_options['relationships']['drupal_id']['id'] = 'drupal
 $handler->display->display_options['relationships']['drupal_id']['table'] = 'civicrm_contact';
 $handler->display->display_options['relationships']['drupal_id']['field'] = 'drupal_id';
 $handler->display->display_options['defaults']['fields'] = FALSE;
-/* Field: CiviCRM Phone Details: Phone Number */
+/* Field: CiviCRM Phone Details: Phone */
 $handler->display->display_options['fields']['phone']['id'] = 'phone';
 $handler->display->display_options['fields']['phone']['table'] = 'civicrm_phone';
 $handler->display->display_options['fields']['phone']['field'] = 'phone';
@@ -220,7 +270,7 @@ $handler->display->display_options['fields']['city']['location_type'] = '1';
 $handler->display->display_options['fields']['city']['location_op'] = '0';
 $handler->display->display_options['fields']['city']['is_primary'] = 1;
 $handler->display->display_options['fields']['city']['is_billing'] = 0;
-/* Field: CiviCRM Address: ZIP / Postal Code */
+/* Field: CiviCRM Address: Postal Code */
 $handler->display->display_options['fields']['postal_code']['id'] = 'postal_code';
 $handler->display->display_options['fields']['postal_code']['table'] = 'civicrm_address';
 $handler->display->display_options['fields']['postal_code']['field'] = 'postal_code';
@@ -255,16 +305,20 @@ $handler->display->display_options['defaults']['relationships'] = FALSE;
 $handler->display->display_options['relationships']['drupal_id']['id'] = 'drupal_id';
 $handler->display->display_options['relationships']['drupal_id']['table'] = 'civicrm_contact';
 $handler->display->display_options['relationships']['drupal_id']['field'] = 'drupal_id';
-/* Relationship: CiviCRM Contacts: HRJobContract Details entity */
-$handler->display->display_options['relationships']['hrjc_details']['id'] = 'hrjc_details';
-$handler->display->display_options['relationships']['hrjc_details']['table'] = 'civicrm_contact';
-$handler->display->display_options['relationships']['hrjc_details']['field'] = 'hrjc_details';
-$handler->display->display_options['relationships']['hrjc_details']['relationship'] = 'drupal_id';
-/* Relationship: CiviCRM Contacts: HRJobContract Role entity */
-$handler->display->display_options['relationships']['hrjc_role']['id'] = 'hrjc_role';
-$handler->display->display_options['relationships']['hrjc_role']['table'] = 'civicrm_contact';
-$handler->display->display_options['relationships']['hrjc_role']['field'] = 'hrjc_role';
-$handler->display->display_options['relationships']['hrjc_role']['relationship'] = 'drupal_id';
+/* Relationship: CiviCRM Contacts: HRJobContract Revision entity */
+$handler->display->display_options['relationships']['hrjc_revision']['id'] = 'hrjc_revision';
+$handler->display->display_options['relationships']['hrjc_revision']['table'] = 'civicrm_contact';
+$handler->display->display_options['relationships']['hrjc_revision']['field'] = 'hrjc_revision';
+/* Relationship: HRJobContract Revision entity: Details_revision_id */
+$handler->display->display_options['relationships']['details_revision_id']['id'] = 'details_revision_id';
+$handler->display->display_options['relationships']['details_revision_id']['table'] = 'hrjc_revision';
+$handler->display->display_options['relationships']['details_revision_id']['field'] = 'details_revision_id';
+$handler->display->display_options['relationships']['details_revision_id']['relationship'] = 'hrjc_revision';
+/* Relationship: HRJobContract Revision entity: Role_jobcontract_id */
+$handler->display->display_options['relationships']['role_jobcontract_id']['id'] = 'role_jobcontract_id';
+$handler->display->display_options['relationships']['role_jobcontract_id']['table'] = 'hrjc_revision';
+$handler->display->display_options['relationships']['role_jobcontract_id']['field'] = 'role_jobcontract_id';
+$handler->display->display_options['relationships']['role_jobcontract_id']['relationship'] = 'hrjc_revision';
 $handler->display->display_options['defaults']['fields'] = FALSE;
 /* Field: CiviCRM Contacts: Contact ID */
 $handler->display->display_options['fields']['id']['id'] = 'id';
@@ -276,7 +330,7 @@ $handler->display->display_options['fields']['display_name']['table'] = 'civicrm
 $handler->display->display_options['fields']['display_name']['field'] = 'display_name';
 $handler->display->display_options['fields']['display_name']['label'] = 'Display name';
 $handler->display->display_options['fields']['display_name']['link_to_civicrm_contact'] = 0;
-/* Field: CiviCRM Phone Details: Phone Number */
+/* Field: CiviCRM Phone Details: Phone */
 $handler->display->display_options['fields']['phone']['id'] = 'phone';
 $handler->display->display_options['fields']['phone']['table'] = 'civicrm_phone';
 $handler->display->display_options['fields']['phone']['field'] = 'phone';
@@ -310,28 +364,6 @@ $handler->display->display_options['fields']['email']['label'] = 'Work Email';
 $handler->display->display_options['fields']['email']['location_type'] = '2';
 $handler->display->display_options['fields']['email']['location_op'] = '0';
 $handler->display->display_options['fields']['email']['is_primary'] = 0;
-/* Field: HRJobContract Details entity: Title */
-$handler->display->display_options['fields']['title']['id'] = 'title';
-$handler->display->display_options['fields']['title']['table'] = 'hrjc_details';
-$handler->display->display_options['fields']['title']['field'] = 'title';
-$handler->display->display_options['fields']['title']['relationship'] = 'hrjc_details';
-$handler->display->display_options['fields']['title']['label'] = 'Designation';
-/* Field: HRJobContract Role entity: Department */
-$handler->display->display_options['fields']['department']['id'] = 'department';
-$handler->display->display_options['fields']['department']['table'] = 'hrjc_role';
-$handler->display->display_options['fields']['department']['field'] = 'department';
-$handler->display->display_options['fields']['department']['relationship'] = 'hrjc_role';
-/* Field: HRJobContract Details entity: Location */
-$handler->display->display_options['fields']['location']['id'] = 'location';
-$handler->display->display_options['fields']['location']['table'] = 'hrjc_details';
-$handler->display->display_options['fields']['location']['field'] = 'location';
-$handler->display->display_options['fields']['location']['relationship'] = 'hrjc_details';
-/* Field: HRJobContract Role entity: Title */
-$handler->display->display_options['fields']['title_1']['id'] = 'title_1';
-$handler->display->display_options['fields']['title_1']['table'] = 'hrjc_role';
-$handler->display->display_options['fields']['title_1']['field'] = 'title';
-$handler->display->display_options['fields']['title_1']['relationship'] = 'hrjc_role';
-$handler->display->display_options['fields']['title_1']['label'] = 'Role title';
 /* Field: CiviCRM Contacts: Birth Date */
 $handler->display->display_options['fields']['birth_date']['id'] = 'birth_date';
 $handler->display->display_options['fields']['birth_date']['table'] = 'civicrm_contact';
@@ -340,7 +372,7 @@ $handler->display->display_options['fields']['birth_date']['label'] = 'Date of b
 $handler->display->display_options['fields']['birth_date']['date_format'] = 'custom';
 $handler->display->display_options['fields']['birth_date']['custom_date_format'] = 'd.m.Y';
 $handler->display->display_options['fields']['birth_date']['second_date_format'] = 'long';
-/* Field: CiviCRM Phone Details: Phone Number */
+/* Field: CiviCRM Phone Details: Phone */
 $handler->display->display_options['fields']['phone_1']['id'] = 'phone_1';
 $handler->display->display_options['fields']['phone_1']['table'] = 'civicrm_phone';
 $handler->display->display_options['fields']['phone_1']['field'] = 'phone';
@@ -384,7 +416,7 @@ $handler->display->display_options['fields']['city']['location_type'] = '1';
 $handler->display->display_options['fields']['city']['location_op'] = '0';
 $handler->display->display_options['fields']['city']['is_primary'] = 1;
 $handler->display->display_options['fields']['city']['is_billing'] = 0;
-/* Field: CiviCRM Address: ZIP / Postal Code */
+/* Field: CiviCRM Address: Postal Code */
 $handler->display->display_options['fields']['postal_code']['id'] = 'postal_code';
 $handler->display->display_options['fields']['postal_code']['table'] = 'civicrm_address';
 $handler->display->display_options['fields']['postal_code']['field'] = 'postal_code';
@@ -497,7 +529,7 @@ $handler->display->display_options['fields']['dependant_s__92']['field'] = 'depe
 $handler->display->display_options['fields']['dependant_s__92']['alter']['strip_tags'] = TRUE;
 $translatables['my_details_block'] = array(
   t('Master'),
-  t('My details block'),
+  t('My Details Block'),
   t('more'),
   t('Apply'),
   t('Reset'),
@@ -505,6 +537,7 @@ $translatables['my_details_block'] = array(
   t('Asc'),
   t('Desc'),
   t('Drupal User'),
+  t('HRJobContract Revision entity'),
   t('HRJobContract Details entity'),
   t('Contact ID'),
   t('.'),
@@ -522,20 +555,21 @@ $translatables['my_details_block'] = array(
   t('Location'),
   t('Role title'),
   t('Role Department'),
+  t('All'),
   t('My address'),
-  t('My address block'),
+  t('My Address Block'),
   t('Personal Phone'),
   t('Personal Email'),
   t('Address'),
   t('Address Line 2'),
   t('City / Suburb'),
-  t('ZIP / Postal Code'),
+  t('Postal Code'),
   t('State/Province'),
   t('Country'),
   t('My details (full)'),
   t('My Details'),
   t('Display name'),
-  t('Department'),
+  t('Work phone'),
   t('Date of birth'),
   t('Full Street Address'),
   t('Supplemental Street Address'),
@@ -548,11 +582,13 @@ $translatables['my_details_block'] = array(
   t('Contact name'),
   t('Mobile number'),
   t('Phone number'),
+  t('Primary email'),
   t('Street Address'),
   t('Street Address Line 2'),
   t('City'),
-  t('Postal Code'),
   t('Relationship with Employee'),
   t('Notes'),
   t('Dependant(s)'),
 );
+
+

--- a/civihr_hrjobcontract_entities/civihr_hrjobcontract_entities.module
+++ b/civihr_hrjobcontract_entities/civihr_hrjobcontract_entities.module
@@ -1,7 +1,7 @@
 <?php
 
 function civihr_hrjobcontract_entities_init() {
-    
+
     $rebuild_hrjobcontract_entities_view = variable_get('rebuild_hrjobcontract_entities_view', 'TRUE');
     if (isset($rebuild_hrjobcontract_entities_view) && $rebuild_hrjobcontract_entities_view == 'TRUE') {
         civicrm_initialize();
@@ -10,7 +10,7 @@ function civihr_hrjobcontract_entities_init() {
 
         db_query('DROP VIEW IF EXISTS hrjc_revision');
         db_query("CREATE OR REPLACE VIEW hrjc_revision AS
-                    SELECT 
+                    SELECT
                     c.contact_id,
 #                    c.is_primary,
 #                    r.id AS revision_id,
@@ -63,15 +63,15 @@ function civihr_hrjobcontract_entities_init() {
                     FROM {$civi_db_name}.civicrm_hrjobcontract_details AS t
                     LEFT JOIN {$civi_db_name}.civicrm_hrjobcontract_revision r ON t.jobcontract_revision_id = r.details_revision_id
                     LEFT JOIN {$civi_db_name}.civicrm_hrjobcontract c ON r.jobcontract_id = c.id
-                    
+
                     LEFT JOIN {$civi_db_name}.civicrm_option_group og_contract_type ON og_contract_type.name = 'hrjc_contract_type'
                     LEFT JOIN {$civi_db_name}.civicrm_option_value ov_contract_type ON og_contract_type.id = ov_contract_type.option_group_id AND ov_contract_type.value = t.contract_type
-                    
+
                     LEFT JOIN {$civi_db_name}.civicrm_option_group og_location ON og_location.name = 'hrjc_location'
                     LEFT JOIN {$civi_db_name}.civicrm_option_value ov_location ON og_location.id = ov_location.option_group_id AND ov_location.value = t.location
-                    
+
                     WHERE c.deleted = 0");
-        
+
         db_query('DROP VIEW IF EXISTS hrjc_health');
         db_query("CREATE OR REPLACE VIEW hrjc_health AS
                     SELECT
@@ -90,11 +90,11 @@ function civihr_hrjobcontract_entities_init() {
                     FROM {$civi_db_name}.civicrm_hrjobcontract_health AS t
                     LEFT JOIN {$civi_db_name}.civicrm_hrjobcontract_revision r ON t.jobcontract_revision_id = r.health_revision_id
                     LEFT JOIN {$civi_db_name}.civicrm_hrjobcontract c ON r.jobcontract_id = c.id
-                    
+
 #                    LEFT JOIN {$civi_db_name}.civicrm_hrjobcontract_details d ON r.details_revision_id = d.jobcontract_revision_id
-                    
+
                     WHERE c.deleted = 0");
-        
+
         db_query('DROP VIEW IF EXISTS hrjc_hour');
         db_query("CREATE OR REPLACE VIEW hrjc_hour AS
                     SELECT
@@ -113,14 +113,14 @@ function civihr_hrjobcontract_entities_init() {
                     FROM {$civi_db_name}.civicrm_hrjobcontract_hour AS t
                     LEFT JOIN {$civi_db_name}.civicrm_hrjobcontract_revision r ON t.jobcontract_revision_id = r.hour_revision_id
                     LEFT JOIN {$civi_db_name}.civicrm_hrjobcontract c ON r.jobcontract_id = c.id
-                    
+
                     LEFT JOIN {$civi_db_name}.civicrm_option_group og_hours_type ON og_hours_type.name = 'hrjc_hours_type'
                     LEFT JOIN {$civi_db_name}.civicrm_option_value ov_hours_type ON og_hours_type.id = ov_hours_type.option_group_id AND ov_hours_type.value = t.hours_type
-                    
+
 #                    LEFT JOIN {$civi_db_name}.civicrm_hrjobcontract_details d ON r.details_revision_id = d.jobcontract_revision_id
-                    
+
                     WHERE c.deleted = 0");
-        
+
         db_query('DROP VIEW IF EXISTS hrjc_leave');
         db_query("CREATE OR REPLACE VIEW hrjc_leave AS
                     SELECT
@@ -133,13 +133,13 @@ function civihr_hrjobcontract_entities_init() {
                     FROM {$civi_db_name}.civicrm_hrjobcontract_leave AS t
                     LEFT JOIN {$civi_db_name}.civicrm_hrjobcontract_revision r ON t.jobcontract_revision_id = r.leave_revision_id
                     LEFT JOIN {$civi_db_name}.civicrm_hrjobcontract c ON r.jobcontract_id = c.id
-                    
+
                     LEFT JOIN {$civi_db_name}.civicrm_hrabsence_type at ON t.leave_type = at.id
-                    
+
 #                    LEFT JOIN {$civi_db_name}.civicrm_hrjobcontract_details d ON r.details_revision_id = d.jobcontract_revision_id
-                    
+
                     WHERE c.deleted = 0");
-        
+
         db_query('DROP VIEW IF EXISTS hrjc_pay');
         db_query("CREATE OR REPLACE VIEW hrjc_pay AS
                     SELECT
@@ -162,20 +162,20 @@ function civihr_hrjobcontract_entities_init() {
                     FROM {$civi_db_name}.civicrm_hrjobcontract_pay AS t
                     LEFT JOIN {$civi_db_name}.civicrm_hrjobcontract_revision r ON t.jobcontract_revision_id = r.pay_revision_id
                     LEFT JOIN {$civi_db_name}.civicrm_hrjobcontract c ON r.jobcontract_id = c.id
-                    
+
                     LEFT JOIN {$civi_db_name}.civicrm_option_group og_is_paid ON og_is_paid.name = 'hrjc_pay_grade'
                     LEFT JOIN {$civi_db_name}.civicrm_option_value ov_is_paid ON og_is_paid.id = ov_is_paid.option_group_id AND ov_is_paid.value = t.is_paid
-                    
+
                     LEFT JOIN {$civi_db_name}.civicrm_option_group og_pay_currency ON og_pay_currency.name = 'currencies_enabled'
                     LEFT JOIN {$civi_db_name}.civicrm_option_value ov_pay_currency ON og_pay_currency.id = ov_pay_currency.option_group_id AND ov_pay_currency.value = t.pay_currency
-                    
+
                     LEFT JOIN {$civi_db_name}.civicrm_option_group og_pay_cycle ON og_pay_cycle.name = 'hrjc_pay_cycle'
                     LEFT JOIN {$civi_db_name}.civicrm_option_value ov_pay_cycle ON og_pay_cycle.id = ov_pay_cycle.option_group_id AND ov_pay_cycle.value = t.pay_cycle
-                    
+
 #                    LEFT JOIN {$civi_db_name}.civicrm_hrjobcontract_details d ON r.details_revision_id = d.jobcontract_revision_id
-                    
+
                     WHERE c.deleted = 0");
-        
+
         db_query('DROP VIEW IF EXISTS hrjc_pension');
         db_query("CREATE OR REPLACE VIEW hrjc_pension AS
                     SELECT
@@ -192,14 +192,14 @@ function civihr_hrjobcontract_entities_init() {
                     FROM {$civi_db_name}.civicrm_hrjobcontract_pension AS t
                     LEFT JOIN {$civi_db_name}.civicrm_hrjobcontract_revision r ON t.jobcontract_revision_id = r.pension_revision_id
                     LEFT JOIN {$civi_db_name}.civicrm_hrjobcontract c ON r.jobcontract_id = c.id
-                    
+
                     LEFT JOIN {$civi_db_name}.civicrm_option_group og_pension_type ON og_pension_type.name = 'hrjc_pension_type'
                     LEFT JOIN {$civi_db_name}.civicrm_option_value ov_pension_type ON og_pension_type.id = ov_pension_type.option_group_id AND ov_pension_type.value = t.pension_type
-                    
+
 #                    LEFT JOIN {$civi_db_name}.civicrm_hrjobcontract_details d ON r.details_revision_id = d.jobcontract_revision_id
-                    
+
                     WHERE c.deleted = 0");
-        
+
         db_query('DROP VIEW IF EXISTS hrjc_role');
         db_query("CREATE OR REPLACE VIEW hrjc_role AS
                     SELECT
@@ -226,24 +226,24 @@ function civihr_hrjobcontract_entities_init() {
                     t.percent_pay_cost_center AS role_percent_pay_cost_center,
                     ov_location.label AS role_location
                     FROM {$civi_db_name}.civicrm_hrjobroles AS t
-                        
+
                     LEFT JOIN {$civi_db_name}.civicrm_hrjobcontract c ON t.job_contract_id = c.id
-                    
+
                     LEFT JOIN {$civi_db_name}.civicrm_option_group og_region ON og_region.name = 'hrjc_region'
                     LEFT JOIN {$civi_db_name}.civicrm_option_value ov_region ON og_region.id = ov_region.option_group_id AND ov_region.id = t.region
-                    
+
                     LEFT JOIN {$civi_db_name}.civicrm_option_group og_department ON og_department.name = 'hrjc_department'
-                    LEFT JOIN {$civi_db_name}.civicrm_option_value ov_department ON og_department.id = ov_department.option_group_id AND ov_department.id = t.department
-                    
+                    LEFT JOIN {$civi_db_name}.civicrm_option_value ov_department ON og_department.id = ov_department.option_group_id AND ov_department.value = t.department
+
                     LEFT JOIN {$civi_db_name}.civicrm_option_group og_level_type ON og_level_type.name = 'hrjc_level_type'
                     LEFT JOIN {$civi_db_name}.civicrm_option_value ov_level_type ON og_level_type.id = ov_level_type.option_group_id AND ov_level_type.id = t.level_type
-                    
+
                     LEFT JOIN {$civi_db_name}.civicrm_option_group og_location ON og_location.name = 'hrjc_location'
                     LEFT JOIN {$civi_db_name}.civicrm_option_value ov_location ON og_location.id = ov_location.option_group_id AND ov_location.id = t.location
 
                     WHERE c.deleted = 0
                     ORDER BY t.job_contract_id");
-                    
+
         variable_set('rebuild_hrjobcontract_entities_view', 'FALSE');
     }
 }
@@ -437,8 +437,8 @@ function civihr_hrjobcontract_entities_schema_alter(&$schema) {
     );
     $schema['hrjc_details']['primary key'] = array('details_entity_revision_id');
 //    $schema['hrjc_details']['primary key'] = array('jobcontract_id');
-    
-    
+
+
     // Health:
     $schema['hrjc_health']['description'] = 'Views data associated with Job Contract Health';
 /*    $schema['hrjc_health']['fields']['contact_id'] = array(
@@ -509,8 +509,8 @@ function civihr_hrjobcontract_entities_schema_alter(&$schema) {
         'description' => 'Health Entity Revision ID',
     );
     $schema['hrjc_health']['primary key'] = array('health_entity_revision_id');
-    
-    
+
+
     // Hour:
     $schema['hrjc_hour']['description'] = 'Views data associated with Job Contract Hour';
 /*    $schema['hrjc_hour']['fields']['contact_id'] = array(
@@ -576,8 +576,8 @@ function civihr_hrjobcontract_entities_schema_alter(&$schema) {
         'description' => 'Hour Entity Revision ID',
     );
     $schema['hrjc_hour']['primary key'] = array('hour_entity_revision_id');
-    
-    
+
+
     // Leave:
     $schema['hrjc_leave']['description'] = 'Views data associated with Job Contract Leave';
 /*    $schema['hrjc_leave']['fields']['contact_id'] = array(
@@ -612,8 +612,8 @@ function civihr_hrjobcontract_entities_schema_alter(&$schema) {
         'description' => 'Leave Entity Revision ID',
     );
     $schema['hrjc_leave']['primary key'] = array('leave_entity_revision_id');
-    
-    
+
+
     // Pay:
     $schema['hrjc_pay']['description'] = 'Views data associated with Job Contract Pay';
 /*    $schema['hrjc_pay']['fields']['contact_id'] = array(
@@ -698,8 +698,8 @@ function civihr_hrjobcontract_entities_schema_alter(&$schema) {
         'description' => 'Pay Entity Revision ID',
     );
     $schema['hrjc_pay']['primary key'] = array('pay_entity_revision_id');
-    
-    
+
+
     // Pension:
     $schema['hrjc_pension']['description'] = 'Views data associated with Job Contract Pension';
 /*    $schema['hrjc_pension']['fields']['contact_id'] = array(
@@ -755,8 +755,8 @@ function civihr_hrjobcontract_entities_schema_alter(&$schema) {
         'description' => 'Pension Entity Revision ID',
     );
     $schema['hrjc_pension']['primary key'] = array('pension_entity_revision_id');
-    
-    
+
+
     // Role:
     $schema['hrjc_role']['description'] = 'Views data associated with Job Contract Role';
     $schema['hrjc_role']['fields']['role_id'] = array(
@@ -921,7 +921,7 @@ function civihr_hrjobcontract_entities_entity_info() {
         'uri callback' => 'entity_class_uri',
         'module' => 'civicrm',// 'civihr_hrjobcontract_entities',
     );
-    
+
     $info['hrjobcontract_health'] = array(
         'label' => t('HRJobContract Health entity'),
         'plural label' => t('HRJobContract Health entity'),
@@ -940,7 +940,7 @@ function civihr_hrjobcontract_entities_entity_info() {
         'uri callback' => 'entity_class_uri',
         'module' => 'civicrm',// 'civihr_hrjobcontract_entities',
     );
-    
+
     $info['hrjobcontract_hour'] = array(
         'label' => t('HRJobContract Hour entity'),
         'plural label' => t('HRJobContract Hour entity'),
@@ -959,7 +959,7 @@ function civihr_hrjobcontract_entities_entity_info() {
         'uri callback' => 'entity_class_uri',
         'module' => 'civicrm',// 'civihr_hrjobcontract_entities',
     );
-    
+
     $info['hrjobcontract_leave'] = array(
         'label' => t('HRJobContract Leave entity'),
         'plural label' => t('HRJobContract Leave entity'),
@@ -978,7 +978,7 @@ function civihr_hrjobcontract_entities_entity_info() {
         'uri callback' => 'entity_class_uri',
         'module' => 'civicrm',// 'civihr_hrjobcontract_entities',
     );
-    
+
     $info['hrjobcontract_pay'] = array(
         'label' => t('HRJobContract Pay entity'),
         'plural label' => t('HRJobContract Pay entity'),
@@ -997,7 +997,7 @@ function civihr_hrjobcontract_entities_entity_info() {
         'uri callback' => 'entity_class_uri',
         'module' => 'civicrm',// 'civihr_hrjobcontract_entities',
     );
-    
+
     $info['hrjobcontract_pension'] = array(
         'label' => t('HRJobContract Pension entity'),
         'plural label' => t('HRJobContract Pension entity'),
@@ -1016,7 +1016,7 @@ function civihr_hrjobcontract_entities_entity_info() {
         'uri callback' => 'entity_class_uri',
         'module' => 'civicrm',// 'civihr_hrjobcontract_entities',
     );
-    
+
     $info['hrjobcontract_role'] = array(
         'label' => t('HRJobContract Role entity'),
         'plural label' => t('HRJobContract Role entity'),
@@ -1035,7 +1035,7 @@ function civihr_hrjobcontract_entities_entity_info() {
         'uri callback' => 'entity_class_uri',
         'module' => 'civicrm',// 'civihr_hrjobcontract_entities',
     );
-    
+
     return $info;
 }
 


### PR DESCRIPTION
The SSP Reports merge introduce a new structure to link the job contract and job role entities for views. They are now all linked through a revision.

These two views use these entities and had to have their relationships declarations updated in order to properly fetch the information. Since things are now linked though revisions, I also had to add contextual filters to the views to make sure it will return only the information related to the current revision.

I also made one small fix to the query that creates the hrjc_role view. It was joining with the option value using its ID, but recently this has changed to use the option value value. I changed the query to reflect this.

Below are the before/after screenshots of My Details and Staff Directory. Note that, on Staff Directory, we had a lot of contact on the list before the fix and just a few after. The reason is that, since the relationships were wrong, the query was not joining with the contract and was returning every contact available. After the fix, it only lists contacts with contracts:

### My Details
Before:
![captura de tela 2016-09-02 as 20 48 55](https://cloud.githubusercontent.com/assets/388373/18221203/6a7e852e-7150-11e6-9c9b-4767223461f0.png)

After:
![captura de tela 2016-09-02 as 20 46 37](https://cloud.githubusercontent.com/assets/388373/18221204/6cfd1be4-7150-11e6-8691-ecc6947c5aeb.png)

### Staff Directory
Before:
![captura de tela 2016-09-02 as 20 49 27](https://cloud.githubusercontent.com/assets/388373/18221207/79ce7b88-7150-11e6-8550-2257c43c7190.png)

After:
![captura de tela 2016-09-02 as 20 46 11](https://cloud.githubusercontent.com/assets/388373/18221213/833126bc-7150-11e6-83fd-87b1a1f71985.png)
