### PR TITLE
PCHR-1550: Fix My Details views to show contact details even if it doesn't have a contract

### DIFF
--- a/civihr_employee_portal/views/views_export/views_my_details_block.inc
+++ b/civihr_employee_portal/views/views_export/views_my_details_block.inc
@@ -179,7 +179,7 @@ $handler->display->display_options['arguments']['period_start_date']['summary'][
 $handler->display->display_options['arguments']['period_start_date']['summary']['format'] = 'default_summary';
 $handler->display->display_options['arguments']['period_start_date']['summary_options']['items_per_page'] = '25';
 $handler->display->display_options['arguments']['period_start_date']['civihr_range'] = '<=';
-$handler->display->display_options['arguments']['period_start_date']['civihr_range_empty'] = '0';
+$handler->display->display_options['arguments']['period_start_date']['civihr_range_empty'] = '1';
 /* Contextual filter: HRJobContract Details entity: Period end date */
 $handler->display->display_options['arguments']['period_end_date']['id'] = 'period_end_date';
 $handler->display->display_options['arguments']['period_end_date']['table'] = 'hrjc_details';


### PR DESCRIPTION
The contextual filter for the contract period start date was filtering out records without a start date (that is, contacts without a contract), making the My Details tab empty for such contracts.

This fixes the issue by allowing an empty start date. In that case, only the information related to the contact (Name, Work email and Work Phone) will be displayed and the contract related fields will be empty.

This is the My Details block before the changes, for an user without a contract:
![captura de tela 2016-09-06 as 11 28 32](https://cloud.githubusercontent.com/assets/388373/18277526/2d834bb4-7425-11e6-829d-fbf6db31d443.png)

And this is after the fix:
![captura de tela 2016-09-06 as 11 24 42](https://cloud.githubusercontent.com/assets/388373/18277528/2e57891a-7425-11e6-981c-fb0088204298.png)

For comparison, this is how it looks like for a contact which has a contract:
![captura de tela 2016-09-06 as 11 30 12](https://cloud.githubusercontent.com/assets/388373/18277569/5101e62c-7425-11e6-9507-8242df62a2f1.png)

