### PR TITLE
PCHR-1245: Fix vacancy list to show location label instead of value

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -2422,6 +2422,12 @@ function civihr_employee_portal_get_vacancy_list() {
         'return' => "id,start_date,end_date,status_id,description,position,salary,location",
     ));
 
+    $result_output['values'] = civihr_employee_portal_convert_array_option_value(
+      'hrjc_location',
+      'location',
+      $result_output['values']
+    );
+
     // Output json
     drupal_json_output($result_output);
     drupal_exit();
@@ -6458,4 +6464,41 @@ function _block_anonymous_access() {
     drupal_add_http_header('Location', "$base_url/welcome-page");
     exit();
   }
+}
+
+/**
+ * Convert array option values in an array to labels
+ *
+ * @param string $optionGroup The option group name to check against for converting data
+ * @param string $fieldName The option field name ( key ) in data array to be converted
+ * @param array $data The data which contain an option field to be converted
+ *
+ * @return array The data list with converted option values
+ */
+function civihr_employee_portal_convert_array_option_value($optionGroup, $fieldName, $data) {
+  // get location option values list
+  $locationOptions = civicrm_api3('OptionValue', 'get', array(
+    'sequential' => 1,
+    'return' => array("value", "label"),
+    'option_group_id' => $optionGroup,
+    'options' => array('limit' => 0),
+  ));
+
+  // create a value => label array from option values
+  $locationList = [];
+  foreach($locationOptions['values'] as $location) {
+    $locationList[$location['value']] = $location['label'];
+  }
+
+  // change location value to location label
+  for($i=0; $i < count($data); $i++) {
+    if (!empty($data[$i][$fieldName])) {
+      $data[$i][$fieldName] = $locationList[$data[$i][$fieldName]];
+    }
+    else {
+      $data[$i][$fieldName] = '';
+    }
+  }
+
+  return $data;
 }


### PR DESCRIPTION
When viewing vacancies , the location value appear instead of its label .
![selection_138](https://cloud.githubusercontent.com/assets/6275540/18354777/8b02238e-75ef-11e6-8ff2-7fa493e12299.png)

That's because the location value which is retrieved with other vacancy details are not converted to label which i fixed in this PR by passing the Vacancies list to a new function **civihr_employee_portal_convert_array_option_value** that do the conversion .


![selection_139](https://cloud.githubusercontent.com/assets/6275540/18354780/9013d318-75ef-11e6-9b5f-72e196c96e3d.png)


