### PR TITLE
PCHR-1583: Removed un-wanted files from being loaded from civicrm pages

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.info
+++ b/civihr_employee_portal/civihr_employee_portal.info
@@ -79,15 +79,3 @@ files[] = views/includes/civihr_employee_portal_handler_absence_day_of_week.inc
 files[] = views/includes/civihr_employee_portal_handler_absence_duration_in_days.inc
 files[] = views/includes/civihr_employee_portal_handler_yes_no.inc
 files[] = views/includes/civihr_employee_portal_handler_pipe.inc
-
-; Custom js
-scripts[] = js/scripts.js
-scripts[] = js/filters.js
-scripts[] = js/plupload/plupload.full.min.js
-scripts[] = js/plupload-init.js
-scripts[] = js/chart.min.js
-
-; Additional js
-scripts[] = lib/tablesorter/jquery.tablesorter.min.js
-scripts[] = lib/tablesaw/tablesaw.js
-scripts[] = lib/sweetalert/sweet-alert.min.js

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -382,6 +382,7 @@ function civihr_employee_portal_init() {
       '/js/plupload-init.js',
       '/js/chart.min.js',
       '/lib/tablesorter/jquery.tablesorter.min.js',
+      '/lib/tablesaw/tablesaw.js',
       '/lib/sweetalert/sweet-alert.min.js'
     ]);
 

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -10,8 +10,8 @@ use Drupal\civihr_employee_portal\Helpers\HelperClass;
  */
 function civihr_employee_portal_css_alter(&$css) {
 
-    // Remove defaults system messages css file.
-    unset($css[drupal_get_path('module', 'system') . '/system.messages.css']);
+  // Remove defaults system messages css file.
+  unset($css[drupal_get_path('module', 'system') . '/system.messages.css']);
 
   // Removing unwanted css files from civicrm pages.
   if (civicrm_invoke()) {
@@ -38,24 +38,22 @@ function civihr_employee_portal_css_alter(&$css) {
  */
 function civihr_employee_portal_js_alter(&$javascript) {
 
-    // Unset jcarousel on panel admin pages as it's causes infinite loops
-    // "admin/structure/pages"
-    if (strpos(current_path(), 'admin/structure/pages') !== false) {
-        foreach ($javascript['settings']['data'] as $key => $value) {
-            if (isset($value['jcarousel'])) {
-
-                unset($javascript['settings']['data'][$key]);
-            }
-        }
-
+  // Unset jcarousel on panel admin pages as it's causes infinite loops
+  // "admin/structure/pages"
+  if (strpos(current_path(), 'admin/structure/pages') !== FALSE) {
+    foreach ($javascript['settings']['data'] as $key => $value) {
+      if (isset($value['jcarousel'])) {
+        unset($javascript['settings']['data'][$key]);
+      }
     }
+  }
 
-    global $user;
-    $uf = get_civihr_uf_match_data($user->uid);
-    drupal_add_js(array('currentDrupalUserId' => $user->uid), 'setting');
-    drupal_add_js(array('currentCiviCRMUserId' => $uf['contact_id']), 'setting');
+  global $user;
+  $uf = get_civihr_uf_match_data($user->uid);
+  drupal_add_js(['currentDrupalUserId' => $user->uid], 'setting');
+  drupal_add_js(['currentCiviCRMUserId' => $uf['contact_id']], 'setting');
 
-    _setup_modals();
+  _setup_modals();
 
   // Removing unwanted js files from civicrm pages.
   if (civicrm_invoke()) {
@@ -355,8 +353,8 @@ function getModuleUrl($moduleName) {
  * Implements hook_init().
  */
 function civihr_employee_portal_init() {
-    // @TODO -> init civi only on pages where we need to (e.g. Dashboard)
-    // Civi init + load the singleton needed for the AJAX calls
+  // @TODO -> init civi only on pages where we need to (e.g. Dashboard)
+  // Civi init + load the singleton needed for the AJAX calls
   // Loads all the resources only for non-civicrm pages.
   if (!civicrm_invoke()) {
     civicrm_initialize();

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -92,11 +92,7 @@ function _remove_resources(&$resourcesList, $blacklist = []) {
  *
  */
 function _isCiviCRM() {
-
-  if (arg(0) == 'civicrm') {
-    return TRUE;
-  }
-  return FALSE;
+  return arg(0) == 'civicrm';
 }
 
 /**

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -12,6 +12,25 @@ function civihr_employee_portal_css_alter(&$css) {
 
     // Remove defaults system messages css file.
     unset($css[drupal_get_path('module', 'system') . '/system.messages.css']);
+
+  // Removing unwanted css files from civicrm pages.
+  if (civicrm_invoke()) {
+    // Multi-dimensional array containing module name and file path.
+    $removeFiles = [
+      ['module_name' => 'ctools', 'file_name' => '/css/ctools.css'],
+      ['module_name' => 'date_api', 'file_name' => '/date.css'],
+      [
+        'module_name' => 'date_popup',
+        'file_name' => '/themes/datepicker.1.7.css',
+      ],
+      ['module_name' => 'panels', 'file_name' => '/css/panels.css'],
+      ['module_name' => 'radix_layouts', 'file_name' => '/radix_layouts.css'],
+      ['module_name' => 'views_tooltip', 'file_name' => '/views_tooltip.css'],
+      ['module_name' => 'tipsy', 'file_name' => '/stylesheets/tipsy.css'],
+    ];
+    // Removes above files.
+    _remove_alter_files_from_civicrm($css, $removeFiles);
+  }
 }
 
 /**
@@ -37,6 +56,44 @@ function civihr_employee_portal_js_alter(&$javascript) {
     drupal_add_js(array('currentCiviCRMUserId' => $uf['contact_id']), 'setting');
 
     _setup_modals();
+
+  // Removing unwanted js files from civicrm pages.
+  if (civicrm_invoke()) {
+
+    // Multi-dimensional array containing module name and file path.
+    $removeFiles = [
+      ['module_name' => 'tipsy', 'file_name' => '/javascripts/jquery.tipsy.js'],
+      ['module_name' => 'tipsy', 'file_name' => '/javascripts/tipsy.js'],
+      [
+        'module_name' => 'jquery_update',
+        'file_name' => '/replace/ui/external/jquery.cookie.js',
+      ],
+      [
+        'module_name' => 'jquery_update',
+        'file_name' => '/replace/jquery/1.8/jquery.min.js',
+      ],
+    ];
+    // Removes above files.
+    _remove_alter_files_from_civicrm($javascript, $removeFiles);
+  }
+}
+
+/**
+ * Removes javascript/css from civicrm pages.
+ *
+ * @param array &$style_type variable contains all the references to loaded
+ *   js/css array from alter.
+ *
+ * @param array $removeFiles contains multi-dimensional array : module_name key
+ *   as name of the contrib module from which we need to remove corresponding
+ *   file using file_name key.
+ */
+function _remove_alter_files_from_civicrm(&$style_type, $removeFiles = []) {
+  if ($style_type) {
+    foreach ($removeFiles as $key => $value) {
+      unset($style_type[drupal_get_path('module', $value['module_name']) . $value['file_name']]);
+    }
+  }
 }
 
 /**
@@ -78,9 +135,12 @@ function _setup_modals() {
  * @param string $scriptFile the name of the script file (extension included)
  * @param string $page
  */
-function _add_script_to_page($scriptFile, $page) {
+function _add_script_to_page($scriptFile, $page = NULL) {
   if (arg()[0] == $page) {
     drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . "/js/$scriptFile");
+  }
+  if (is_null($page)) {
+    drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . $scriptFile, 'file');
   }
 }
 
@@ -297,6 +357,8 @@ function getModuleUrl($moduleName) {
 function civihr_employee_portal_init() {
     // @TODO -> init civi only on pages where we need to (e.g. Dashboard)
     // Civi init + load the singleton needed for the AJAX calls
+  // Loads all the resources only for non-civicrm pages.
+  if (!civicrm_invoke()) {
     civicrm_initialize();
     CRM_Core_Resources::singleton()->addCoreResources();
 
@@ -307,10 +369,19 @@ function civihr_employee_portal_init() {
     drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/lib/tablesaw/tablesaw.css");
 
     _add_script_to_page('tasks.js', 'dashboard');
+    _add_script_to_page('/js/scripts.js');
+    _add_script_to_page('/js/filters.js');
+    _add_script_to_page('/js/plupload/plupload.full.min.js');
+    _add_script_to_page('/js/plupload-init.js');
+    _add_script_to_page('/js/chart.min.js');
+
+    _add_script_to_page('/lib/tablesorter/jquery.tablesorter.min.js');
+    _add_script_to_page('/lib/sweetalert/sweet-alert.min.js');
 
     _rebuild_view('absence_list');
     _rebuild_view('length_of_service');
     _rebuild_view('absence_activity');
+  }
 }
 
 /**

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -14,7 +14,7 @@ function civihr_employee_portal_css_alter(&$css) {
   unset($css[drupal_get_path('module', 'system') . '/system.messages.css']);
 
   // Removing unwanted css files from civicrm pages.
-  if (arg(0) == 'civicrm') {
+  if (_isCiviCRM()) {
     // Multi-dimensional array containing module name and file path.
     $removeFiles = [
       ['module_name' => 'ctools', 'file_name' => '/css/ctools.css'],
@@ -54,7 +54,7 @@ function civihr_employee_portal_js_alter(&$javascript) {
   _setup_modals();
 
   // Removing unwanted js files from civicrm pages.
-  if (arg(0) == 'civicrm') {
+  if (_isCiviCRM()) {
 
     // Multi-dimensional array containing module name and file path.
     $removeFiles = [
@@ -82,6 +82,21 @@ function _remove_resources(&$resourcesList, $blacklist = []) {
       unset($resourcesList[drupal_get_path('module', $value['module_name']) . $value['file_name']]);
     }
   }
+}
+
+/**
+ * Checks if the current page is an CiviCRM loaded page.
+ *
+ * @return bool
+ *  Returns true when the current page is on CiviCRM.
+ *
+ */
+function _isCiviCRM() {
+
+  if (arg(0) == 'civicrm') {
+    return TRUE;
+  }
+  return FALSE;
 }
 
 /**
@@ -351,7 +366,7 @@ function getModuleUrl($moduleName) {
 function civihr_employee_portal_init() {
 
   // Loads all the resources only for non-civicrm pages.
-  if (arg(0) != 'civicrm') {
+  if (!_isCiviCRM()) {
     // Civi init + load the singleton needed for the AJAX calls
     civicrm_initialize();
     CRM_Core_Resources::singleton()->addCoreResources();

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -14,22 +14,19 @@ function civihr_employee_portal_css_alter(&$css) {
   unset($css[drupal_get_path('module', 'system') . '/system.messages.css']);
 
   // Removing unwanted css files from civicrm pages.
-  if (civicrm_invoke()) {
+  if (arg(0) == 'civicrm') {
     // Multi-dimensional array containing module name and file path.
     $removeFiles = [
       ['module_name' => 'ctools', 'file_name' => '/css/ctools.css'],
       ['module_name' => 'date_api', 'file_name' => '/date.css'],
-      [
-        'module_name' => 'date_popup',
-        'file_name' => '/themes/datepicker.1.7.css',
-      ],
+      ['module_name' => 'date_popup', 'file_name' => '/themes/datepicker.1.7.css'],
       ['module_name' => 'panels', 'file_name' => '/css/panels.css'],
       ['module_name' => 'radix_layouts', 'file_name' => '/radix_layouts.css'],
       ['module_name' => 'views_tooltip', 'file_name' => '/views_tooltip.css'],
       ['module_name' => 'tipsy', 'file_name' => '/stylesheets/tipsy.css'],
     ];
     // Removes above files.
-    _remove_alter_files_from_civicrm($css, $removeFiles);
+   _remove_resources($css, $removeFiles);
   }
 }
 
@@ -37,6 +34,9 @@ function civihr_employee_portal_css_alter(&$css) {
  * Implements hook_js_alter()
  */
 function civihr_employee_portal_js_alter(&$javascript) {
+
+  global $user;
+  $uf = get_civihr_uf_match_data($user->uid);
 
   // Unset jcarousel on panel admin pages as it's causes infinite loops
   // "admin/structure/pages"
@@ -48,48 +48,38 @@ function civihr_employee_portal_js_alter(&$javascript) {
     }
   }
 
-  global $user;
-  $uf = get_civihr_uf_match_data($user->uid);
   drupal_add_js(['currentDrupalUserId' => $user->uid], 'setting');
   drupal_add_js(['currentCiviCRMUserId' => $uf['contact_id']], 'setting');
 
   _setup_modals();
 
   // Removing unwanted js files from civicrm pages.
-  if (civicrm_invoke()) {
+  if (arg(0) == 'civicrm') {
 
     // Multi-dimensional array containing module name and file path.
     $removeFiles = [
       ['module_name' => 'tipsy', 'file_name' => '/javascripts/jquery.tipsy.js'],
-      ['module_name' => 'tipsy', 'file_name' => '/javascripts/tipsy.js'],
-      [
-        'module_name' => 'jquery_update',
-        'file_name' => '/replace/ui/external/jquery.cookie.js',
-      ],
-      [
-        'module_name' => 'jquery_update',
-        'file_name' => '/replace/jquery/1.8/jquery.min.js',
-      ],
+      ['module_name' => 'tipsy', 'file_name' => '/javascripts/tipsy.js']
     ];
     // Removes above files.
-    _remove_alter_files_from_civicrm($javascript, $removeFiles);
+     _remove_resources($javascript, $removeFiles);
   }
 }
 
 /**
  * Removes javascript/css from civicrm pages.
  *
- * @param array &$style_type variable contains all the references to loaded
+ * @param array &$resourcesList variable contains all the references to loaded
  *   js/css array from alter.
  *
- * @param array $removeFiles contains multi-dimensional array : module_name key
+ * @param array $blacklist contains multi-dimensional array : module_name key
  *   as name of the contrib module from which we need to remove corresponding
  *   file using file_name key.
  */
-function _remove_alter_files_from_civicrm(&$style_type, $removeFiles = []) {
-  if ($style_type) {
-    foreach ($removeFiles as $key => $value) {
-      unset($style_type[drupal_get_path('module', $value['module_name']) . $value['file_name']]);
+function _remove_resources(&$resourcesList, $blacklist = []) {
+  if ($resourcesList) {
+    foreach ($blacklist as $key => $value) {
+      unset($resourcesList[drupal_get_path('module', $value['module_name']) . $value['file_name']]);
     }
   }
 }
@@ -134,10 +124,16 @@ function _setup_modals() {
  * @param string $page
  */
 function _add_script_to_page($scriptFile, $page = NULL) {
-  if (arg()[0] == $page) {
-    drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . "/js/$scriptFile");
+
+  if (!is_null($page) && arg(0) != $page) {
+    return;
   }
-  if (is_null($page)) {
+  if (is_array($scriptFile)) {
+    foreach ($scriptFile as $value) {
+      drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . $value, 'file');
+    }
+  }
+  else {
     drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . $scriptFile, 'file');
   }
 }
@@ -353,10 +349,10 @@ function getModuleUrl($moduleName) {
  * Implements hook_init().
  */
 function civihr_employee_portal_init() {
-  // @TODO -> init civi only on pages where we need to (e.g. Dashboard)
-  // Civi init + load the singleton needed for the AJAX calls
+
   // Loads all the resources only for non-civicrm pages.
-  if (!civicrm_invoke()) {
+  if (arg(0) != 'civicrm') {
+    // Civi init + load the singleton needed for the AJAX calls
     civicrm_initialize();
     CRM_Core_Resources::singleton()->addCoreResources();
 
@@ -366,15 +362,17 @@ function civihr_employee_portal_init() {
     drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/lib/sweetalert/sweet-alert.css");
     drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/lib/tablesaw/tablesaw.css");
 
-    _add_script_to_page('tasks.js', 'dashboard');
-    _add_script_to_page('/js/scripts.js');
-    _add_script_to_page('/js/filters.js');
-    _add_script_to_page('/js/plupload/plupload.full.min.js');
-    _add_script_to_page('/js/plupload-init.js');
-    _add_script_to_page('/js/chart.min.js');
+    _add_script_to_page('/js/tasks.js', 'dashboard');
 
-    _add_script_to_page('/lib/tablesorter/jquery.tablesorter.min.js');
-    _add_script_to_page('/lib/sweetalert/sweet-alert.min.js');
+    _add_script_to_page([
+      '/js/scripts.js',
+      '/js/filters.js',
+      '/js/plupload/plupload.full.min.js',
+      '/js/plupload-init.js',
+      '/js/chart.min.js',
+      '/lib/tablesorter/jquery.tablesorter.min.js',
+      '/lib/sweetalert/sweet-alert.min.js'
+    ]);
 
     _rebuild_view('absence_list');
     _rebuild_view('length_of_service');


### PR DESCRIPTION
Removing unnecessary resource files from CiviHR pages that are not required to be loaded. 
Below files are removed from being loaded from all the CiviHR pages.

1. Removed from civihr_employee_portal_init function 
 * 'civihr_employee_portal/css/custom.css'
 * 'org.civicrm.bootstrapcivicrm/css/bootstrap.css'
 * 'civihr_employee_portal/lib/sweetalert/sweet-alert.css'
 * 'civihr_employee_portal//lib/tablesaw/tablesaw.css'

2. Removed from .info file and moved to init function
 * 'js/scripts.js'
 * 'js/filters.js'
 * 'js/plupload/plupload.full.min.js'
 * 'js/plupload-init.js'
 * 'js/chart.min.js'
 -; Additional js
 * 'lib/tablesorter/jquery.tablesorter.min.js'
 * 'lib/tablesaw/tablesaw.js'
 * 'lib/sweetalert/sweet-alert.min.js'

3. Removed un-wanted contrib modules js and css 
 * civihr-contrib-required/ctools/css/ctools.css
 * civihr-contrib-required/date/date_api/date.css
 * civihr-contrib-required/date/date_popup/themes/datepicker.1.7.css
 * civihr-contrib-required/panels/css/panels.css
 * civihr-contrib-required/radix_layouts/radix_layouts.css
 * civihr-contrib-required/views_tooltip/views_tooltip.css
 * civihr-contrib-required/tipsy/stylesheets/tipsy.css
 * civihr-contrib-required/jquery_update/replace/ui/external/jquery.cookie.js - **Can't be removed**
 * civihr-contrib-required/jquery_update/replace/jquery/1.8/jquery.min.js - **Can't be removed**
above are required to load admin toolbar on civipages.
 * civihr-contrib-required/tipsy/javascripts/jquery.tipsy.js
 * civihr-contrib-required/tipsy/javascripts/tipsy.js
