### PR TITLE
PCHR-1520: Add new view to show (HR resource type) Vocabulary terms

### DIFF
--- a/civihr_employee_portal/views/views_export/views_hr_resource_types_list.inc
+++ b/civihr_employee_portal/views/views_export/views_hr_resource_types_list.inc
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * Exported hr_resource_types_list view
+ */
+
+$view = new view();
+$view->name = 'hr_resource_types_list';
+$view->description = 'A view to show a list of';
+$view->tag = 'default';
+$view->base_table = 'taxonomy_term_data';
+$view->human_name = 'HR Resource Types List';
+$view->core = 7;
+$view->api_version = '3.0';
+$view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
+
+/* Display: Master */
+$handler = $view->new_display('default', 'Master', 'default');
+$handler->display->display_options['title'] = 'HR Resource Types List';
+$handler->display->display_options['use_more_always'] = FALSE;
+$handler->display->display_options['access']['type'] = 'perm';
+$handler->display->display_options['access']['perm'] = 'edit terms in 2';
+$handler->display->display_options['cache']['type'] = 'none';
+$handler->display->display_options['query']['type'] = 'views_query';
+$handler->display->display_options['exposed_form']['type'] = 'basic';
+$handler->display->display_options['pager']['type'] = 'none';
+$handler->display->display_options['pager']['options']['offset'] = '0';
+$handler->display->display_options['style_plugin'] = 'table';
+/* No results behavior: Global: Text area */
+$handler->display->display_options['empty']['area']['id'] = 'area';
+$handler->display->display_options['empty']['area']['table'] = 'views';
+$handler->display->display_options['empty']['area']['field'] = 'area';
+$handler->display->display_options['empty']['area']['empty'] = TRUE;
+$handler->display->display_options['empty']['area']['content'] = 'No terms available.';
+$handler->display->display_options['empty']['area']['format'] = 'filtered_html';
+/* Field: Taxonomy term: Name */
+$handler->display->display_options['fields']['name']['id'] = 'name';
+$handler->display->display_options['fields']['name']['table'] = 'taxonomy_term_data';
+$handler->display->display_options['fields']['name']['field'] = 'name';
+$handler->display->display_options['fields']['name']['alter']['word_boundary'] = FALSE;
+$handler->display->display_options['fields']['name']['alter']['ellipsis'] = FALSE;
+$handler->display->display_options['fields']['name']['link_to_taxonomy'] = TRUE;
+/* Field: Taxonomy term: Term edit link */
+$handler->display->display_options['fields']['edit_term']['id'] = 'edit_term';
+$handler->display->display_options['fields']['edit_term']['table'] = 'taxonomy_term_data';
+$handler->display->display_options['fields']['edit_term']['field'] = 'edit_term';
+$handler->display->display_options['fields']['edit_term']['label'] = 'OPERATIONS';
+/* Filter criterion: Taxonomy vocabulary: Machine name */
+$handler->display->display_options['filters']['machine_name']['id'] = 'machine_name';
+$handler->display->display_options['filters']['machine_name']['table'] = 'taxonomy_vocabulary';
+$handler->display->display_options['filters']['machine_name']['field'] = 'machine_name';
+$handler->display->display_options['filters']['machine_name']['value'] = array(
+  'hr_resource_type' => 'hr_resource_type',
+);
+
+/* Display: Page */
+$handler = $view->new_display('page', 'Page', 'page');
+$handler->display->display_options['path'] = 'hr-resource-types-list';
+$handler->display->display_options['menu']['title'] = 'HR Resource Types List';
+$handler->display->display_options['menu']['weight'] = '0';
+$handler->display->display_options['menu']['name'] = 'main-menu';
+$handler->display->display_options['menu']['context'] = 1;
+$handler->display->display_options['menu']['context_only_inline'] = 0;
+
+/* Display: Block */
+$handler = $view->new_display('block', 'Block', 'block');
+$translatables['hr_resource_types_list'] = array(
+  t('Master'),
+  t('HR Resource Types List'),
+  t('more'),
+  t('Apply'),
+  t('Reset'),
+  t('Sort by'),
+  t('Asc'),
+  t('Desc'),
+  t('No terms available.'),
+  t('Name'),
+  t('OPERATIONS'),
+  t('Page'),
+  t('Block'),
+);


### PR DESCRIPTION
## Problem 

Even when Edit terms in HR Resource type permission is enabled the user cannot access http://civihr-staging.civihrhosting.co.uk/admin/structure/taxonomy/hr_resource_type/ .

But that's the default drupal behavior , having the permission will allow the user to edit the "terms" added to (HR Resource type) only , if you want to be able to access this page , then you should have (Administer vocabularies and terms) permission.

But to work around this we need to create a new drupal view that show the list of Vocabulary terms in (HR resource type) .

## Solution

The new view get added (hr_resource_types_list) and another PR added https://github.com/compucorp/civihr-employee-portal-theme/pull/104 to add a link for this new view in the gear menu.

![selection_032](https://cloud.githubusercontent.com/assets/6275540/18948449/00955324-862f-11e6-85dc-5d2931894f4f.png)
