### PR TITLE
PCHR-1589: Don't redirct guest users to welcome-page from /user page

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -6860,7 +6860,7 @@ function _is_hrreports_data_table_view($viewName) {
 
 /**
  * Return Appraisal Employee filter type used on Appraisal Manager template.
- * 
+ *
  * @param int $status
  * @param string $selfAppraisalDue
  * @param string $managerAppraisalDue
@@ -6978,6 +6978,9 @@ function _block_anonymous_access() {
     // This is the URL for the modal that is displayed when the user
     // clicks on "Click here to request one from your HR administrator"
     'request_new_account/ajax',
+    // PCHR-1589 : The guest user should be able to access this url
+    // to access default drupal login specially for maintenance mode
+    'user',
   ];
 
   if ($user_is_anonymous && !in_array($current_path, $allowed_paths)) {

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -6978,9 +6978,11 @@ function _block_anonymous_access() {
     // This is the URL for the modal that is displayed when the user
     // clicks on "Click here to request one from your HR administrator"
     'request_new_account/ajax',
-    // PCHR-1589 : The guest user should be able to access this url
-    // to access default drupal login specially for maintenance mode
+    // PCHR-1589 : The guest user should be able to access these urls
+    // to access default drupal login and rest password page specially for maintenance mode
     'user',
+    'user/password',
+    'user/login',
   ];
 
   if ($user_is_anonymous && !in_array($current_path, $allowed_paths)) {


### PR DESCRIPTION
When a guest user access /user or ?q=user from the browser , it shouldn't be redirected to /welcome-page because that will prevent from logging into drupal in maintenance mode .

Before : 

![before](https://cloud.githubusercontent.com/assets/6275540/18956873/f3903bf0-8654-11e6-8e75-fa6843e04984.gif)

After :

![after](https://cloud.githubusercontent.com/assets/6275540/18956879/f8983788-8654-11e6-9a47-ae5de2d3a68b.gif)
