### PR TITLE
PCHR-1460: Show (no result) if vacancy search shows no result

### DIFF
--- a/civihr_employee_portal/views/views_export/views_hr_vacancies.inc
+++ b/civihr_employee_portal/views/views_export/views_hr_vacancies.inc
@@ -40,6 +40,13 @@ $handler->display->display_options['header']['area']['field'] = 'area';
 $handler->display->display_options['header']['area']['empty'] = TRUE;
 $handler->display->display_options['header']['area']['content'] = '<a href="hr-vacancies">View all vacancies</a>';
 $handler->display->display_options['header']['area']['format'] = 'filtered_html';
+/* No results behavior: Global: Text area */
+$handler->display->display_options['empty']['area']['id'] = 'area';
+$handler->display->display_options['empty']['area']['table'] = 'views';
+$handler->display->display_options['empty']['area']['field'] = 'area';
+$handler->display->display_options['empty']['area']['empty'] = TRUE;
+$handler->display->display_options['empty']['area']['content'] = '<p style="text-align:center;">No results found</p>';
+$handler->display->display_options['empty']['area']['format'] = 'full_html';
 /* Field: HRVacancy entity: Hrvacancy entity ID */
 $handler->display->display_options['fields']['id']['id'] = 'id';
 $handler->display->display_options['fields']['id']['table'] = 'hrvacancy';
@@ -307,6 +314,7 @@ $translatables['hr_vacancies'] = array(
   t('Asc'),
   t('Desc'),
   t('<a href="hr-vacancies">View all vacancies</a>'),
+  t('<p style="text-align:center;">No results found</p>'),
   t('Job ID'),
   t('.'),
   t('Job Position'),


### PR DESCRIPTION
## Requirements 
When using filters to search for vacancy , a "no result found" message should appear to the user in case there are no results .

## Solution 

A No results behavior is added to vacancy list drupal view .


- Before

![selection_036](https://cloud.githubusercontent.com/assets/6275540/19069588/6ceebab2-8a1f-11e6-96d0-4f968f52167e.png)

- After

![selection_035](https://cloud.githubusercontent.com/assets/6275540/19069593/714ac6d2-8a1f-11e6-8e7b-b4760d7a010e.png)

