### PR TITLE
PCHR-1620: Align columns in absence block

### DIFF
--- a/civihr_employee_portal/css/custom.css
+++ b/civihr_employee_portal/css/custom.css
@@ -12,6 +12,10 @@ and open the template in the editor.
     width: 15%;
 }
 
+.view-absence-list > .view-content {
+    margin: 0 -20px;
+}
+
 .table-editable {
     width: auto;
     position: relative;


### PR DESCRIPTION
## Problem

Columns were not aligned correctly i.e. header table cells were wider than content table cells.
### Before

![before-align](https://cloud.githubusercontent.com/assets/5514826/19469982/606535c0-9526-11e6-851d-9b70a47ae4b6.png)
### After

![dashboard-align](https://cloud.githubusercontent.com/assets/5514826/19469989/6a83d1ba-9526-11e6-941c-c73d9221439a.png)
![report-align](https://cloud.githubusercontent.com/assets/5514826/19469988/6a836e32-9526-11e6-8526-c98cbf94e86c.png)
