### PR TITLE
PCHR-1589: fix user redirection

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -7026,14 +7026,12 @@ function _block_anonymous_access() {
     // This is the URL for the modal that is displayed when the user
     // clicks on "Click here to request one from your HR administrator"
     'request_new_account/ajax',
-    // PCHR-1589 : The guest user should be able to access these urls
-    // to access default drupal login and rest password page specially for maintenance mode
-    'user',
-    'user/password',
-    'user/login',
   ];
 
-  if ($user_is_anonymous && !in_array($current_path, $allowed_paths)) {
+  if (
+    $user_is_anonymous &&
+    !in_array($current_path, $allowed_paths) && substr($current_path, 0, 4) !== 'user'
+  ) {
     drupal_add_http_header('Location', "$base_url/welcome-page");
     exit();
   }

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -6991,12 +6991,11 @@ function _get_task_filter_by_date($date, $normalize = false) {
  * Implements hook_boot()
  */
 function civihr_employee_portal_boot() {
-  _block_anonymous_access();
+  _user_redirection();
 }
 
 /**
- * This method redirect any request made by an anonymous
- * user to the welcome-page.
+ * This method handle user redirection for special use cases
  *
  * The redirection is made by manually setting the Location header,
  * and it checks the current_path using the request_path() function,
@@ -7004,7 +7003,7 @@ function civihr_employee_portal_boot() {
  * is called, only a limited set of functions is available, and things like
  * drupal_goto() and current_path() cannot be used).
  */
-function _block_anonymous_access() {
+function _user_redirection() {
   global $user, $base_url;
 
   // This function should only be executed in a
@@ -7028,11 +7027,16 @@ function _block_anonymous_access() {
     'request_new_account/ajax',
   ];
 
-  if (
-    $user_is_anonymous &&
-    !in_array($current_path, $allowed_paths) && substr($current_path, 0, 4) !== 'user'
-  ) {
-    drupal_add_http_header('Location', "$base_url/welcome-page");
+  if ($user_is_anonymous) {
+    if (!in_array($current_path, $allowed_paths) && substr($current_path, 0, 4) !== 'user') {
+      $redirect_path = 'welcome-page';
+    }
+  } else if ($current_path == 'civicrm') {
+    $redirect_path = 'civicrm/tasksassignments/dashboard#/tasks';
+  }
+
+  if (!empty($redirect_path)) {
+    drupal_add_http_header('Location', "$base_url/{$redirect_path}");
     exit();
   }
 }

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -7028,7 +7028,10 @@ function _user_redirection() {
   ];
 
   if ($user_is_anonymous) {
-    if (!in_array($current_path, $allowed_paths) && substr($current_path, 0, 4) !== 'user') {
+    if (
+    (!in_array($current_path, $allowed_paths) && substr($current_path, 0, 4) !== 'user') ||
+    $current_path == 'user/register'
+    ) {
       $redirect_path = 'welcome-page';
     }
   } else if ($current_path == 'civicrm') {


### PR DESCRIPTION
After new user requests a login,  the reset password link received via email which looks something like this  https://compucorp.civihrhosting.co.uk/user/reset/12/1477310738/At0L5hbbyhOk-XNeXj8kQhxkGoPKMQjzayjsSBaoXwQ  Will redirect to welcome-page instead which is wrong . So any access to a link start with **user** for anymones users should not lead to welcome-page redirection .

Also  when the logged in user access /civicrm it should be redirected to T&A dashboard not to civicrm dashboard .

So I've changed  **_block_anonymous_access**  to **_user_redirection** to handle both situation 
