### PR TITLE
PCHR-1636: Allow civihr_admin role to access the site in maintenance mode

### DIFF
--- a/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
+++ b/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
@@ -314,6 +314,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'access site in maintenance mode',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin' => 'civihr_admin',
     ),
     'module' => 'system',
   );


### PR DESCRIPTION
any user with civihr_admin should be able to access the site in maintenance mode