### PR TITLE
PCHR-1651 - Absence report doesn't pick up absence data from civi

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -492,10 +492,10 @@ function _rebuild_absence_activity_view() {
  * @return array
  */
 function _get_absence_activity_types_ids() {
-  $activityTypesIds = array();
-  $absenceTypes = civicrm_api3('HRAbsenceType', 'get', array(
+  $activityTypesIds = [];
+  $absenceTypes = civicrm_api3('HRAbsenceType', 'get', [
     'sequential' => 1,
-  ));
+  ]);
 
   foreach ($absenceTypes['values'] as $absenceType) {
     if (!empty($absenceType['debit_activity_type_id'])) {

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -465,15 +465,13 @@ function _rebuild_absence_activity_view() {
                   IF (ov.label = 'TOIL (Credit)', a2.duration, NULL) AS absence_amount_accrued,
                   IF (ov.label = 'TOIL (Credit)', -a2.duration, a2.duration) AS absence_absolute_amount,
                   abc.{$absenceCommentColumn} AS absence_comment,
-                  ov2.label AS absence_status,
+                  a.status_id AS absence_status,
                   IF (ov.label = 'TOIL (Credit)', 1, 0) AS absence_is_credit
                 FROM {$civi_db_name}.civicrm_activity absence_activity
                 LEFT JOIN {$civi_db_name}.civicrm_activity a ON a.id = absence_activity.id
                 LEFT JOIN {$civi_db_name}.civicrm_activity a2 ON a2.source_record_id = absence_activity.id
                 LEFT JOIN {$civi_db_name}.civicrm_option_group og ON og.name = 'activity_type'
                 LEFT JOIN {$civi_db_name}.civicrm_option_value ov ON ov.value = a.activity_type_id AND ov.option_group_id = og.id
-                LEFT JOIN {$civi_db_name}.civicrm_option_group og2 ON og2.name = 'activity_status'
-                LEFT JOIN {$civi_db_name}.civicrm_option_value ov2 ON ov2.value = a.status_id AND ov2.option_group_id = og2.id
                 LEFT JOIN {$civi_db_name}.civicrm_activity_contact ac ON ac.activity_id = absence_activity.id AND ac.record_type_id = 3
                 LEFT JOIN {$civi_db_name}.{$absenceCommentTable} abc ON abc.entity_id = absence_activity.id
                 WHERE (a2.duration IS NOT NULL AND a2.duration > 0)

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -593,6 +593,13 @@ function civihr_employee_portal_init() {
   }
 }
 
+function _rebuild_reports_views() {
+  variable_set('rebuild_length_of_service', 'TRUE');
+  _rebuild_view('length_of_service');
+  variable_set('rebuild_absence_activity', 'TRUE');
+  _rebuild_view('absence_activity');
+}
+
 /**
  * When caches are cleared rebuild the helper mysql views
  */
@@ -6271,6 +6278,8 @@ function civihr_employee_portal_hrreport_printtable($viewName) {
  * @return array
  */
 function civihr_employee_portal_hrreport_custom($reportName) {
+  _rebuild_reports_views();
+
   $view = views_get_view('civihr_report_' . $reportName);
   if (!$view) {
     return drupal_not_found();

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -446,38 +446,67 @@ function _rebuild_absence_activity_view() {
     ));
     $absenceCommentColumn = $customName['column_name'];
 
-    db_query('DROP VIEW IF EXISTS absence_activity');
-    db_query("CREATE VIEW absence_activity AS
-              SELECT ac.contact_id AS absence_contact_id,
-                abc.entity_id AS absence_activity_id,
-                ov.label AS absence_type,
-                DATE(a2.activity_date_time) AS absence_date,
-                DATE_FORMAT(DATE(a2.activity_date_time), '%Y-%m') AS absence_month,
-                (SELECT MIN(DATE(activity_date_time)) FROM {$civi_db_name}.civicrm_activity WHERE source_record_id = a2.source_record_id) AS absence_start_date,
-                DATE_FORMAT((SELECT MIN(DATE(activity_date_time)) FROM {$civi_db_name}.civicrm_activity WHERE source_record_id = a2.source_record_id), '%Y-%m') AS absence_start_date_month,
-                (SELECT MAX(DATE(activity_date_time)) FROM {$civi_db_name}.civicrm_activity WHERE source_record_id = a2.source_record_id) AS absence_end_date,
-                DATE_FORMAT((SELECT MAX(DATE(activity_date_time)) FROM {$civi_db_name}.civicrm_activity WHERE source_record_id = a2.source_record_id), '%Y-%m') AS absence_end_date_month,
-                CONCAT(IF (DATE_FORMAT(a2.activity_date_time, '%w') = 0, 7, DATE_FORMAT(a2.activity_date_time, '%w')), '. ', DATE_FORMAT(a2.activity_date_time, '%W')) AS absence_day_of_week,
-                a2.duration AS absence_duration,
-                IF (ov.label <> 'TOIL (Credit)', a2.duration, NULL) AS absence_amount_taken,
-                IF (ov.label = 'TOIL (Credit)', a2.duration, NULL) AS absence_amount_accrued,
-                IF (ov.label = 'TOIL (Credit)', -a2.duration, a2.duration) AS absence_absolute_amount,
-                abc.{$absenceCommentColumn} AS absence_comment,
-                ov2.label AS absence_status,
-                IF (ov.label = 'TOIL (Credit)', 1, 0) AS absence_is_credit
-              FROM {$civi_db_name}.{$absenceCommentTable} abc
-              LEFT JOIN {$civi_db_name}.civicrm_activity a ON a.id = abc.entity_id
-              LEFT JOIN {$civi_db_name}.civicrm_activity a2 ON a2.source_record_id = abc.entity_id
-              LEFT JOIN {$civi_db_name}.civicrm_option_group og ON og.name = 'activity_type'
-              LEFT JOIN {$civi_db_name}.civicrm_option_value ov ON ov.value = a.activity_type_id AND ov.option_group_id = og.id
-              LEFT JOIN {$civi_db_name}.civicrm_option_group og2 ON og2.name = 'activity_status'
-              LEFT JOIN {$civi_db_name}.civicrm_option_value ov2 ON ov2.value = a.status_id AND ov2.option_group_id = og2.id
-              LEFT JOIN {$civi_db_name}.civicrm_activity_contact ac ON ac.activity_id = abc.entity_id AND ac.record_type_id = 3
-              WHERE (a2.duration IS NOT NULL AND a2.duration > 0)");
+    $activityTypesIds = _get_absence_activity_types_ids();
+    if (!empty($activityTypesIds)) {
+      db_query('DROP VIEW IF EXISTS absence_activity');
+      db_query("CREATE VIEW absence_activity AS
+                SELECT ac.contact_id AS absence_contact_id,
+                  absence_activity.id AS absence_activity_id,
+                  ov.label AS absence_type,
+                  DATE(a2.activity_date_time) AS absence_date,
+                  DATE_FORMAT(DATE(a2.activity_date_time), '%Y-%m') AS absence_month,
+                  (SELECT MIN(DATE(activity_date_time)) FROM {$civi_db_name}.civicrm_activity WHERE source_record_id = a2.source_record_id) AS absence_start_date,
+                  DATE_FORMAT((SELECT MIN(DATE(activity_date_time)) FROM {$civi_db_name}.civicrm_activity WHERE source_record_id = a2.source_record_id), '%Y-%m') AS absence_start_date_month,
+                  (SELECT MAX(DATE(activity_date_time)) FROM {$civi_db_name}.civicrm_activity WHERE source_record_id = a2.source_record_id) AS absence_end_date,
+                  DATE_FORMAT((SELECT MAX(DATE(activity_date_time)) FROM {$civi_db_name}.civicrm_activity WHERE source_record_id = a2.source_record_id), '%Y-%m') AS absence_end_date_month,
+                  CONCAT(IF (DATE_FORMAT(a2.activity_date_time, '%w') = 0, 7, DATE_FORMAT(a2.activity_date_time, '%w')), '. ', DATE_FORMAT(a2.activity_date_time, '%W')) AS absence_day_of_week,
+                  a2.duration AS absence_duration,
+                  IF (ov.label <> 'TOIL (Credit)', a2.duration, NULL) AS absence_amount_taken,
+                  IF (ov.label = 'TOIL (Credit)', a2.duration, NULL) AS absence_amount_accrued,
+                  IF (ov.label = 'TOIL (Credit)', -a2.duration, a2.duration) AS absence_absolute_amount,
+                  abc.{$absenceCommentColumn} AS absence_comment,
+                  ov2.label AS absence_status,
+                  IF (ov.label = 'TOIL (Credit)', 1, 0) AS absence_is_credit
+                FROM {$civi_db_name}.civicrm_activity absence_activity
+                LEFT JOIN {$civi_db_name}.civicrm_activity a ON a.id = absence_activity.id
+                LEFT JOIN {$civi_db_name}.civicrm_activity a2 ON a2.source_record_id = absence_activity.id
+                LEFT JOIN {$civi_db_name}.civicrm_option_group og ON og.name = 'activity_type'
+                LEFT JOIN {$civi_db_name}.civicrm_option_value ov ON ov.value = a.activity_type_id AND ov.option_group_id = og.id
+                LEFT JOIN {$civi_db_name}.civicrm_option_group og2 ON og2.name = 'activity_status'
+                LEFT JOIN {$civi_db_name}.civicrm_option_value ov2 ON ov2.value = a.status_id AND ov2.option_group_id = og2.id
+                LEFT JOIN {$civi_db_name}.civicrm_activity_contact ac ON ac.activity_id = absence_activity.id AND ac.record_type_id = 3
+                LEFT JOIN {$civi_db_name}.{$absenceCommentTable} abc ON abc.entity_id = absence_activity.id
+                WHERE (a2.duration IS NOT NULL AND a2.duration > 0)
+                AND
+                absence_activity.activity_type_id IN (" . implode(',', $activityTypesIds) . ")");
 
-    // Set to false so it will not rebuild until not asked to rebuild
-    variable_set('rebuild_absence_activity', 'FALSE');
+      // Set to false so it will not rebuild until not asked to rebuild
+      variable_set('rebuild_absence_activity', 'FALSE');
+    }
   }
+}
+
+/**
+ * Return an array of absence activity types IDs.
+ *
+ * @return array
+ */
+function _get_absence_activity_types_ids() {
+  $activityTypesIds = array();
+  $absenceTypes = civicrm_api3('HRAbsenceType', 'get', array(
+    'sequential' => 1,
+  ));
+
+  foreach ($absenceTypes['values'] as $absenceType) {
+    if (!empty($absenceType['debit_activity_type_id'])) {
+      $activityTypesIds[] = $absenceType['debit_activity_type_id'];
+    }
+    if (!empty($absenceType['credit_activity_type_id'])) {
+      $activityTypesIds[] = $absenceType['credit_activity_type_id'];
+    }
+  }
+
+  return $activityTypesIds;
 }
 
 /**

--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.views_default.inc
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.views_default.inc
@@ -926,6 +926,13 @@ Type ID: [activity_type_id] '),
   $handler->display->display_options['filters']['date_filter']['date_fields'] = array(
     'absence_activity.absence_date' => 'absence_activity.absence_date',
   );
+  /* Filter criterion: Absence Activity entity: Absence activity entity ID */
+  $handler->display->display_options['filters']['absence_activity_id']['id'] = 'absence_activity_id';
+  $handler->display->display_options['filters']['absence_activity_id']['table'] = 'absence_activity';
+  $handler->display->display_options['filters']['absence_activity_id']['field'] = 'absence_activity_id';
+  $handler->display->display_options['filters']['absence_activity_id']['relationship'] = 'absence_activity';
+  $handler->display->display_options['filters']['absence_activity_id']['operator'] = '>';
+  $handler->display->display_options['filters']['absence_activity_id']['value']['value'] = '0';
 
   /* Display: Page */
   $handler = $view->new_display('page', 'Page', 'page');

--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -819,6 +819,26 @@ function civihr_employee_portal_views_data_alter(&$data) {
     'sort' => array('handler' => 'views_json_query_handler_sort'),
   );
 
+  $data['absence_activity']['absence_status'] = array(
+    'title' => t('Absence status'),
+    'help' => t('Absence status field value'),
+    'real field' => 'absence_status',
+    'field' => array(
+      'handler' => 'civihr_employee_portal_handler_absence_status',
+      'click sortable' => TRUE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument_string',
+      'name_field' => 'title',
+      'string' => TRUE
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_string',
+      'help' => t('Filter results to a particular result set'),
+    ),
+    'sort' => array('handler' => 'views_handler_sort'),
+  );
+
   $data['civicrm_value_emergency_contacts_21']['id'] = array(
     'title' => t('Emergency Contact ID'),
     'help' => t('Emergency Contact ID field value'),

--- a/civihr_employee_portal/views/views_export/views_civihr_report_leave_and_absence.inc
+++ b/civihr_employee_portal/views/views_export/views_civihr_report_leave_and_absence.inc
@@ -512,6 +512,13 @@ $handler->display->display_options['filters']['date_filter']['year_range'] = '-1
 $handler->display->display_options['filters']['date_filter']['date_fields'] = array(
   'absence_activity.absence_date' => 'absence_activity.absence_date',
 );
+/* Filter criterion: Absence Activity entity: Absence activity entity ID */
+$handler->display->display_options['filters']['absence_activity_id']['id'] = 'absence_activity_id';
+$handler->display->display_options['filters']['absence_activity_id']['table'] = 'absence_activity';
+$handler->display->display_options['filters']['absence_activity_id']['field'] = 'absence_activity_id';
+$handler->display->display_options['filters']['absence_activity_id']['relationship'] = 'absence_activity';
+$handler->display->display_options['filters']['absence_activity_id']['operator'] = '>';
+$handler->display->display_options['filters']['absence_activity_id']['value']['value'] = '0';
 
 /* Display: Page */
 $handler = $view->new_display('page', 'Page', 'page');


### PR DESCRIPTION
Rewriting absence_activity SQL View to base on leave activity records by leave type IDs  instead of custom absence comment table. The comment table may be empty and therefore SQL View won't create any data.
