### PR TITLE
PCHR-1247: My Leave page build.

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.install
+++ b/civihr_employee_portal/civihr_employee_portal.install
@@ -36,3 +36,15 @@ function civihr_employee_portal_update_7001() {
     throw new DrupalUpdateException(implode(', ', $modules) . ' or dependencies could not be enabled');
   }
 }
+
+/**
+ * Implements hook_update_N().
+ *  Enables modules and throws an exception if that can't be done.
+ */
+function civihr_employee_portal_update_7002() {
+  $modules = ['leave_and_absences_feature'];
+
+  if (empty(module_enable($modules))) {
+    throw new DrupalUpdateException(implode(', ', $modules) . ' or dependencies could not be enabled');
+  }
+}

--- a/civihr_employee_portal/civihr_leave_absences/civihr_leave_absences.info
+++ b/civihr_employee_portal/civihr_leave_absences/civihr_leave_absences.info
@@ -3,3 +3,4 @@ description = Provides Leave and Absences functionality on the CiviHR Self Servi
 core = 7.x
 package = Compucorp
 dependencies[] = civihr_employee_portal
+dependencies[] = civicrm_resources

--- a/civihr_employee_portal/features/leave_and_absences_feature/leave_and_absences_feature.features.inc
+++ b/civihr_employee_portal/features/leave_and_absences_feature/leave_and_absences_feature.features.inc
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @file
+ * leave_and_absences_feature.features.inc
+ */
+
+/**
+ * Implements hook_ctools_plugin_api().
+ */
+function leave_and_absences_feature_ctools_plugin_api($module = NULL, $api = NULL) {
+  if ($module == "page_manager" && $api == "pages_default") {
+    return array("version" => "1");
+  }
+}

--- a/civihr_employee_portal/features/leave_and_absences_feature/leave_and_absences_feature.info
+++ b/civihr_employee_portal/features/leave_and_absences_feature/leave_and_absences_feature.info
@@ -5,6 +5,7 @@ package = Compucorp
 dependencies[] = block
 dependencies[] = civihr_employee_portal
 dependencies[] = civihr_leave_absences
+dependencies[] = civicrm_resources
 dependencies[] = ctools
 dependencies[] = page_manager
 features[ctools][] = page_manager:pages_default:1

--- a/civihr_employee_portal/features/leave_and_absences_feature/leave_and_absences_feature.info
+++ b/civihr_employee_portal/features/leave_and_absences_feature/leave_and_absences_feature.info
@@ -1,0 +1,12 @@
+name = Leave and Absences Feature
+description = Contains all the sections related to Leave and Absences section.
+core = 7.x
+package = Compucorp
+dependencies[] = block
+dependencies[] = civihr_employee_portal
+dependencies[] = civihr_leave_absences
+dependencies[] = ctools
+dependencies[] = page_manager
+features[ctools][] = page_manager:pages_default:1
+features[features_api][] = api:2
+features[page_manager_pages][] = my_leave

--- a/civihr_employee_portal/features/leave_and_absences_feature/leave_and_absences_feature.module
+++ b/civihr_employee_portal/features/leave_and_absences_feature/leave_and_absences_feature.module
@@ -1,0 +1,7 @@
+<?php
+/**
+ * @file
+ * Code for the Leave and Absences Feature feature.
+ */
+
+include_once 'leave_and_absences_feature.features.inc';

--- a/civihr_employee_portal/features/leave_and_absences_feature/leave_and_absences_feature.pages_default.inc
+++ b/civihr_employee_portal/features/leave_and_absences_feature/leave_and_absences_feature.pages_default.inc
@@ -1,0 +1,114 @@
+<?php
+/**
+ * @file
+ * leave_and_absences_feature.pages_default.inc
+ */
+
+/**
+ * Implements hook_default_page_manager_pages().
+ */
+function leave_and_absences_feature_default_page_manager_pages() {
+  $page = new stdClass();
+  $page->disabled = FALSE; /* Edit this to true to make a default page disabled initially */
+  $page->api_version = 1;
+  $page->name = 'my_leave';
+  $page->task = 'page';
+  $page->admin_title = 'My Leave';
+  $page->admin_description = 'Show details of My Leave section.';
+  $page->path = 'my-leave';
+  $page->access = array(
+    'plugins' => array(
+      0 => array(
+        'name' => 'perm',
+        'settings' => array(
+          'perm' => 'access leave and absences in ssp',
+        ),
+        'context' => 'logged-in-user',
+        'not' => FALSE,
+      ),
+    ),
+    'logic' => 'and',
+  );
+  $page->menu = array(
+    'type' => 'normal',
+    'title' => 'My Leave',
+    'name' => 'main-menu',
+    'weight' => '0',
+    'parent' => array(
+      'type' => 'none',
+      'title' => '',
+      'name' => 'navigation',
+      'weight' => '0',
+    ),
+  );
+  $page->arguments = array();
+  $page->conf = array(
+    'admin_paths' => FALSE,
+  );
+  $page->default_handlers = array();
+  $handler = new stdClass();
+  $handler->disabled = FALSE; /* Edit this to true to make a default handler disabled initially */
+  $handler->api_version = 1;
+  $handler->name = 'page_my_leave__panel';
+  $handler->task = 'page';
+  $handler->subtask = 'my_leave';
+  $handler->handler = 'panel_context';
+  $handler->weight = 0;
+  $handler->conf = array(
+    'title' => 'Panel',
+    'no_blocks' => 0,
+    'pipeline' => 'standard',
+    'body_classes_to_remove' => '',
+    'body_classes_to_add' => '',
+    'css_id' => '',
+    'css' => '',
+    'contexts' => array(),
+    'relationships' => array(),
+    'name' => 'panel',
+  );
+  $display = new panels_display();
+  $display->layout = 'flexible';
+  $display->layout_settings = array();
+  $display->panel_settings = array(
+    'style_settings' => array(
+      'default' => NULL,
+      'center' => NULL,
+    ),
+  );
+  $display->cache = array();
+  $display->title = '';
+  $display->uuid = '3e38d75b-5b66-4f4c-a262-f40536afc036';
+  $display->content = array();
+  $display->panels = array();
+    $pane = new stdClass();
+    $pane->pid = 'new-05560690-f3f8-4f5d-85bd-1ba75a3ad03a';
+    $pane->panel = 'center';
+    $pane->type = 'block';
+    $pane->subtype = 'civihr_leave_absences-my_leave';
+    $pane->shown = TRUE;
+    $pane->access = array();
+    $pane->configuration = array(
+      'override_title' => 0,
+      'override_title_text' => '',
+      'override_title_heading' => 'h2',
+    );
+    $pane->cache = array();
+    $pane->style = array(
+      'settings' => NULL,
+    );
+    $pane->css = array();
+    $pane->extras = array();
+    $pane->position = 0;
+    $pane->locks = array();
+    $pane->uuid = '05560690-f3f8-4f5d-85bd-1ba75a3ad03a';
+    $display->content['new-05560690-f3f8-4f5d-85bd-1ba75a3ad03a'] = $pane;
+    $display->panels['center'][0] = 'new-05560690-f3f8-4f5d-85bd-1ba75a3ad03a';
+  $display->hide_title = PANELS_TITLE_FIXED;
+  $display->title_pane = '0';
+  $handler->conf['display'] = $display;
+  $page->default_handlers[$handler->name] = $handler;
+  $pages['my_leave'] = $page;
+
+  return $pages;
+
+}


### PR DESCRIPTION
Problem:
Need to have simple drupal Page that can be exported in a new "Leave and Absences" feature, that will contain the block described in   PCHR-1248. Basically a bare-bone container that provides a menu link in the top menu bar and a place where the user can access the angular app.

Solution:
Created Panel page called my-leave that contains the block called my_leave which contains pre-defined template markup from block with required user access permissions "Access CiviHR Leave and Absences."

<img width="1277" alt="screen shot 2016-10-28 at 8 34 23 pm" src="https://cloud.githubusercontent.com/assets/2689257/19811232/21d2a8c6-9d4e-11e6-8ef5-92b13f59293d.png">
