### PR TITLE
PCHR-1628 - Absence report date filter is showing no results

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -6295,7 +6295,7 @@ function civihr_employee_portal_hrreport_get_json($reportName) {
 
 /**
  * Return an array with mapped default exposed filter values for given view
- * and params. Used to map date filter default values if they are not specified
+ * and parameters. Used to map date filter default values if they are not specified
  * in request.
  *
  * @param object $view
@@ -6311,13 +6311,17 @@ function civihr_employee_portal_hrreport_get_exposed_filter_default_values($view
   $dateFilter = $view->display['default']->display_options['filters']['date_filter'];
   if (!empty($dateFilter['expose']['identifier'])) {
     $identifier = $dateFilter['expose']['identifier'];
+
     $defaultFromDate = !empty($dateFilter['default_date']) ? $dateFilter['default_date'] : '';
     $defaultToDate = !empty($dateFilter['default_to_date']) ? $dateFilter['default_to_date'] : '';
+
     $from = (new DateTime())->modify($defaultFromDate);
     $to = (new DateTime())->modify($defaultToDate);
+
     if (empty($params[$identifier]['min'])) {
       $params[$identifier]['min'] = $from->format('Y-m-d');
     }
+
     if (empty($params[$identifier]['max'])) {
       $params[$identifier]['max'] = $to->format('Y-m-d');
     }

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -6312,29 +6312,37 @@ function civihr_employee_portal_hrreport_get_exposed_filter_default_values($view
   if (!empty($dateFilter['expose']['identifier'])) {
     $identifier = $dateFilter['expose']['identifier'];
 
-    $defaultFromDate = !empty($dateFilter['default_date']) ? $dateFilter['default_date'] : null;
-    $defaultToDate = !empty($dateFilter['default_to_date']) ? $dateFilter['default_to_date'] : null;
-
-    $from = new DateTime();
-    if ($defaultFromDate) {
-      $from->modify($defaultFromDate);
-    }
-
-    $to = new DateTime();
-    if ($defaultToDate) {
-      $to->modify($defaultToDate);
-    }
-
-    if (empty($params[$identifier]['min'])) {
-      $params[$identifier]['min'] = $from->format('Y-m-d');
-    }
-
-    if (empty($params[$identifier]['max'])) {
-      $params[$identifier]['max'] = $to->format('Y-m-d');
-    }
+    $params[$identifier]['min'] = civihr_employee_portal_get_date_filter_default_value($params, $dateFilter, 'default_date', $identifier, 'min');
+    $params[$identifier]['max'] = civihr_employee_portal_get_date_filter_default_value($params, $dateFilter, 'default_to_date', $identifier, 'max');
   }
 
   return $params;
+}
+
+/**
+ * Return a date filter default value from View filter settings
+ * if it's not specified in the parameters.
+ *
+ * @param array $params
+ * @param string $dateFilter
+ * @param string $dateFilterKey
+ * @param string $identifier
+ * @param string $identifierKey
+ *
+ * @return string
+ */
+function civihr_employee_portal_get_date_filter_default_value(array $params, $dateFilter, $dateFilterKey, $identifier, $identifierKey) {
+  if (empty($params[$identifier][$identifierKey])) {
+    $defaultDate = !empty($dateFilter[$dateFilterKey]) ? $dateFilter[$dateFilterKey] : null;
+
+    if ($defaultDate) {
+      $date = new DateTime();
+      $date->modify($defaultDate);
+      $params[$identifier][$identifierKey] = $date->format('Y-m-d');
+    }
+  }
+
+  return $params[$identifier][$identifierKey];
 }
 
 function civihr_employee_portal_hrreport_custom_printtable($reportName, $dateFilterValue = null) {

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -6276,12 +6276,54 @@ function civihr_employee_portal_hrreport_custom($reportName) {
   );
 }
 
+/**
+ * Render a JSON structure containing data for specified report name.
+ *
+ * @param string $reportName
+ *
+ * @return string
+ */
 function civihr_employee_portal_hrreport_get_json($reportName) {
+  $params = drupal_get_query_parameters();
   $view = views_get_view('civihr_report_' . $reportName);
+  $view->exposed_input = civihr_employee_portal_hrreport_get_exposed_filter_default_values($view, $params);
   $view->set_display('page');
   $view->execute();
   $view->style_plugin->options['using_views_api_mode'] = FALSE;
   return $view->render('page');
+}
+
+/**
+ * Return an array with mapped default exposed filter values for given view
+ * and params. Used to map date filter default values if they are not specified
+ * in request.
+ *
+ * @param object $view
+ * @param array $params
+ *
+ * @return array
+ */
+function civihr_employee_portal_hrreport_get_exposed_filter_default_values($view, array $params) {
+  if (empty($view->display['default']->display_options['filters']['date_filter'])) {
+    return $params;
+  }
+
+  $dateFilter = $view->display['default']->display_options['filters']['date_filter'];
+  if (!empty($dateFilter['expose']['identifier'])) {
+    $identifier = $dateFilter['expose']['identifier'];
+    $defaultFromDate = !empty($dateFilter['default_date']) ? $dateFilter['default_date'] : '';
+    $defaultToDate = !empty($dateFilter['default_to_date']) ? $dateFilter['default_to_date'] : '';
+    $from = (new DateTime())->modify($defaultFromDate);
+    $to = (new DateTime())->modify($defaultToDate);
+    if (empty($params[$identifier]['min'])) {
+      $params[$identifier]['min'] = $from->format('Y-m-d');
+    }
+    if (empty($params[$identifier]['max'])) {
+      $params[$identifier]['max'] = $to->format('Y-m-d');
+    }
+  }
+
+  return $params;
 }
 
 function civihr_employee_portal_hrreport_custom_printtable($reportName, $dateFilterValue = null) {

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -6312,11 +6312,18 @@ function civihr_employee_portal_hrreport_get_exposed_filter_default_values($view
   if (!empty($dateFilter['expose']['identifier'])) {
     $identifier = $dateFilter['expose']['identifier'];
 
-    $defaultFromDate = !empty($dateFilter['default_date']) ? $dateFilter['default_date'] : '';
-    $defaultToDate = !empty($dateFilter['default_to_date']) ? $dateFilter['default_to_date'] : '';
+    $defaultFromDate = !empty($dateFilter['default_date']) ? $dateFilter['default_date'] : null;
+    $defaultToDate = !empty($dateFilter['default_to_date']) ? $dateFilter['default_to_date'] : null;
 
-    $from = (new DateTime())->modify($defaultFromDate);
-    $to = (new DateTime())->modify($defaultToDate);
+    $from = new DateTime();
+    if ($defaultFromDate) {
+      $from->modify($defaultFromDate);
+    }
+
+    $to = new DateTime();
+    if ($defaultToDate) {
+      $to->modify($defaultToDate);
+    }
 
     if (empty($params[$identifier]['min'])) {
       $params[$identifier]['min'] = $from->format('Y-m-d');

--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.views_default.inc
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.views_default.inc
@@ -920,8 +920,8 @@ Type ID: [activity_type_id] '),
     57573969 => 0,
   );
   $handler->display->display_options['filters']['date_filter']['form_type'] = 'date_popup';
-  $handler->display->display_options['filters']['date_filter']['default_date'] = 'now -12 month';
-  $handler->display->display_options['filters']['date_filter']['default_to_date'] = 'now +1 month';
+  $handler->display->display_options['filters']['date_filter']['default_date'] = 'now -10 year';
+  $handler->display->display_options['filters']['date_filter']['default_to_date'] = 'now +10 year';
   $handler->display->display_options['filters']['date_filter']['year_range'] = '-10:+10';
   $handler->display->display_options['filters']['date_filter']['date_fields'] = array(
     'absence_activity.absence_date' => 'absence_activity.absence_date',

--- a/civihr_employee_portal/views/views_export/views_civihr_report_leave_and_absence.inc
+++ b/civihr_employee_portal/views/views_export/views_civihr_report_leave_and_absence.inc
@@ -506,8 +506,8 @@ $handler->display->display_options['filters']['date_filter']['expose']['remember
   57573969 => 0,
 );
 $handler->display->display_options['filters']['date_filter']['form_type'] = 'date_popup';
-$handler->display->display_options['filters']['date_filter']['default_date'] = 'now -12 month';
-$handler->display->display_options['filters']['date_filter']['default_to_date'] = 'now +1 month';
+$handler->display->display_options['filters']['date_filter']['default_date'] = 'now -10 year';
+$handler->display->display_options['filters']['date_filter']['default_to_date'] = 'now +10 year';
 $handler->display->display_options['filters']['date_filter']['year_range'] = '-10:+10';
 $handler->display->display_options['filters']['date_filter']['date_fields'] = array(
   'absence_activity.absence_date' => 'absence_activity.absence_date',


### PR DESCRIPTION
Creating a new 'civihr_employee_portal_hrreport_get_exposed_filter_default_values()' SSP function to map date filter default values to the view if the values are not specified in the request.
