### PR TITLE
PCHR-1492: Remove unused job roles fields

### DIFF
--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.views_default.inc
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.views_default.inc
@@ -695,24 +695,6 @@ Type ID: [activity_type_id] '),
   $handler->display->display_options['fields']['role_department']['field'] = 'role_department';
   $handler->display->display_options['fields']['role_department']['relationship'] = 'role_jobcontract_id';
   $handler->display->display_options['fields']['role_department']['label'] = 'Role department';
-  /* Field: HRJobContract Role entity: Role_functional_area */
-  $handler->display->display_options['fields']['role_functional_area']['id'] = 'role_functional_area';
-  $handler->display->display_options['fields']['role_functional_area']['table'] = 'hrjc_role';
-  $handler->display->display_options['fields']['role_functional_area']['field'] = 'role_functional_area';
-  $handler->display->display_options['fields']['role_functional_area']['relationship'] = 'role_jobcontract_id';
-  $handler->display->display_options['fields']['role_functional_area']['label'] = 'Role functional area';
-  /* Field: HRJobContract Role entity: Role_hours */
-  $handler->display->display_options['fields']['role_hours']['id'] = 'role_hours';
-  $handler->display->display_options['fields']['role_hours']['table'] = 'hrjc_role';
-  $handler->display->display_options['fields']['role_hours']['field'] = 'role_hours';
-  $handler->display->display_options['fields']['role_hours']['relationship'] = 'role_jobcontract_id';
-  $handler->display->display_options['fields']['role_hours']['label'] = 'Role hours';
-  /* Field: HRJobContract Role entity: Role_hours_unit */
-  $handler->display->display_options['fields']['role_hours_unit']['id'] = 'role_hours_unit';
-  $handler->display->display_options['fields']['role_hours_unit']['table'] = 'hrjc_role';
-  $handler->display->display_options['fields']['role_hours_unit']['field'] = 'role_hours_unit';
-  $handler->display->display_options['fields']['role_hours_unit']['relationship'] = 'role_jobcontract_id';
-  $handler->display->display_options['fields']['role_hours_unit']['label'] = 'Role hours unit';
   /* Field: HRJobContract Role entity: Role_level_type */
   $handler->display->display_options['fields']['role_level_type']['id'] = 'role_level_type';
   $handler->display->display_options['fields']['role_level_type']['table'] = 'hrjc_role';
@@ -1375,9 +1357,6 @@ Type ID: [activity_type_id] '),
     t('Role cost center'),
     t('Role percent pay cost center'),
     t('Role department'),
-    t('Role functional area'),
-    t('Role hours'),
-    t('Role hours unit'),
     t('Role level type'),
     t('Role organization'),
     t('Role region'),
@@ -1690,24 +1669,6 @@ Type ID: [activity_type_id] '),
   $handler->display->display_options['fields']['role_department']['field'] = 'role_department';
   $handler->display->display_options['fields']['role_department']['relationship'] = 'role_jobcontract_id';
   $handler->display->display_options['fields']['role_department']['label'] = 'Role department';
-  /* Field: HRJobContract Role entity: Role_functional_area */
-  $handler->display->display_options['fields']['role_functional_area']['id'] = 'role_functional_area';
-  $handler->display->display_options['fields']['role_functional_area']['table'] = 'hrjc_role';
-  $handler->display->display_options['fields']['role_functional_area']['field'] = 'role_functional_area';
-  $handler->display->display_options['fields']['role_functional_area']['relationship'] = 'role_jobcontract_id';
-  $handler->display->display_options['fields']['role_functional_area']['label'] = 'Role functional area';
-  /* Field: HRJobContract Role entity: Role_hours */
-  $handler->display->display_options['fields']['role_hours']['id'] = 'role_hours';
-  $handler->display->display_options['fields']['role_hours']['table'] = 'hrjc_role';
-  $handler->display->display_options['fields']['role_hours']['field'] = 'role_hours';
-  $handler->display->display_options['fields']['role_hours']['relationship'] = 'role_jobcontract_id';
-  $handler->display->display_options['fields']['role_hours']['label'] = 'Role hours';
-  /* Field: HRJobContract Role entity: Role_hours_unit */
-  $handler->display->display_options['fields']['role_hours_unit']['id'] = 'role_hours_unit';
-  $handler->display->display_options['fields']['role_hours_unit']['table'] = 'hrjc_role';
-  $handler->display->display_options['fields']['role_hours_unit']['field'] = 'role_hours_unit';
-  $handler->display->display_options['fields']['role_hours_unit']['relationship'] = 'role_jobcontract_id';
-  $handler->display->display_options['fields']['role_hours_unit']['label'] = 'Role hours unit';
   /* Field: HRJobContract Role entity: Role_level_type */
   $handler->display->display_options['fields']['role_level_type']['id'] = 'role_level_type';
   $handler->display->display_options['fields']['role_level_type']['table'] = 'hrjc_role';
@@ -2353,9 +2314,6 @@ return date(\'Y-m-d\');';
     t('Role cost center'),
     t('Role percent pay cost center'),
     t('Role department'),
-    t('Role functional area'),
-    t('Role hours'),
-    t('Role hours unit'),
     t('Role level type'),
     t('Role organization'),
     t('Role region'),

--- a/civihr_employee_portal/views/views_export/views_civihr_report_leave_and_absence.inc
+++ b/civihr_employee_portal/views/views_export/views_civihr_report_leave_and_absence.inc
@@ -281,24 +281,6 @@ $handler->display->display_options['fields']['role_department']['table'] = 'hrjc
 $handler->display->display_options['fields']['role_department']['field'] = 'role_department';
 $handler->display->display_options['fields']['role_department']['relationship'] = 'role_jobcontract_id';
 $handler->display->display_options['fields']['role_department']['label'] = 'Role department';
-/* Field: HRJobContract Role entity: Role_functional_area */
-$handler->display->display_options['fields']['role_functional_area']['id'] = 'role_functional_area';
-$handler->display->display_options['fields']['role_functional_area']['table'] = 'hrjc_role';
-$handler->display->display_options['fields']['role_functional_area']['field'] = 'role_functional_area';
-$handler->display->display_options['fields']['role_functional_area']['relationship'] = 'role_jobcontract_id';
-$handler->display->display_options['fields']['role_functional_area']['label'] = 'Role functional area';
-/* Field: HRJobContract Role entity: Role_hours */
-$handler->display->display_options['fields']['role_hours']['id'] = 'role_hours';
-$handler->display->display_options['fields']['role_hours']['table'] = 'hrjc_role';
-$handler->display->display_options['fields']['role_hours']['field'] = 'role_hours';
-$handler->display->display_options['fields']['role_hours']['relationship'] = 'role_jobcontract_id';
-$handler->display->display_options['fields']['role_hours']['label'] = 'Role hours';
-/* Field: HRJobContract Role entity: Role_hours_unit */
-$handler->display->display_options['fields']['role_hours_unit']['id'] = 'role_hours_unit';
-$handler->display->display_options['fields']['role_hours_unit']['table'] = 'hrjc_role';
-$handler->display->display_options['fields']['role_hours_unit']['field'] = 'role_hours_unit';
-$handler->display->display_options['fields']['role_hours_unit']['relationship'] = 'role_jobcontract_id';
-$handler->display->display_options['fields']['role_hours_unit']['label'] = 'Role hours unit';
 /* Field: HRJobContract Role entity: Role_level_type */
 $handler->display->display_options['fields']['role_level_type']['id'] = 'role_level_type';
 $handler->display->display_options['fields']['role_level_type']['table'] = 'hrjc_role';
@@ -961,9 +943,6 @@ $translatables['civihr_report_leave_and_absence'] = array(
   t('Role cost center'),
   t('Role percent pay cost center'),
   t('Role department'),
-  t('Role functional area'),
-  t('Role hours'),
-  t('Role hours unit'),
   t('Role level type'),
   t('Role organization'),
   t('Role region'),

--- a/civihr_employee_portal/views/views_export/views_civihr_report_people.inc
+++ b/civihr_employee_portal/views/views_export/views_civihr_report_people.inc
@@ -280,24 +280,6 @@ $handler->display->display_options['fields']['role_department']['table'] = 'hrjc
 $handler->display->display_options['fields']['role_department']['field'] = 'role_department';
 $handler->display->display_options['fields']['role_department']['relationship'] = 'role_jobcontract_id';
 $handler->display->display_options['fields']['role_department']['label'] = 'Role department';
-/* Field: HRJobContract Role entity: Role_functional_area */
-$handler->display->display_options['fields']['role_functional_area']['id'] = 'role_functional_area';
-$handler->display->display_options['fields']['role_functional_area']['table'] = 'hrjc_role';
-$handler->display->display_options['fields']['role_functional_area']['field'] = 'role_functional_area';
-$handler->display->display_options['fields']['role_functional_area']['relationship'] = 'role_jobcontract_id';
-$handler->display->display_options['fields']['role_functional_area']['label'] = 'Role functional area';
-/* Field: HRJobContract Role entity: Role_hours */
-$handler->display->display_options['fields']['role_hours']['id'] = 'role_hours';
-$handler->display->display_options['fields']['role_hours']['table'] = 'hrjc_role';
-$handler->display->display_options['fields']['role_hours']['field'] = 'role_hours';
-$handler->display->display_options['fields']['role_hours']['relationship'] = 'role_jobcontract_id';
-$handler->display->display_options['fields']['role_hours']['label'] = 'Role hours';
-/* Field: HRJobContract Role entity: Role_hours_unit */
-$handler->display->display_options['fields']['role_hours_unit']['id'] = 'role_hours_unit';
-$handler->display->display_options['fields']['role_hours_unit']['table'] = 'hrjc_role';
-$handler->display->display_options['fields']['role_hours_unit']['field'] = 'role_hours_unit';
-$handler->display->display_options['fields']['role_hours_unit']['relationship'] = 'role_jobcontract_id';
-$handler->display->display_options['fields']['role_hours_unit']['label'] = 'Role hours unit';
 /* Field: HRJobContract Role entity: Role_level_type */
 $handler->display->display_options['fields']['role_level_type']['id'] = 'role_level_type';
 $handler->display->display_options['fields']['role_level_type']['table'] = 'hrjc_role';
@@ -943,9 +925,6 @@ $translatables['civihr_report_people'] = array(
   t('Role cost center'),
   t('Role percent pay cost center'),
   t('Role department'),
-  t('Role functional area'),
-  t('Role hours'),
-  t('Role hours unit'),
   t('Role level type'),
   t('Role organization'),
   t('Role region'),

--- a/civihr_hrjobcontract_entities/civihr_hrjobcontract_entities.module
+++ b/civihr_hrjobcontract_entities/civihr_hrjobcontract_entities.module
@@ -208,8 +208,6 @@ function civihr_hrjobcontract_entities_init() {
                     t.job_contract_id AS jobcontract_id,
                     t.title AS role_title,
                     t.description AS role_description,
-                    t.hours AS role_hours,
-                    t.role_hours_unit AS role_hours_unit,
                     DATE_FORMAT(t.start_date, '%Y-%m-%d') AS role_start_date,
                     DATE_FORMAT(t.end_date, '%Y-%m-%d') AS role_end_date,
                     DATE_FORMAT(t.start_date, '%Y-%m') AS role_start_month,
@@ -218,7 +216,6 @@ function civihr_hrjobcontract_entities_init() {
                     ov_department.label AS role_department,
                     ov_level_type.label AS role_level_type,
                     t.manager_contact_id AS role_manager_contact_id,
-                    t.functional_area AS role_functional_area,
                     t.organization AS role_organization,
                     t.cost_center AS role_cost_center,
                     t.funder AS role_funder,
@@ -785,16 +782,6 @@ function civihr_hrjobcontract_entities_schema_alter(&$schema) {
         'not null' => FALSE,
         'description' => 'Description.',
     );
-    $schema['hrjc_role']['fields']['role_hours'] = array(
-        'type' => 'varchar',
-        'not null' => FALSE,
-        'description' => 'Hours.',
-    );
-    $schema['hrjc_role']['fields']['role_hours_unit'] = array(
-        'type' => 'varchar',
-        'not null' => FALSE,
-        'description' => 'Role hours unit.',
-    );
     $schema['hrjc_role']['fields']['role_region'] = array(
         'type' => 'varchar',
         'not null' => FALSE,
@@ -814,11 +801,6 @@ function civihr_hrjobcontract_entities_schema_alter(&$schema) {
         'type' => 'int',
         'not null' => FALSE,
         'description' => 'Manager contact ID.',
-    );
-    $schema['hrjc_role']['fields']['role_functional_area'] = array(
-        'type' => 'varchar',
-        'not null' => FALSE,
-        'description' => 'Functional area.',
     );
     $schema['hrjc_role']['fields']['role_organization'] = array(
         'type' => 'varchar',


### PR DESCRIPTION
Removing any usage for the following unused job roles fields :

- Job role functional area
- Job role hours
- Job role hours unit


Related PR : https://github.com/civicrm/civihr/pull/1228