### PR TITLE
PCHR-1698: Redirect from civi dashboard to T&A dashboard

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -7033,7 +7033,7 @@ function _user_redirection() {
     ) {
       $redirect_path = 'welcome-page';
     }
-  } else if ($current_path == 'civicrm') {
+  } else if ($current_path == 'civicrm' || $current_path == 'civicrm/dashboard') {
     $redirect_path = 'civicrm/tasksassignments/dashboard#/tasks';
   }
 


### PR DESCRIPTION
Don't allow logged in users to access civicrm/dasboard by redirecting them to T&A dashboard.