### PR TITLE
PCHR-1382: Fixed Quick Approve/Reject Buttons in Manager Absence Approval

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -1625,6 +1625,13 @@ function civihr_employee_portal_menu() {
         'type' => MENU_CALLBACK,
     );
 
+    $items['manager_approval/%ctools_js/quick_approval'] = array(
+      'page callback' => 'civihr_employee_portal_manager_approval_quick_approval',
+      'page arguments' => array(1, 2, 3, 4, 5),
+      'access callback' => TRUE,
+      'type' => MENU_CALLBACK,
+    );
+
     $items['manager_approval/%ctools_js/calendar/show'] = array(
         'page callback' => 'civihr_employee_portal_manager_approval_show_calendar_callback',
         'page arguments' => array(1),
@@ -2167,6 +2174,117 @@ function civihr_employee_portal_manager_approval_pick_days_callback($ajax, $acti
         return drupal_get_form('civihr_employee_portal_manager_approval_pick_days_form');
     }
 
+}
+
+/**
+ * Function that processes approvals and rejections made by manager from the absence approval widget
+ *
+ * @param int $ajax
+ *   boolean value, 1 if it is an ajax call
+ * @param string $action
+ *   should always be "quick_approval"
+ * @param int $activity_id
+ *   Activity ID that identifies the absence to be processed
+ * @param int $status
+ *   ID of status that should be set to main absence and each absence per day (2: Accepted, 9: Rejected)
+ * @param string $type
+ *   Staus type that is to be set, either "accept" or "reject"
+ */
+function civihr_employee_portal_manager_approval_quick_approval($ajax, $action, $activity_id, $status, $type) {
+  // Civi init
+  civicrm_initialize();
+
+  try {
+    // Load main activity leave
+    $main_activity = civicrm_api3('Activity', 'get', ['sequential' => 1, 'id' => $activity_id])['values'][0];
+
+    // Get activities for each day of leave
+    $search_params = ['source_record_id' => $activity_id, 'activity_type_id' => $main_activity['activity_type_id']];
+    $absence_details = civicrm_api3('Activity', 'get', $search_params);
+
+    // Set activities' status for each day of leave
+    foreach ($absence_details['values'] as $current_absence) {
+      civicrm_api3('Activity', 'setvalue', ['id' => $current_absence['id'], 'field' => 'status_id', 'value' => $status]);
+    }
+
+    // Set main activity's status
+    civicrm_api3('Activity', 'setvalue', ['id' => $activity_id, 'field' => 'status_id', 'value' => $status]);
+
+    // Invoke rules event
+    _invoke_rules_on_absence_decision($main_activity, $type, $absence_details['values']);
+
+    $result = ['status' => 'success'];
+  } catch (CiviCRM_API3_Exception $e) {
+    $errorMessage = $e->getMessage();
+    $errorCode = $e->getErrorCode();
+    $errorData = $e->getExtraParams();
+
+    $result = [
+      'status' => 'error',
+      'error' => $errorMessage,
+      'error_code' => $errorCode,
+      'error_data' => $errorData,
+    ];
+  }
+
+  // Issue response
+  print drupal_json_output($result);
+  drupal_exit();
+}
+
+/**
+ * Helper function that builds required parameters to pass to rules_invoke_event on decision (accept/reject) by manager
+ *
+ * @param $main_activity
+ * @param $type
+ * @param $absence_details
+ */
+function _invoke_rules_on_absence_decision($main_activity, $type, $absence_details) {
+  global $user;
+
+  // Get target user id
+  $target_user = user_load(_get_uf_match_contact($main_activity['source_contact_id'])['uf_id']);
+
+  // Build $leave_date
+  $disputes = [];
+  $all_duration = 0;
+
+  foreach ($absence_details as $key => $current_absence) {
+    $duration = $current_absence['duration'] / (6 * 80);
+    $all_duration += $duration;
+    $date = new DateTime($current_absence['activity_date_time']);
+    $disputes[$current_absence['id']] = [$date->format('Y-m-d'), $duration, get_civihr_absence_statuses($current_absence['status_id'])];
+    $last_day = $current_absence;
+  }
+
+  if ($all_duration <= 1) {
+    $date = new DateTime($last_day['activity_date_time']);
+    $duration_date = $date->format('Y-m-d');
+    $day = t('day');
+  }
+  else {
+    // Show start date and end date for the absence
+    $endDate = new DateTime($last_day['activity_date_time']);
+    $duration_date = array_values($disputes)[0][0] . ' - ' .  $endDate->format('Y-m-d');
+    $day = t('days');
+  }
+  $leave_date = $duration_date . ' = ' . $all_duration . ' ' . $day;
+
+  // Get absence type title
+  $absenceTypes = get_civihr_absence_types();
+
+  foreach ($absenceTypes as $absenceType) {
+    if (isset($absenceType['credit_activity_type_id']) && $absenceType['credit_activity_type_id'] == $main_activity['activity_type_id']) {
+      $leave_type = $absenceType['title'];
+    }
+
+    if (isset($absenceType['debit_activity_type_id']) && $absenceType['debit_activity_type_id'] == $main_activity['activity_type_id']) {
+      $leave_type = $absenceType['title'];
+    }
+  }
+
+  $event = ($type == 'approve' ? 'approve_all_post_event' : 'reject_all_post_event');
+  rules_invoke_event($event, $user, $target_user, '', $leave_type, $leave_date);
 }
 
 /**

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -2199,7 +2199,11 @@ function civihr_employee_portal_manager_approval_quick_approval($ajax, $action, 
     $main_activity = civicrm_api3('Activity', 'get', ['sequential' => 1, 'id' => $activity_id])['values'][0];
 
     // Get activities for each day of leave
-    $search_params = ['source_record_id' => $activity_id, 'activity_type_id' => $main_activity['activity_type_id']];
+    $activityTypes = CRM_Core_OptionGroup::values('activity_type', FALSE, FALSE, FALSE, NULL, 'name');
+    $search_params = [
+      'source_record_id' => $activity_id,
+      'activity_type_id' => CRM_Utils_Array::key('Absence', $activityTypes)
+    ];
     $absence_details = civicrm_api3('Activity', 'get', $search_params);
 
     // Set activities' status for each day of leave

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -1625,7 +1625,7 @@ function civihr_employee_portal_menu() {
         'type' => MENU_CALLBACK,
     );
 
-    $items['manager_approval/%ctools_js/quick_approval'] = array(
+    $items['manager_approval/ajax/quick_approval'] = array(
       'page callback' => 'civihr_employee_portal_manager_approval_quick_approval',
       'page arguments' => array(1, 2, 3, 4, 5),
       'access callback' => TRUE,
@@ -2177,7 +2177,7 @@ function civihr_employee_portal_manager_approval_pick_days_callback($ajax, $acti
 }
 
 /**
- * Function that processes approvals and rejections made by manager from the absence approval widget
+ * Function that processes approvals and rejections made by manager from the quick absence approval widget button
  *
  * @param int $ajax
  *   boolean value, 1 if it is an ajax call

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -2199,10 +2199,16 @@ function civihr_employee_portal_manager_approval_quick_approval($ajax, $action, 
     $main_activity = civicrm_api3('Activity', 'get', ['sequential' => 1, 'id' => $activity_id])['values'][0];
 
     // Get activities for each day of leave
-    $activityTypes = CRM_Core_OptionGroup::values('activity_type', FALSE, FALSE, FALSE, NULL, 'name');
+    $absenceTypeValue = civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'return' => array("value"),
+      'option_group_id' => "activity_type",
+      'name' => "Absence",
+      'options' => array('limit' => 1),
+    ])['values'][0];
     $search_params = [
       'source_record_id' => $activity_id,
-      'activity_type_id' => CRM_Utils_Array::key('Absence', $activityTypes)
+      'activity_type_id' => CRM_Utils_Array::key('Absence', $absenceTypeValue['value'])
     ];
     $absence_details = civicrm_api3('Activity', 'get', $search_params);
 

--- a/civihr_employee_portal/js/filters.js
+++ b/civihr_employee_portal/js/filters.js
@@ -51,7 +51,7 @@ Drupal.behaviors.civihr_employee_portal_filters = {
                     error: function(data) {
                         console.log(data);
                         console.log('Error approving leave!');
-                        swal("Failed!", "Error calling API", "error");
+                        swal("Failed!", "Error approving leave!", "error");
                     }
                 });
             }

--- a/civihr_employee_portal/js/filters.js
+++ b/civihr_employee_portal/js/filters.js
@@ -25,63 +25,33 @@ Drupal.behaviors.civihr_employee_portal_filters = {
                     var status_message = 'The whole leave request has been Rejected.';
                 }
 
-                CRM.api3('Activity', 'get', {
-                    "sequential": 1,
-                    "source_record_id": clicked_object,
-                }).done(function(result) {
+                $.ajax({
+                    type: 'GET',
+                    url: Drupal.settings.basePath + 'manager_approval/ajax/quick_approval/' + clicked_object + '/' + status_value + '/' + type,
+                    success: function(data) {
+                        console.log('Decision processed on Leave: ' + type);
+                        if (data.status == 'error') {
+                            swal("Failed!", data.error, "error");
+                        }
+                        else {
+                            // Update absence status on the screen
+                            $("#act-id-" + clicked_object).html(status_type);
 
-                    for (index = 0; index < result.count; ++index) {
+                            // Remove the row (so it will not be loaded when rebuilding the filters)
+                            $("#act-id-" + clicked_object).closest('tr').remove();
 
-                        CRM.api3('Activity', 'setvalue', {
-                            "sequential": 1,
-                            "id": result.values[index].id,
-                            "field": "status_id",
-                            "value": status_value
-                        }).done(function(result) {
+                            // Rebuild filters
+                            loadFilters();
 
-                        });
-                    }
+                            // Notify with popup
+                            swal(status_type + "!", status_message, "success");
+                        }
 
-                });
-
-                CRM.api3('Activity', 'setvalue', {
-                    "sequential": 1,
-                    "id": clicked_object,
-                    "field": "status_id",
-                    "value": status_value
-                }).done(function(result) {
-
-                    if (result.is_error == 1) {
-                        swal("Failed!", result.error_message, "error");
-                    }
-                    else {
-
-                        // Update absence status on the screen
-                        $("#act-id-" + clicked_object).html(status_type);
-
-                        // Remove the row (so it will not be loaded when rebuilding the filters)
-                        $("#act-id-" + clicked_object).closest('tr').remove();
-
-                        // Rebuild filters
-                        loadFilters();
-
-                        console.log(Drupal.settings.basePath + 'ajax/quick_email_notify/' + clicked_object + '/' + type);
-
-                        // Notify by email
-                        $.ajax({
-                            type: 'GET',
-                            url: Drupal.settings.basePath + 'ajax/quick_email_notify/' + clicked_object + '/' + type,
-                            success: function(data) {
-                                console.log('Email sent');
-                            },
-                            error: function(data) {
-                                console.log(data);
-                                console.log('Email not sent!');
-                            }
-                        });
-
-                        // Notify with popup
-                        swal(status_type + "!", status_message, "success");
+                    },
+                    error: function(data) {
+                        console.log(data);
+                        console.log('Error approving leave!');
+                        swal("Failed!", "Error calling API", "error");
                     }
                 });
             }


### PR DESCRIPTION
Changed functionality of quick approve/reject buttons, so that instead of making a
direct API Call to CiviCRM, it makes the call to the Drupal civihr_employee_portal
module, where the request is processed.

- Changed quick-button functionality on front-end
- Added manager_approval/%ctools_js/quick_approval route
- Route uses civihr_employee_portal_manager_approval_quick_approval as callback
- Added _invoke_rules_on_absence_decision helper function to build required data
  for rules_invoke_event