### PR TITLE
PCHR-1250: Set up the AngularJS app

### DIFF
--- a/civicrm_resources/civicrm_resources.module
+++ b/civicrm_resources/civicrm_resources.module
@@ -55,7 +55,7 @@ function civicrm_resources_add_resources($extention_path, $req_files = []) {
     drupal_add_css(ltrim(str_replace(DRUPAL_ROOT, '', $css_file), '/'));
   }
   foreach ($js_list as $key => $js_file) {
-    drupal_add_js(ltrim(str_replace(DRUPAL_ROOT, '', $js_file), '/'));
+    drupal_add_js(ltrim(str_replace(DRUPAL_ROOT, '', $js_file), '/'),  array('scope' => 'footer'));
   }
 }
 

--- a/civihr_employee_portal/civihr_leave_absences/civihr_leave_absences.module
+++ b/civihr_employee_portal/civihr_leave_absences/civihr_leave_absences.module
@@ -33,6 +33,18 @@ function civihr_leave_absences_block_view($delta = '') {
 }
 
 /**
+ * Implements hook_init().
+ *
+ * Fetches the base URL of the angular app, to be stored in the Drupal.settings global var
+ */
+function civihr_leave_absences_init() {
+  if (!_isCiviCRM()) {
+    $baseURL = CRM_Extension_System::singleton()->getMapper()->keyToUrl('uk.co.compucorp.civicrm.hrleaveandabsences');
+    drupal_add_js(array('civihr_leave_absences' => array('baseURL' => $baseURL)), 'setting');
+  }
+}
+
+/**
  * Internal function for fetching custom markup from template/Angular Js to display My Leave block.
  * @return Custom markup from template file.
  */
@@ -45,5 +57,6 @@ function civihr_leave_absences_my_leave_get_markup() {
   if (file_exists($file_path)) {
     return @file_get_contents($file_path);
   }
+
   return '';
 }

--- a/civihr_employee_portal/civihr_leave_absences/civihr_leave_absences.module
+++ b/civihr_employee_portal/civihr_leave_absences/civihr_leave_absences.module
@@ -37,10 +37,8 @@ function civihr_leave_absences_block_view($delta = '') {
  * @return Custom markup from template file.
  */
 function civihr_leave_absences_my_leave_get_markup() {
-
-  // @ TODO -> Pointing to Angular JS App once its ready for My Leave block.
-  // Loading angular js application for My Leave block using CiviCRM Resources API.
-  // eg: civicrm_resources_load('org.civicrm.hrjobcontract', array('gulpfile.js', 'hrjc.css', 'contact.js'));
+  civicrm_resources_load('org.civicrm.reqangular', array('reqangular.min.js'));
+  civicrm_resources_load('uk.co.compucorp.civicrm.hrleaveandabsences', array('my-leave.min.js'));
 
   // Fetching custom markup from pre-defined template file.
   $file_path = drupal_get_path('module', 'civihr_leave_absences') . '/templates/my_leave.html';

--- a/civihr_employee_portal/civihr_leave_absences/templates/my_leave.html
+++ b/civihr_employee_portal/civihr_leave_absences/templates/my_leave.html
@@ -2,7 +2,9 @@
   <ui-view></ui-view>
 </section>
 <script>
-CRM.vars.leaveAbsences = {
-  baseURL: 'sites/all/modules/civicrm/tools/extensions/civihr/uk.co.compucorp.civicrm.hrleaveandabsences'
-};
+  // Transfers the baseURL from Drupal.settings into
+  // the expected (by the app) CRM.vars.leaveAbsences object
+  CRM.vars.leaveAbsences = {
+    baseURL: Drupal.settings.civihr_leave_absences.baseURL
+  };
 </script>

--- a/civihr_employee_portal/civihr_leave_absences/templates/my_leave.html
+++ b/civihr_employee_portal/civihr_leave_absences/templates/my_leave.html
@@ -1,49 +1,8 @@
-<div class="my-leave-page">
-  <div class="button-container">
-    <div class="btn-group">
-      <button type="button" class="btn btn-primary dropdown-toggle"
-        data-toggle="dropdown" aria-haspopup="true"
-        aria-expanded="false">
-        Record New Absence
-        <span class="caret"></span>
-      </button>
-      <ul class="dropdown-menu">
-        <li><a href="#">Action 1</a></li>
-      </ul>
-    </div>
-  </div>
-  <div class="tabs-container">
-    <div class="container">
-      <ul class="nav nav-tabs nav-justified nav-tabs-header">
-        <li role="presentation" class="active">
-          <a href="#report">Report</a>
-        </li>
-        <li role="presentation">
-          <a href="#calendar">Calendar</a>
-        </li>
-      </ul>
-      <div class="tab-content">
-        <div id="report" class="tab-pane fade in active">
-          <h3>Report</h3>
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-          </p>
-        </div>
-        <div id="calendar" class="tab-pane fade">
-          <h3>Calendar</h3>
-          <p>
-            Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodoconsequat.
-          </p>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
+<section data-leave-absences-my-leave>
+  <ui-view></ui-view>
+</section>
 <script>
-  //This script is kept here which will later move to Angular Code
-  jQuery(document).ready(function () {
-    jQuery(".nav-tabs a").click(function () {
-      jQuery(this).tab('show');
-    });
-  });
+CRM.vars.leaveAbsences = {
+  baseURL: 'sites/all/modules/civicrm/tools/extensions/civihr/uk.co.compucorp.civicrm.hrleaveandabsences'
+};
 </script>


### PR DESCRIPTION
This PR complements the work done in [this PR](https://github.com/civicrm/civihr/pull/1255), so that the L&A AngularJS app defined in `uk.co.civicrm.hrleaveandabsences` can be used in the */my-leave* Drupal page

## Add civihr extension javascript file at the end of `<body>`
The `civicrm_resources` module was adding the javascript files in the `<head>` of the page. The behaviour has been changed so that now it adds the file right before the closing of the `<body>` tag
```php
drupal_add_js(/* ... */,  array('scope' => 'footer'));
````

## Add AngularJS app file in the /my-leave page
By using the `civicrm_resources` module, both the `reqangular.min.js` (which contains RequireJS, AngularJS and all the common angular dependencies) and the `my-leave.min.js` (which contains the `my-leave` angular app) are added the the `/my-leave` page
```php
civicrm_resources_load('org.civicrm.reqangular', array('reqangular.min.js'));
civicrm_resources_load('uk.co.compucorp.civicrm.hrleaveandabsences', array('my-leave.min.js'));
```

## Simplify the /my-leave template
Given that the entire content of the page is now contained in the `<my-leave></my-leave>` angular component (defined in the `my-leave` angular app), the page can be drastically simplified:
```html
<section data-leave-absences-my-leave>
  <ui-view></ui-view>
</section>
```
The `[data-leave-absences-my-leave]` is used by the app to bootstrap itself, while `<ui-view>` is used by the `ui.router` module to inject the app html (it's the only hard dependencies that the page has with the internal functioning of the app)

## Fetch the extension full path in Drupal and pass it to the angular app
The angular app relies on a `CRM.vars.leaveAbsences.baseURL` object (the `CRM.vars.<extensionShortName>.baseURL` format is a standard that is used across all of the CiviHR extension) to be defined as a global variable in order to be able to know what the full path of the extension is. This is necessary for things like defining the path aliases to certain RequireJS modules
```js
var srcPath = CRM.vars.leaveAbsences.baseURL + '/js/angular/src/leave-absences/shared';

require.config({
  paths: {
    'leave-absences/shared/ui-router': srcPath + '/vendor/angular-ui-router.min',
  }
});
```
or to know where the components/directives templates are located
```js
return angular.module('my-leave.settings', []).constant('settings', {
  pathTpl: CRM.vars.leaveAbsences.baseURL + '/views/my-leave/'
});
```
In order to have the Drupal block provide the `baseURL` to the extension, in the `_init` hook the block uses `CRM_Extension_System` to fetch the url and puts it into a `Drupal.settings` object
```php
if (!_isCiviCRM()) {
  $baseURL = CRM_Extension_System::singleton()->getMapper()->keyToUrl('uk.co.compucorp.civicrm.hrleaveandabsences');

  // Will be in Drupal.settings.civihr_leave_absences.baseURL
  drupal_add_js(array('civihr_leave_absences' => array('baseURL' => $baseURL)), 'setting');
}
```
Subsequently, the block html contains a simple `<script>` tag that transfers the value to `CRM.vars.leaveAbsences.baseURL`, ready for the app to use
```html
<script>
  CRM.vars.leaveAbsences = {
    baseURL: Drupal.settings.civihr_leave_absences.baseURL
  };
</script>

```