### PR TITLE
PCHR-1283: Pass current user CRM id to my-leave angular app

### DIFF
--- a/civihr_employee_portal/civihr_leave_absences/templates/my_leave.html
+++ b/civihr_employee_portal/civihr_leave_absences/templates/my_leave.html
@@ -2,9 +2,10 @@
   <ui-view></ui-view>
 </section>
 <script>
-  // Transfers the baseURL from Drupal.settings into
-  // the expected (by the app) CRM.vars.leaveAbsences object
-  CRM.vars.leaveAbsences = {
-    baseURL: Drupal.settings.civihr_leave_absences.baseURL
+  // Transfers the Drupal.settings data into
+  // the expected (by the app) CRM.vars.leaveAndAbsences object
+  CRM.vars.leaveAndAbsences = {
+    baseURL: Drupal.settings.civihr_leave_absences.baseURL,
+    contactId: Drupal.settings.currentCiviCRMUserId
   };
 </script>


### PR DESCRIPTION
The civihr-employee-portal drupal module holds the current user's CRM id in `Drupal.settings.currentCiviCRMUserId`.
The my-leave angular app expects this value in the CMS-agnostic `CRM.vars.leaveAndAbsences` object

In this PR we simply pass the value from one variable to another