### PR TITLE
PCHR-1792: Added Manager Leave block containing AngularJS app.

### DIFF
--- a/civihr_employee_portal/civihr_leave_absences/civihr_leave_absences.module
+++ b/civihr_employee_portal/civihr_leave_absences/civihr_leave_absences.module
@@ -14,6 +14,10 @@ function civihr_leave_absences_block_info() {
     'info' => t('My Leave'),
     'cache' => DRUPAL_NO_CACHE,
   ];
+  $blocks['manager_leave'] = [
+    'info' => t('Manager Leave'),
+    'cache' => DRUPAL_NO_CACHE,
+  ];
   return $blocks;
 }
 
@@ -27,6 +31,9 @@ function civihr_leave_absences_block_view($delta = '') {
   switch ($delta) {
     case 'my_leave':
       $block['content'] = civihr_leave_absences_my_leave_get_markup();
+      break;
+    case 'manager_leave':
+      $block['content'] = civihr_leave_absences_manager_leave_get_markup();
       break;
   }
   return $block;
@@ -46,7 +53,8 @@ function civihr_leave_absences_init() {
 
 /**
  * Internal function for fetching custom markup from template/Angular Js to display My Leave block.
- * @return Custom markup from template file.
+ * @return String
+ *    Custom markup from template file.
  */
 function civihr_leave_absences_my_leave_get_markup() {
   civicrm_resources_load('org.civicrm.reqangular', array('reqangular.min.js'));
@@ -58,5 +66,25 @@ function civihr_leave_absences_my_leave_get_markup() {
     return @file_get_contents($file_path);
   }
 
+  return '';
+}
+
+/**
+ * Internal function for fetching custom markup from template/Angular Js to display
+ * Manager Leave block.
+ * @return String
+ *    Custom markup from template file.
+ */
+function civihr_leave_absences_manager_leave_get_markup() {
+
+  // @ TODO -> Pointing to Angular JS App once its ready for Manager Leave block.
+  // Loading angular js application for Manager Leave block using CiviCRM Resources API.
+  // eg: civicrm_resources_load('org.civicrm.hrjobcontract', array('gulpfile.js', 'hrjc.css', 'contact.js'));
+
+  // Fetching custom markup from pre-defined template file.
+  $file_path = drupal_get_path('module', 'civihr_leave_absences') . '/templates/manager_leave.html';
+  if (file_exists($file_path)) {
+    return @file_get_contents($file_path);
+  }
   return '';
 }

--- a/civihr_employee_portal/civihr_leave_absences/civihr_leave_absences.module
+++ b/civihr_employee_portal/civihr_leave_absences/civihr_leave_absences.module
@@ -60,13 +60,7 @@ function civihr_leave_absences_my_leave_get_markup() {
   civicrm_resources_load('org.civicrm.reqangular', array('reqangular.min.js'));
   civicrm_resources_load('uk.co.compucorp.civicrm.hrleaveandabsences', array('my-leave.min.js'));
 
-  // Fetching custom markup from pre-defined template file.
-  $file_path = drupal_get_path('module', 'civihr_leave_absences') . '/templates/my_leave.html';
-  if (file_exists($file_path)) {
-    return @file_get_contents($file_path);
-  }
-
-  return '';
+  return civihr_leave_absences_load_file('my_leave');
 }
 
 /**
@@ -76,15 +70,29 @@ function civihr_leave_absences_my_leave_get_markup() {
  *    Custom markup from template file.
  */
 function civihr_leave_absences_manager_leave_get_markup() {
+  civicrm_resources_load('org.civicrm.reqangular', array('reqangular.min.js'));
+  civicrm_resources_load('uk.co.compucorp.civicrm.hrleaveandabsences', array('manager-leave.min.js'));
 
-  // @ TODO -> Pointing to Angular JS App once its ready for Manager Leave block.
-  // Loading angular js application for Manager Leave block using CiviCRM Resources API.
-  // eg: civicrm_resources_load('org.civicrm.hrjobcontract', array('gulpfile.js', 'hrjc.css', 'contact.js'));
+  return civihr_leave_absences_load_file('manager_leave');
+}
+
+/**
+ * Internal function to load predefined template file.
+ *
+ * @param String
+ *    File name to load the content.
+ *
+ * @return String
+ *    File Content.
+ */
+function civihr_leave_absences_load_file($template = '') {
 
   // Fetching custom markup from pre-defined template file.
-  $file_path = drupal_get_path('module', 'civihr_leave_absences') . '/templates/manager_leave.html';
+  $file_path = drupal_get_path('module', 'civihr_leave_absences') . '/templates/' . $template . '.html';
   if (file_exists($file_path)) {
     return @file_get_contents($file_path);
   }
-  return '';
+  else {
+    return '';
+  }
 }

--- a/civihr_employee_portal/civihr_leave_absences/templates/manager_leave.html
+++ b/civihr_employee_portal/civihr_leave_absences/templates/manager_leave.html
@@ -1,0 +1,3 @@
+<section data-leave-absences-manager-leave>
+    <p>Manager Leave Block Template.</p>
+</section>

--- a/civihr_employee_portal/civihr_leave_absences/templates/manager_leave.html
+++ b/civihr_employee_portal/civihr_leave_absences/templates/manager_leave.html
@@ -1,3 +1,3 @@
 <section data-leave-absences-manager-leave>
-    <p>Manager Leave Block Template.</p>
+  <p>Manager Leave Block Template.</p>
 </section>


### PR DESCRIPTION
Problem :
Added Manager Leave block that can fetch custom markup from pre-defined template file and also an angular js app defined for Manager Leave block that will be use to place block in whatever page/view is necessary.

Solution:
Created new block called Manager Leave that contains markup for block from pre-defined template file and angular js app. As this is custom block we can easily export and place in whatever region we require.