### PR TITLE
PCHR-1561: Hide Appraisal menu

### DIFF
--- a/civihr_employee_portal/views/views_export/views_appraisals.inc
+++ b/civihr_employee_portal/views/views_export/views_appraisals.inc
@@ -124,6 +124,7 @@ $handler->display->display_options['fields']['cycle_end_date']['element_label_co
 
 /* Display: Page */
 $handler = $view->new_display('page', 'Page', 'appraisals_manager');
+$handler->display->display_options['enabled'] = FALSE;
 $handler->display->display_options['defaults']['arguments'] = FALSE;
 /* Contextual filter: Appraisal entity: Appraisal Manager ID */
 $handler->display->display_options['arguments']['manager_id']['id'] = 'manager_id';
@@ -180,3 +181,4 @@ $translatables['appraisals'] = array(
   t('All'),
   t('Block'),
 );
+


### PR DESCRIPTION
## Problem

The appraisals extension is not comeplete yet , so its SSP menu and page need to be disabled for now

![selection_187](https://cloud.githubusercontent.com/assets/6275540/21390669/05f20a78-c780-11e6-9cee-598454048d5b.png)

## Solution

I disabled the appraisals view page so it will not be shown on the SSP anymore.

![selection_186](https://cloud.githubusercontent.com/assets/6275540/21390674/0cd7ec2c-c780-11e6-991f-f06a3a016bb9.png)


