### PR TITLE
PCHR-1719: Redirect logged-in users from the main path (/) to their acessible dashboard

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -532,6 +532,9 @@ function getModuleUrl($moduleName) {
  * Implements hook_init().
  */
 function civihr_employee_portal_init() {
+  // calling this inside hook_init so we could access
+  // some drupal functions such as user_access
+  _user_redirection();
 
   // Loads all the resources only for non-civicrm pages.
   if (!_isCiviCRM()) {
@@ -7199,12 +7202,6 @@ function _get_task_filter_by_date($date, $normalize = false) {
   return $normalize ? ($filter == 'tomorrow' ? 'week' : $filter) : $filter;
 }
 
-/**
- * Implements hook_boot()
- */
-function civihr_employee_portal_boot() {
-  _user_redirection();
-}
 
 /**
  * This method handle user redirection for special use cases
@@ -7240,14 +7237,13 @@ function _user_redirection() {
   ];
 
   if ($user_is_anonymous) {
-    if (
-    (!in_array($current_path, $allowed_paths) && substr($current_path, 0, 4) !== 'user') ||
-    $current_path == 'user/register'
-    ) {
+    if ((!in_array($current_path, $allowed_paths) && substr($current_path, 0, 4) !== 'user') ||
+      $current_path == 'user/register') {
       $redirect_path = 'welcome-page';
     }
-  } else if ($current_path == 'civicrm' || $current_path == 'civicrm/dashboard') {
-    $redirect_path = 'civicrm/tasksassignments/dashboard#/tasks';
+  }
+  else if (in_array($current_path, ['', 'civicrm', 'civicrm/dashboard'])) {
+    $redirect_path = user_access('access CiviCRM') ?  'civicrm/tasksassignments/dashboard#/tasks' : 'dashboard';
   }
 
   if (!empty($redirect_path)) {


### PR DESCRIPTION
## Problem

IF you go to www.any-civihr-site-url.com/ then the emergency contacts webform will appear. but what is expected to happen : 

![screen shot 2016-11-14 at 13 38 39](https://cloud.githubusercontent.com/assets/6275540/21522815/77419194-cd11-11e6-9ba8-95404fcf82c8.png)

1. If you have 'access civicrm' permission: get to T&A dashboard
2. If you don't have 'access civicrm' permission: get to /dashboard



## Solution 

Removing hook_boot implementation and moving _user_redirection() call to hook_init where user_access() function is accessible . Then altering   _user_redirection() so if the $current_path == '' (which is any empty string that means we are on the main site path / )  then we redirect according to the specified rules above.

![anim](https://cloud.githubusercontent.com/assets/6275540/21523040/48a7c428-cd13-11e6-9ae0-c480a38f726b.gif)



