### PR TITLE
PCHR-1754: Add Administer Users Permission to civihr_admin Role

### DIFF
--- a/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
+++ b/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
@@ -787,6 +787,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer users',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin' => 'civihr_admin',
     ),
     'module' => 'user',
   );


### PR DESCRIPTION
## Problem
Users with civihr_admin role should be able to create drupal user records for contacts, using the appropriate option in the "Actions" menu of the contact view, but the option is currently not shown.

![screenshot-2](https://cloud.githubusercontent.com/assets/21999940/21679885/66e66d3e-d314-11e6-8cd2-4cc22573c0ea.png)

## Solution
Permission being checked to show link to create user record is "administer users", which was disabled for civihr_admin role by default.  Fixed by adding permission for the role in civihr_default_permissions feature.

![screenshot-1](https://cloud.githubusercontent.com/assets/21999940/21679892/6d18d3e0-d314-11e6-97a2-4df090c1ad7c.png)
