### PR TITLE
PCHR-1797: Manager Leave HTML

### DIFF
--- a/civihr_employee_portal/civihr_leave_absences/templates/manager_leave.html
+++ b/civihr_employee_portal/civihr_leave_absences/templates/manager_leave.html
@@ -1,3 +1,11 @@
 <section data-leave-absences-manager-leave>
-  <p>Manager Leave Block Template.</p>
+  <ui-view></ui-view>
 </section>
+<script>
+  // Transfers the Drupal.settings data into
+  // the expected (by the app) CRM.vars.leaveAndAbsences object
+  CRM.vars.leaveAndAbsences = {
+    baseURL: Drupal.settings.civihr_leave_absences.baseURL,
+    contactId: Drupal.settings.currentCiviCRMUserId
+  };
+</script>


### PR DESCRIPTION
This PR contains the following basic setup for Manager Leave page,

1. `<ui-view>` - This would be replaced by Angular's views.
2. `CRM.vars.leaveAndAbsences. baseURL` - Base URL for the LeaveAndAbsences extension saved in this global variable.
3. `CRM.vars.leaveAndAbsences. contactId` - `contactId` for the logged in user is saved in this global variable. 