### PR TITLE
PCHR-1852: Adding civicrm views intergration module

### DIFF
--- a/civicrm_views_integration/.editorconfig
+++ b/civicrm_views_integration/.editorconfig
@@ -1,0 +1,14 @@
+# Drupal editor configuration normalization
+# @see http://editorconfig.org/
+
+# This is the top-most .editorconfig file; do not search in parent directories.
+root = true
+
+# All files.
+[*]
+end_of_line = LF
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/civicrm_views_integration/.gitignore
+++ b/civicrm_views_integration/.gitignore
@@ -1,0 +1,5 @@
+# Ignore PHPStorm project folder
+.idea/
+
+# Ignore Linux backup files
+*~

--- a/civicrm_views_integration/README.md
+++ b/civicrm_views_integration/README.md
@@ -1,0 +1,15 @@
+CiviCRM Views Integration
+=============
+Making civicrm work with Drupal Views module [is pain](https://wiki.civicrm.org/confluence/display/CRMDOC/Views3+Integration),
+you also need to keep updating the drupal settings.php file each time a new table by and extension or
+new custom group get added .
+
+This Extension simplifies this operation by updating the setting.php file with all CiviCRM tables prefixes when installed
+and keep an eye on any custom group get added and append it to the setting.php file automaticly 
+without any user interaction.
+
+
+Author
+======
+
+- Omar Abu Hussein, [Compucorp LTD](http://compucorp.co.uk)

--- a/civicrm_views_integration/README.md
+++ b/civicrm_views_integration/README.md
@@ -4,10 +4,7 @@ Making civicrm work with Drupal Views module [is pain](https://wiki.civicrm.org/
 you also need to keep updating the drupal settings.php file each time a new table by and extension or
 new custom group get added .
 
-This Extension simplifies this operation by updating the setting.php file with all CiviCRM tables prefixes when installed
-and keep an eye on any custom group get added and append it to the setting.php file automaticly 
-without any user interaction.
-
+This Extension simplifies this operation by creating/updating json file that holds the views integration database array which should be used in settings.php file with all CiviCRM tables prefixes; after installing the module the code that should be added by site admin is visible from admin/reports/status page and should be manually added to settings.php and keeping an eye on any custom group get added via hook_civicrm_post and re-create json file to hold updated custom group within array to the settings.php file automatically without any user interaction.
 
 Author
 ======

--- a/civicrm_views_integration/civicrm_views_integration.info
+++ b/civicrm_views_integration/civicrm_views_integration.info
@@ -1,0 +1,7 @@
+name = CiviCRM Views Integration
+description = Easy and automatic intergration with drupal (views) module
+
+core = 7.x
+
+dependencies[] = views
+dependencies[] = civicrm

--- a/civicrm_views_integration/civicrm_views_integration.install
+++ b/civicrm_views_integration/civicrm_views_integration.install
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Implements hook_install().
+ * Appends settings.php file with prefixes for all current civicrm tables
+ * when installing this module for the first time
+ */
+function civicrm_views_integration_install() {
+  civicrm_initialize();
+
+  global $databases;
+
+  // Don't do anything if there are prefixes already defined
+  if (is_array($databases['default']['default']['prefix'])) {
+    return NULL;
+  }
+
+  $config = CRM_Core_Config::singleton();
+
+  // Only add the prefix if civicrm and drupal database are not the same one
+  if ($config->dsn != $config->userFrameworkDSN) {
+    $tableNames = CRM_Core_DAO::GetStorageValues(NULL, 0, 'Name');
+
+    $tablePrefixes = '$databases[\'default\'][\'default\'][\'prefix\']= array(';
+
+    // add default prefix: the drupal database prefix
+    $tablePrefixes .= "\n  'default' => '" .$databases['default']['default']['prefix'] . "',";
+
+    $dsnArray = DB::parseDSN($config->dsn);
+    $prefix = "`{$dsnArray['database']}`.";
+
+    foreach ($tableNames as $tableName => $value) {
+      $tablePrefixes .= "\n  '" . str_pad($tableName . '\'', 41) . " => '{$prefix}',";
+    }
+    $tablePrefixes .= "\n);";
+
+    $cmsSettingsPath = $config->userSystem->cmsRootPath() . '/sites/default/settings.php';
+    $myfile = fopen($cmsSettingsPath, 'a');
+    fwrite($myfile, "\n". $tablePrefixes);
+    fclose($myfile);
+  }
+}

--- a/civicrm_views_integration/civicrm_views_integration.install
+++ b/civicrm_views_integration/civicrm_views_integration.install
@@ -16,7 +16,7 @@ function civicrm_views_integration_install() {
  * Implements hook_requirements().
  */
 function civicrm_views_integration_requirements($phase) {
-  $requirements = array();
+  $requirements = []; 
   if ($phase == 'runtime') {
     // Provides Database prefix array for civicrm to be used in settings.php.
     $settings_message = "

--- a/civicrm_views_integration/civicrm_views_integration.install
+++ b/civicrm_views_integration/civicrm_views_integration.install
@@ -16,36 +16,30 @@ function civicrm_views_integration_install() {
  * Implements hook_requirements().
  */
 function civicrm_views_integration_requirements($phase) {
+  global $databases;
   $requirements = []; 
+
   if ($phase == 'runtime') {
-    // Provides Database prefix array for civicrm to be used in settings.php.
-    $settings_message = "
-      if (file_exists(DRUPAL_ROOT . '/sites/default/files/civicrm/custom/views-mapping.json')) {
-        \$databases['default']['default']['prefix'] = json_decode(file_get_contents(DRUPAL_ROOT . '/sites/default/files/civicrm/custom/views-mapping.json'), true);
-      }";
+    if (!is_array($databases['default']['default']['prefix'])) {
+      // Provides Database prefix array for civicrm to be used in settings.php.
+      $settings_message = "
+        if (file_exists(DRUPAL_ROOT . '/sites/default/files/civicrm/custom/views-mapping.json')) {
+          \$databases['default']['default']['prefix'] = json_decode(file_get_contents(DRUPAL_ROOT . '/sites/default/files/civicrm/custom/views-mapping.json'), true);
+        }";
 
-    $message = "<fieldset>
-                  <legend>Views integration settings</legend>
-                    <div>To enable CiviCRM Views integration, add the following to the site <code>settings.php</code> file:</div>
-                    <pre>{$settings_message}</pre>
-                </fieldset>";
+      $message = "<fieldset>
+                    <legend>Views integration settings</legend>
+                      <div>To enable CiviCRM Views integration, add the following to the site <code>settings.php</code> file:</div>
+                      <pre>{$settings_message}</pre>
+                  </fieldset>";
 
-    $requirements['civicrm_db_prefix'] = array(
-      'title' => t('Views integration settings'),
-      'description' => $message,
-      'severity' => REQUIREMENT_INFO,
-    );
+      $requirements['civicrm_db_prefix'] = array(
+        'title' => t('Views integration settings'),
+        'description' => $message,
+        'severity' => REQUIREMENT_INFO,
+      );
+    }
   }
 
   return $requirements;
-}
-
-/**
- * Implements hook_uninstall().
- */
-function civicrm_views_integration_uninstall() {
-  // Deletes views settngs json file.
-  if (file_exists(DRUPAL_ROOT . '/sites/default/files/civicrm/custom/views-mapping.json')) {
-    unlink(DRUPAL_ROOT . '/sites/default/files/civicrm/custom/views-mapping.json');
-  }
 }

--- a/civicrm_views_integration/civicrm_views_integration.install
+++ b/civicrm_views_integration/civicrm_views_integration.install
@@ -2,41 +2,50 @@
 
 /**
  * Implements hook_install().
- * Appends settings.php file with prefixes for all current civicrm tables
- * when installing this module for the first time
  */
 function civicrm_views_integration_install() {
-  civicrm_initialize();
-
   global $databases;
-
   // Don't do anything if there are prefixes already defined
-  if (is_array($databases['default']['default']['prefix'])) {
-    return NULL;
+  if (!is_array($databases['default']['default']['prefix'])) {
+    // Appends settings.php file with prefixes for all current civicrm tables.
+    _civicrm_views_integrating_generate_db_prefixes();
+  }
+}
+
+/**
+ * Implements hook_requirements().
+ */
+function civicrm_views_integration_requirements($phase) {
+  $requirements = array();
+  if ($phase == 'runtime') {
+    // Provides Database prefix array for civicrm to be used in settings.php.
+    $settings_message = "
+      if (file_exists(DRUPAL_ROOT . '/sites/default/files/civicrm/custom/views-mapping.json')) {
+        \$databases['default']['default']['prefix'] = json_decode(file_get_contents(DRUPAL_ROOT . '/sites/default/files/civicrm/custom/views-mapping.json'), true);
+      }";
+
+    $message = "<fieldset>
+                  <legend>Views integration settings</legend>
+                    <div>To enable CiviCRM Views integration, add the following to the site <code>settings.php</code> file:</div>
+                    <pre>{$settings_message}</pre>
+                </fieldset>";
+
+    $requirements['civicrm_db_prefix'] = array(
+      'title' => t('Views integration settings'),
+      'description' => $message,
+      'severity' => REQUIREMENT_INFO,
+    );
   }
 
-  $config = CRM_Core_Config::singleton();
+  return $requirements;
+}
 
-  // Only add the prefix if civicrm and drupal database are not the same one
-  if ($config->dsn != $config->userFrameworkDSN) {
-    $tableNames = CRM_Core_DAO::GetStorageValues(NULL, 0, 'Name');
-
-    $tablePrefixes = '$databases[\'default\'][\'default\'][\'prefix\']= array(';
-
-    // add default prefix: the drupal database prefix
-    $tablePrefixes .= "\n  'default' => '" .$databases['default']['default']['prefix'] . "',";
-
-    $dsnArray = DB::parseDSN($config->dsn);
-    $prefix = "`{$dsnArray['database']}`.";
-
-    foreach ($tableNames as $tableName => $value) {
-      $tablePrefixes .= "\n  '" . str_pad($tableName . '\'', 41) . " => '{$prefix}',";
-    }
-    $tablePrefixes .= "\n);";
-
-    $cmsSettingsPath = $config->userSystem->cmsRootPath() . '/sites/default/settings.php';
-    $myfile = fopen($cmsSettingsPath, 'a');
-    fwrite($myfile, "\n". $tablePrefixes);
-    fclose($myfile);
+/**
+ * Implements hook_uninstall().
+ */
+function civicrm_views_integration_uninstall() {
+  // Deletes views settngs json file.
+  if (file_exists(DRUPAL_ROOT . '/sites/default/files/civicrm/custom/views-mapping.json')) {
+    unlink(DRUPAL_ROOT . '/sites/default/files/civicrm/custom/views-mapping.json');
   }
 }

--- a/civicrm_views_integration/civicrm_views_integration.module
+++ b/civicrm_views_integration/civicrm_views_integration.module
@@ -16,7 +16,6 @@ function civicrm_views_integration_post($op, $objectName, $id, &$params) {
  * for connecting CiviCRM to views.
  */
 function _civicrm_views_integrating_generate_db_prefixes(){
-
   civicrm_initialize();
   global $databases;
 
@@ -26,7 +25,7 @@ function _civicrm_views_integrating_generate_db_prefixes(){
   if ($config->dsn != $config->userFrameworkDSN) {
     $tableNames = CRM_Core_DAO::GetStorageValues(NULL, 0, 'Name');
 
-    $tablePrefixes = array();
+    $tablePrefixes = [];
     // add default prefix: the drupal database prefix
     $tablePrefixes['default'] = '';
 
@@ -37,21 +36,19 @@ function _civicrm_views_integrating_generate_db_prefixes(){
       $tablePrefixes[$tableName] = "'" . $prefix . "',";;
     }
     // Generates JSON file.
-    _civicrm_views_integrating_generate_json($tablePrefixes, $config);
+    _civicrm_views_integrating_generate_json($tablePrefixes);
   }
 }
 
 /**
  * Creates Json file to hold Views integration settings database prefix array to be used in settings.php 
- * @param array
+ *
+ * @param array $tablePrefixes
  *      Database prefix array.
- * @param object
- *      CiviCRM config object.
  */
-function _civicrm_views_integrating_generate_json($tablePrefixes = array(), $config){
-
+function _civicrm_views_integrating_generate_json($tablePrefixes = []){
   $json_data = json_encode($tablePrefixes);
-  $cmsSettingsPath = $config->userSystem->cmsRootPath() . '/sites/default/files/civicrm/custom/views-mapping.json';
+  $cmsSettingsPath = DRUPAL_ROOT . '/sites/default/files/civicrm/custom/views-mapping.json';
   $myfile = fopen($cmsSettingsPath, 'w+');
   fwrite($myfile, "\n" . $json_data);
   fclose($myfile);

--- a/civicrm_views_integration/civicrm_views_integration.module
+++ b/civicrm_views_integration/civicrm_views_integration.module
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Implements CiviCRM hook :  hook_civicrm_post() [https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_post].
+ * This hook will check if any custom group get added and will append the prefix for it to settings.php
+ * file automatically
+ */
+function civicrm_views_integration_post($op, $objectName, $id, &$params) {
+  if ($objectName == 'CustomGroup' && $op == 'create') {
+    $config = CRM_Core_Config::singleton();
+
+    $tableName = CRM_Core_DAO::getFieldValue( 'CRM_Core_DAO_CustomGroup', $id, 'table_name' );
+
+    // Only add the prefix if civicrm and drupal database are not the same one
+    if ($config->dsn != $config->userFrameworkDSN) {
+      $dsnArray = DB::parseDSN($config->dsn);
+      $prefix = "`{$dsnArray['database']}`.";
+
+      $ctable = '$databases[\'default\'][\'default\'][\'prefix\'][\'' . $tableName . '\']= ' . '\'' . $prefix . '\';';
+
+      $cmsSettingsPath = $config->userSystem->cmsRootPath() . '/sites/default/settings.php';
+      $myfile = fopen($cmsSettingsPath, 'a');
+      fwrite($myfile, "\n". $ctable);
+      fclose($myfile);
+    }
+  }
+}

--- a/civicrm_views_integration/civicrm_views_integration.module
+++ b/civicrm_views_integration/civicrm_views_integration.module
@@ -1,27 +1,58 @@
 <?php
 
 /**
- * Implements CiviCRM hook :  hook_civicrm_post() [https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_post].
- * This hook will check if any custom group get added and will append the prefix for it to settings.php
+ * Implements CiviCRM hook : hook_civicrm_post() [https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_post].
+ * This hook will check if any custom group get added and will create database prefix for it to be used in settings.php
  * file automatically
  */
 function civicrm_views_integration_post($op, $objectName, $id, &$params) {
   if ($objectName == 'CustomGroup' && $op == 'create') {
-    $config = CRM_Core_Config::singleton();
-
-    $tableName = CRM_Core_DAO::getFieldValue( 'CRM_Core_DAO_CustomGroup', $id, 'table_name' );
-
-    // Only add the prefix if civicrm and drupal database are not the same one
-    if ($config->dsn != $config->userFrameworkDSN) {
-      $dsnArray = DB::parseDSN($config->dsn);
-      $prefix = "`{$dsnArray['database']}`.";
-
-      $ctable = '$databases[\'default\'][\'default\'][\'prefix\'][\'' . $tableName . '\']= ' . '\'' . $prefix . '\';';
-
-      $cmsSettingsPath = $config->userSystem->cmsRootPath() . '/sites/default/settings.php';
-      $myfile = fopen($cmsSettingsPath, 'a');
-      fwrite($myfile, "\n". $ctable);
-      fclose($myfile);
-    }
+    _civicrm_views_integrating_generate_db_prefixes();
   }
+}
+
+/**
+ * Creates Views integration settings database prefix array to be used in settings.php 
+ * for connecting CiviCRM to views.
+ */
+function _civicrm_views_integrating_generate_db_prefixes(){
+
+  civicrm_initialize();
+  global $databases;
+
+  $config = CRM_Core_Config::singleton();
+
+  // Only add the prefix if civicrm and drupal database are not the same one
+  if ($config->dsn != $config->userFrameworkDSN) {
+    $tableNames = CRM_Core_DAO::GetStorageValues(NULL, 0, 'Name');
+
+    $tablePrefixes = array();
+    // add default prefix: the drupal database prefix
+    $tablePrefixes['default'] = '';
+
+    $dsnArray = DB::parseDSN($config->dsn);
+    $prefix = "`{$dsnArray['database']}`.";
+    
+    foreach ($tableNames as $tableName => $value) {
+      $tablePrefixes[$tableName] = "'" . $prefix . "',";;
+    }
+    // Generates JSON file.
+    _civicrm_views_integrating_generate_json($tablePrefixes, $config);
+  }
+}
+
+/**
+ * Creates Json file to hold Views integration settings database prefix array to be used in settings.php 
+ * @param array
+ *      Database prefix array.
+ * @param object
+ *      CiviCRM config object.
+ */
+function _civicrm_views_integrating_generate_json($tablePrefixes = array(), $config){
+
+  $json_data = json_encode($tablePrefixes);
+  $cmsSettingsPath = $config->userSystem->cmsRootPath() . '/sites/default/files/civicrm/custom/views-mapping.json';
+  $myfile = fopen($cmsSettingsPath, 'w+');
+  fwrite($myfile, "\n" . $json_data);
+  fclose($myfile);
 }

--- a/civicrm_views_integration/civicrm_views_integration.module
+++ b/civicrm_views_integration/civicrm_views_integration.module
@@ -5,7 +5,7 @@
  * This hook will check if any custom group get added and will create database prefix for it to be used in settings.php
  * file automatically
  */
-function civicrm_views_integration_post($op, $objectName, $id, &$params) {
+function civicrm_views_integration_civicrm_post($op, $objectName, $id, &$params) {
   if ($objectName == 'CustomGroup' && $op == 'create') {
     _civicrm_views_integrating_generate_db_prefixes();
   }


### PR DESCRIPTION
**Problem**
Making civicrm work with Drupal Views module [is pain](https://wiki.civicrm.org/confluence/display/CRMDOC/Views3+Integration), you also need to keep updating the drupal settings.php file each time a new table by and extension or
new custom group get added .

**Solution**
This Extension simplifies this operation by creating/updating json file that holds the views integration database array which should be used in settings.php file with all CiviCRM tables prefixes; after installing the module the code that should be added by site admin is visible from admin/reports/status page and should be manually added to settings.php and keeping an eye on any custom group get added via hook_civicrm_post and re-create json file to hold updated custom group within array to the settings.php file automatically without any user interaction.
