### PR TITLE
PCHR-1712: Improve Administration of Content on Welcome Page

### DIFF
--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.pages_default.inc
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.pages_default.inc
@@ -629,137 +629,176 @@ function civihr_employee_portal_features_default_page_manager_pages() {
   $display->cache = array();
   $display->title = '<none>';
   $display->uuid = '65fa22bb-05c5-4318-b3eb-20181449dc7a';
+  $display->storage_type = 'page_manager';
+  $display->storage_id = 'page_welcome_page_panel_context';
   $display->content = array();
   $display->panels = array();
-    $pane = new stdClass();
-    $pane->pid = 'new-3f0db58e-4030-419c-add3-07e0e6e8c7e0';
-    $pane->panel = 'column2';
-    $pane->type = 'custom';
-    $pane->subtype = 'custom';
-    $pane->shown = TRUE;
-    $pane->access = array();
-    $pane->configuration = array(
-      'admin_title' => '',
-      'title' => '',
-      'body' => '<div id="block-header-welcome">
-     <div class="row">
-         <div class="col-xs-12 text-center">
-             <div class="logo-rect-wrapper">
-                 <img src="sites/all/modules/civihr-custom/civihr_employee_portal/images/logo.png">
-             </div>
-             <h1>CiviHR DEMO</h1>
-             <h2>Self Service Portal</h2>
-         </div>
-     </div>
- </div>',
-      'format' => 'full_html',
-      'substitute' => TRUE,
-    );
-    $pane->cache = array();
-    $pane->style = array(
-      'settings' => NULL,
-    );
-    $pane->css = array();
-    $pane->extras = array();
-    $pane->position = 0;
-    $pane->locks = array();
-    $pane->uuid = '3f0db58e-4030-419c-add3-07e0e6e8c7e0';
-    $display->content['new-3f0db58e-4030-419c-add3-07e0e6e8c7e0'] = $pane;
-    $display->panels['column2'][0] = 'new-3f0db58e-4030-419c-add3-07e0e6e8c7e0';
-    $pane = new stdClass();
-    $pane->pid = 'new-f122256d-6524-48e1-a630-60a24dfb412e';
-    $pane->panel = 'column2';
-    $pane->type = 'block';
-    $pane->subtype = 'user-login';
-    $pane->shown = TRUE;
-    $pane->access = array();
-    $pane->configuration = array(
-      'override_title' => 1,
-      'override_title_text' => 'Login:',
-      'override_title_heading' => 'h2',
-    );
-    $pane->cache = array();
-    $pane->style = array(
-      'settings' => NULL,
-    );
-    $pane->css = array();
-    $pane->extras = array();
-    $pane->position = 1;
-    $pane->locks = array();
-    $pane->uuid = 'f122256d-6524-48e1-a630-60a24dfb412e';
-    $display->content['new-f122256d-6524-48e1-a630-60a24dfb412e'] = $pane;
-    $display->panels['column2'][1] = 'new-f122256d-6524-48e1-a630-60a24dfb412e';
-    $pane = new stdClass();
-    $pane->pid = 'new-c1e74a5e-1513-4ae2-bd55-e097b00d3575';
-    $pane->panel = 'column2';
-    $pane->type = 'custom';
-    $pane->subtype = 'custom';
-    $pane->shown = TRUE;
-    $pane->access = array();
-    $pane->configuration = array(
-      'admin_title' => '',
-      'title' => '',
-      'body' => '<p class="text-center">Don\'t have a login?
-        <a href="/request_new_account/nojs" class="ctools-use-modal ctools-modal-civihr-default-style ctools-use-modal-processed" title="Request new account">Click here to request one from your HR administrator</a></p>',
-      'format' => 'full_html',
-      'substitute' => TRUE,
-    );
-    $pane->cache = array();
-    $pane->style = array(
-      'settings' => NULL,
-    );
-    $pane->css = array();
-    $pane->extras = array();
-    $pane->position = 2;
-    $pane->locks = array();
-    $pane->uuid = 'c1e74a5e-1513-4ae2-bd55-e097b00d3575';
-    $display->content['new-c1e74a5e-1513-4ae2-bd55-e097b00d3575'] = $pane;
-    $display->panels['column2'][2] = 'new-c1e74a5e-1513-4ae2-bd55-e097b00d3575';
-    $pane = new stdClass();
-    $pane->pid = 'new-34a8c3b9-acb5-4419-ba57-7ebfc1f3e8f2';
-    $pane->panel = 'header';
-    $pane->type = 'node';
-    $pane->subtype = 'node';
-    $pane->shown = TRUE;
-    $pane->access = array(
-      'plugins' => array(
-        0 => array(
-          'name' => 'role',
-          'settings' => array(
-            'rids' => array(
-              0 => 30037204,
-            ),
+  $pane = new stdClass();
+  $pane->pid = 'new-889a60ef-1b56-4330-85cf-d3c0f25fcc01';
+  $pane->panel = 'column2';
+  $pane->type = 'page_logo';
+  $pane->subtype = 'page_logo';
+  $pane->shown = TRUE;
+  $pane->access = array();
+  $pane->configuration = array();
+  $pane->cache = array();
+  $pane->style = array(
+    'settings' => NULL,
+  );
+  $pane->css = array(
+    'css_id' => 'block-welcome-logo',
+    'css_class' => '',
+  );
+  $pane->extras = array();
+  $pane->position = 0;
+  $pane->locks = array();
+  $pane->uuid = '889a60ef-1b56-4330-85cf-d3c0f25fcc01';
+  $display->content['new-889a60ef-1b56-4330-85cf-d3c0f25fcc01'] = $pane;
+  $display->panels['column2'][0] = 'new-889a60ef-1b56-4330-85cf-d3c0f25fcc01';
+  $pane = new stdClass();
+  $pane->pid = 'new-3b43f2a1-c244-4018-adcc-ee092c4fa9d8';
+  $pane->panel = 'column2';
+  $pane->type = 'page_site_name';
+  $pane->subtype = 'page_site_name';
+  $pane->shown = TRUE;
+  $pane->access = array();
+  $pane->configuration = array(
+    'linked' => 0,
+    'override_title' => 0,
+    'override_title_text' => '',
+    'override_title_heading' => 'h2',
+  );
+  $pane->cache = array();
+  $pane->style = array(
+    'settings' => NULL,
+  );
+  $pane->css = array(
+    'css_id' => 'block-welcome-sitename',
+    'css_class' => '',
+  );
+  $pane->extras = array();
+  $pane->position = 1;
+  $pane->locks = array();
+  $pane->uuid = '3b43f2a1-c244-4018-adcc-ee092c4fa9d8';
+  $display->content['new-3b43f2a1-c244-4018-adcc-ee092c4fa9d8'] = $pane;
+  $display->panels['column2'][1] = 'new-3b43f2a1-c244-4018-adcc-ee092c4fa9d8';
+  $pane = new stdClass();
+  $pane->pid = 'new-6f7f063d-ef96-4a44-8e20-921039687b30';
+  $pane->panel = 'column2';
+  $pane->type = 'page_slogan';
+  $pane->subtype = 'page_slogan';
+  $pane->shown = TRUE;
+  $pane->access = array();
+  $pane->configuration = array();
+  $pane->cache = array();
+  $pane->style = array(
+    'settings' => NULL,
+  );
+  $pane->css = array(
+    'css_id' => 'block-welcome-slogan',
+    'css_class' => '',
+  );
+  $pane->extras = array();
+  $pane->position = 2;
+  $pane->locks = array();
+  $pane->uuid = '6f7f063d-ef96-4a44-8e20-921039687b30';
+  $display->content['new-6f7f063d-ef96-4a44-8e20-921039687b30'] = $pane;
+  $display->panels['column2'][2] = 'new-6f7f063d-ef96-4a44-8e20-921039687b30';
+  $pane = new stdClass();
+  $pane->pid = 'new-f122256d-6524-48e1-a630-60a24dfb412e';
+  $pane->panel = 'column2';
+  $pane->type = 'block';
+  $pane->subtype = 'user-login';
+  $pane->shown = TRUE;
+  $pane->access = array();
+  $pane->configuration = array(
+    'override_title' => 1,
+    'override_title_text' => 'Login:',
+    'override_title_heading' => 'h2',
+  );
+  $pane->cache = array();
+  $pane->style = array(
+    'settings' => NULL,
+  );
+  $pane->css = array();
+  $pane->extras = array();
+  $pane->position = 3;
+  $pane->locks = array();
+  $pane->uuid = 'f122256d-6524-48e1-a630-60a24dfb412e';
+  $display->content['new-f122256d-6524-48e1-a630-60a24dfb412e'] = $pane;
+  $display->panels['column2'][3] = 'new-f122256d-6524-48e1-a630-60a24dfb412e';
+  $pane = new stdClass();
+  $pane->pid = 'new-c1e74a5e-1513-4ae2-bd55-e097b00d3575';
+  $pane->panel = 'column2';
+  $pane->type = 'custom';
+  $pane->subtype = 'custom';
+  $pane->shown = TRUE;
+  $pane->access = array();
+  $pane->configuration = array(
+    'admin_title' => '',
+    'title' => '',
+    'body' => '<p class="text-center">Don\'t have a login?
+          <a href="/request_new_account/nojs" class="ctools-use-modal ctools-modal-civihr-default-style ctools-use-modal-processed" title="Request new account">Click here to request one from your HR administrator</a></p>',
+    'format' => 'full_html',
+    'substitute' => TRUE,
+  );
+  $pane->cache = array();
+  $pane->style = array(
+    'settings' => NULL,
+  );
+  $pane->css = array();
+  $pane->extras = array();
+  $pane->position = 4;
+  $pane->locks = array();
+  $pane->uuid = 'c1e74a5e-1513-4ae2-bd55-e097b00d3575';
+  $display->content['new-c1e74a5e-1513-4ae2-bd55-e097b00d3575'] = $pane;
+  $display->panels['column2'][4] = 'new-c1e74a5e-1513-4ae2-bd55-e097b00d3575';
+  $pane = new stdClass();
+  $pane->pid = 'new-34a8c3b9-acb5-4419-ba57-7ebfc1f3e8f2';
+  $pane->panel = 'header';
+  $pane->type = 'node';
+  $pane->subtype = 'node';
+  $pane->shown = TRUE;
+  $pane->access = array(
+    'plugins' => array(
+      0 => array(
+        'name' => 'role',
+        'settings' => array(
+          'rids' => array(
+            0 => 30037204,
           ),
-          'context' => 'logged-in-user',
-          'not' => FALSE,
         ),
+        'context' => 'logged-in-user',
+        'not' => FALSE,
       ),
-    );
-    $pane->configuration = array(
-      'nid' => '1',
-      'links' => 1,
-      'leave_node_title' => 0,
-      'identifier' => '',
-      'build_mode' => 'full',
-      'link_node_title' => 0,
-      'override_title' => 1,
-      'override_title_text' => '<none>',
-    );
-    $pane->cache = array();
-    $pane->style = array(
-      'settings' => NULL,
-    );
-    $pane->css = array();
-    $pane->extras = array();
-    $pane->position = 0;
-    $pane->locks = array();
-    $pane->uuid = '34a8c3b9-acb5-4419-ba57-7ebfc1f3e8f2';
-    $display->content['new-34a8c3b9-acb5-4419-ba57-7ebfc1f3e8f2'] = $pane;
-    $display->panels['header'][0] = 'new-34a8c3b9-acb5-4419-ba57-7ebfc1f3e8f2';
+    ),
+  );
+  $pane->configuration = array(
+    'nid' => '1',
+    'links' => 1,
+    'leave_node_title' => 0,
+    'identifier' => '',
+    'build_mode' => 'full',
+    'link_node_title' => 0,
+    'override_title' => 1,
+    'override_title_text' => '<none>',
+  );
+  $pane->cache = array();
+  $pane->style = array(
+    'settings' => NULL,
+  );
+  $pane->css = array();
+  $pane->extras = array();
+  $pane->position = 0;
+  $pane->locks = array();
+  $pane->uuid = '34a8c3b9-acb5-4419-ba57-7ebfc1f3e8f2';
+  $display->content['new-34a8c3b9-acb5-4419-ba57-7ebfc1f3e8f2'] = $pane;
+  $display->panels['header'][0] = 'new-34a8c3b9-acb5-4419-ba57-7ebfc1f3e8f2';
   $display->hide_title = PANELS_TITLE_FIXED;
   $display->title_pane = '0';
   $handler->conf['display'] = $display;
   $page->default_handlers[$handler->name] = $handler;
+
   $pages['welcome_page'] = $page;
 
   return $pages;


### PR DESCRIPTION
## Problem
Content in welcome page holding logo, site name and slogan was being included using a custom module with the raw HTML left to be edited to update any information, which is not ideal if it is supposed to be administered by regular users.

## Solution
Removed custom block and added separate blocks with administrable drupal site logo, site name and slogan to the page.  Each block has its own CSS ID, so each can be styled to match expected look & feel for welcome page.