### PR TITLE
PCHR-1685: update footer info

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -7450,7 +7450,7 @@ function get_civihr_version() {
             } catch (CiviCRM_API3_Exception $e) {
                 $error = $e->getMessage();
             }
-            cache_set('civihr_version', $civihrVersion, 'cache', time() + 360);
+            cache_set('civihr_version', $civihrVersion, 'cache', time() + 86400);
         }
     }
 

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -7436,23 +7436,24 @@ function civihr_employee_portal_html_head_alter(&$head_elements) {
  *  Return current version of Civihr.
  */
 function get_civihr_version() {
-    $civihrVersion = &drupal_static(__FUNCTION__);
+  $civihrVersion = &drupal_static(__FUNCTION__);
 
-    if (!isset($civihrVersion)) {
-        if ($cache = cache_get('civihr_version')) {
-            $civihrVersion = $cache->data;
-        } else {
-            try {
-                // Civi init
-                civicrm_initialize();
-                $result = civicrm_api3('HRCoreInfo', 'getversion', array('sequential' => 1));
-                $civihrVersion = $result['values'];
-            } catch (CiviCRM_API3_Exception $e) {
-                $error = $e->getMessage();
-            }
-            cache_set('civihr_version', $civihrVersion, 'cache', time() + 86400);
-        }
+  if (!isset($civihrVersion)) {
+    if ($cache = cache_get('civihr_version')) {
+      $civihrVersion = $cache->data;
+    } else {
+      try {
+        // Civi init
+        civicrm_initialize();
+        $result = civicrm_api3('HRCoreInfo', 'getversion', array('sequential' => 1));
+        $civihrVersion = $result['values'];
+      } catch (CiviCRM_API3_Exception $e) {
+        $error = $e->getMessage();
+      }
+
+      cache_set('civihr_version', $civihrVersion, 'cache', time() + 86400);
     }
+  }
 
-    return $civihrVersion;
+  return $civihrVersion;
 }

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -7432,6 +7432,9 @@ function civihr_employee_portal_html_head_alter(&$head_elements) {
   $head_elements[$default_favicon_element]['#attributes']['href'] = "{$base_url}/{$icoPath}";
 }
 
+/**
+ *  Return current version of Civihr.
+ */
 function get_civihr_version() {
     $civihrVersion = &drupal_static(__FUNCTION__);
 

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -7431,3 +7431,25 @@ function civihr_employee_portal_html_head_alter(&$head_elements) {
 
   $head_elements[$default_favicon_element]['#attributes']['href'] = "{$base_url}/{$icoPath}";
 }
+
+function get_civihr_version() {
+    $civihrVersion = &drupal_static(__FUNCTION__);
+
+    if (!isset($civihrVersion)) {
+        if ($cache = cache_get('civihr_version')) {
+            $civihrVersion = $cache->data;
+        } else {
+            try {
+                // Civi init
+                civicrm_initialize();
+                $result = civicrm_api3('HRCoreInfo', 'getversion', array('sequential' => 1));
+                $civihrVersion = $result['values'];
+            } catch (CiviCRM_API3_Exception $e) {
+                $error = $e->getMessage();
+            }
+            cache_set('civihr_version', $civihrVersion, 'cache', time() + 360);
+        }
+    }
+
+    return $civihrVersion;
+}

--- a/civihr_employee_portal/css/custom.css
+++ b/civihr_employee_portal/css/custom.css
@@ -159,3 +159,27 @@ span.appraisals-employee-legend {
   vertical-align: middle;
   padding-left: 10px;
 }
+
+#footer {
+    height: 250px;
+    color: #727e8a;
+    padding-top: 85px;
+    font-size: 13px;
+    line-height: 2;
+}
+
+#footer a {
+    color: #42afcb;
+}
+
+#footer a:hover {
+    color: #42afcb;
+}
+
+#footer a:visited {
+    color: #42afcb;
+}
+
+.footer-logo {
+    margin-top: 25px;
+}

--- a/civihr_employee_portal/css/custom.css
+++ b/civihr_employee_portal/css/custom.css
@@ -161,25 +161,25 @@ span.appraisals-employee-legend {
 }
 
 #footer {
-    height: 250px;
-    color: #727e8a;
-    padding-top: 85px;
-    font-size: 13px;
-    line-height: 2;
+  height: 250px;
+  color: #727e8a;
+  padding-top: 85px;
+  font-size: 13px;
+  line-height: 2;
 }
 
 #footer a {
-    color: #42afcb;
+  color: #42afcb;
 }
 
 #footer a:hover {
-    color: #42afcb;
+  color: #42afcb;
 }
 
 #footer a:visited {
-    color: #42afcb;
+  color: #42afcb;
 }
 
 .footer-logo {
-    margin-top: 25px;
+  margin-top: 25px;
 }


### PR DESCRIPTION
# Getting Current Version Of Civihr

A function was required to return the current version of civihr to display on the footer.

# Styling the footer

<img width="910" alt="screen shot 2017-01-16 at 5 32 35 pm" src="https://cloud.githubusercontent.com/assets/5742538/21991528/430a913a-dc13-11e6-9cb9-468210d86a5c.png">


The footer was styled to meet the design requirements. 