### PR TITLE
PCHR-1764: Get Staff Contact Information by Location Name

### DIFF
--- a/civihr_employee_portal/views/views_export/views_hr_staff_directory.inc
+++ b/civihr_employee_portal/views/views_export/views_hr_staff_directory.inc
@@ -296,6 +296,7 @@ $handler->display->display_options['fields']['work_phone']['id'] = 'work_phone';
 $handler->display->display_options['fields']['work_phone']['table'] = 'hrjc_contact_details';
 $handler->display->display_options['fields']['work_phone']['field'] = 'work_phone';
 $handler->display->display_options['fields']['work_phone']['relationship'] = 'hrjc_contact_details';
+$handler->display->display_options['fields']['work_phone']['label'] = 'Work Phone';
 /* Field: HRJobContract Contact Work/Home Phone and E-mail Entity: Work_phone_ext */
 $handler->display->display_options['fields']['work_phone_ext']['id'] = 'work_phone_ext';
 $handler->display->display_options['fields']['work_phone_ext']['table'] = 'hrjc_contact_details';
@@ -462,7 +463,7 @@ $handler->display->display_options['filters']['work_phone']['operator'] = 'conta
 $handler->display->display_options['filters']['work_phone']['group'] = 1;
 $handler->display->display_options['filters']['work_phone']['exposed'] = TRUE;
 $handler->display->display_options['filters']['work_phone']['expose']['operator_id'] = 'work_phone_op';
-$handler->display->display_options['filters']['work_phone']['expose']['label'] = 'Work_phone';
+$handler->display->display_options['filters']['work_phone']['expose']['label'] = 'Work Phone';
 $handler->display->display_options['filters']['work_phone']['expose']['operator'] = 'work_phone_op';
 $handler->display->display_options['filters']['work_phone']['expose']['identifier'] = 'work_phone';
 $handler->display->display_options['filters']['work_phone']['expose']['remember_roles'] = array(
@@ -752,7 +753,7 @@ $translatables['civihr_staff_directory'] = array(
   t('.'),
   t('Name'),
   t('[first_name] [last_name]'),
-  t('Work_phone'),
+  t('Work Phone'),
   t('Work Phone Extension'),
   t('Job Title'),
   t('Location'),

--- a/civihr_employee_portal/views/views_export/views_hr_staff_directory.inc
+++ b/civihr_employee_portal/views/views_export/views_hr_staff_directory.inc
@@ -42,8 +42,8 @@ $handler->display->display_options['style_options']['columns'] = array(
   'first_name' => 'first_name',
   'last_name' => 'last_name',
   'display_name' => 'display_name',
-  'phone' => 'phone',
-  'phone_ext' => 'phone_ext',
+  'work_phone' => 'work_phone',
+  'work_phone_ext' => 'work_phone_ext',
   'title' => 'title',
   'email_1' => 'email_1',
   'location_label' => 'location_label',
@@ -95,14 +95,14 @@ $handler->display->display_options['style_options']['info'] = array(
     'separator' => '',
     'empty_column' => 0,
   ),
-  'phone' => array(
+  'work_phone' => array(
     'sortable' => 1,
     'default_sort_order' => 'asc',
     'align' => '',
     'separator' => '',
     'empty_column' => 0,
   ),
-  'phone_ext' => array(
+  'work_phone_ext' => array(
     'sortable' => 1,
     'default_sort_order' => 'asc',
     'align' => '',
@@ -252,6 +252,10 @@ $handler->display->display_options['relationships']['contact_id_b__1']['table'] 
 $handler->display->display_options['relationships']['contact_id_b__1']['field'] = 'contact_id_b_';
 $handler->display->display_options['relationships']['contact_id_b__1']['relationship'] = 'relationship_id_a_1';
 $handler->display->display_options['relationships']['contact_id_b__1']['label'] = 'Unfiltered Managers';
+/* Relationship: CiviCRM Contacts: HRJobContract Contact Work/Home Phone and E-mail Entity */
+$handler->display->display_options['relationships']['hrjc_contact_details']['id'] = 'hrjc_contact_details';
+$handler->display->display_options['relationships']['hrjc_contact_details']['table'] = 'civicrm_contact';
+$handler->display->display_options['relationships']['hrjc_contact_details']['field'] = 'hrjc_contact_details';
 /* Field: CiviCRM Contacts: Contact ID */
 $handler->display->display_options['fields']['id']['id'] = 'id';
 $handler->display->display_options['fields']['id']['table'] = 'civicrm_contact';
@@ -287,24 +291,17 @@ $handler->display->display_options['fields']['display_name']['exclude'] = TRUE;
 $handler->display->display_options['fields']['display_name']['alter']['alter_text'] = TRUE;
 $handler->display->display_options['fields']['display_name']['alter']['text'] = '[first_name] [last_name]';
 $handler->display->display_options['fields']['display_name']['link_to_civicrm_contact'] = 0;
-/* Field: CiviCRM Phone Details: Phone */
-$handler->display->display_options['fields']['phone']['id'] = 'phone';
-$handler->display->display_options['fields']['phone']['table'] = 'civicrm_phone';
-$handler->display->display_options['fields']['phone']['field'] = 'phone';
-$handler->display->display_options['fields']['phone']['label'] = 'Work Phone';
-$handler->display->display_options['fields']['phone']['location_type'] = '2';
-$handler->display->display_options['fields']['phone']['location_op'] = '0';
-$handler->display->display_options['fields']['phone']['is_primary'] = 0;
-$handler->display->display_options['fields']['phone']['phone_type'] = '0';
-/* Field: CiviCRM Phone Details: Phone Number Extension */
-$handler->display->display_options['fields']['phone_ext']['id'] = 'phone_ext';
-$handler->display->display_options['fields']['phone_ext']['table'] = 'civicrm_phone';
-$handler->display->display_options['fields']['phone_ext']['field'] = 'phone_ext';
-$handler->display->display_options['fields']['phone_ext']['label'] = 'Work Phone Extension';
-$handler->display->display_options['fields']['phone_ext']['location_type'] = '2';
-$handler->display->display_options['fields']['phone_ext']['location_op'] = '0';
-$handler->display->display_options['fields']['phone_ext']['is_primary'] = 0;
-$handler->display->display_options['fields']['phone_ext']['phone_type'] = '0';
+/* Field: HRJobContract Contact Work/Home Phone and E-mail Entity: Work_phone */
+$handler->display->display_options['fields']['work_phone']['id'] = 'work_phone';
+$handler->display->display_options['fields']['work_phone']['table'] = 'hrjc_contact_details';
+$handler->display->display_options['fields']['work_phone']['field'] = 'work_phone';
+$handler->display->display_options['fields']['work_phone']['relationship'] = 'hrjc_contact_details';
+/* Field: HRJobContract Contact Work/Home Phone and E-mail Entity: Work_phone_ext */
+$handler->display->display_options['fields']['work_phone_ext']['id'] = 'work_phone_ext';
+$handler->display->display_options['fields']['work_phone_ext']['table'] = 'hrjc_contact_details';
+$handler->display->display_options['fields']['work_phone_ext']['field'] = 'work_phone_ext';
+$handler->display->display_options['fields']['work_phone_ext']['relationship'] = 'hrjc_contact_details';
+$handler->display->display_options['fields']['work_phone_ext']['label'] = 'Work Phone Extension';
 /* Field: HRJobContract Details entity: Title */
 $handler->display->display_options['fields']['title']['id'] = 'title';
 $handler->display->display_options['fields']['title']['table'] = 'hrjc_details';
@@ -456,32 +453,32 @@ $handler->display->display_options['filters']['title']['expose']['autocomplete_f
 $handler->display->display_options['filters']['title']['expose']['autocomplete_raw_suggestion'] = 1;
 $handler->display->display_options['filters']['title']['expose']['autocomplete_raw_dropdown'] = 1;
 $handler->display->display_options['filters']['title']['expose']['autocomplete_dependent'] = 0;
-/* Filter criterion: CiviCRM Phone Details: Phone */
-$handler->display->display_options['filters']['phone']['id'] = 'phone';
-$handler->display->display_options['filters']['phone']['table'] = 'civicrm_phone';
-$handler->display->display_options['filters']['phone']['field'] = 'phone';
-$handler->display->display_options['filters']['phone']['operator'] = 'contains';
-$handler->display->display_options['filters']['phone']['group'] = 1;
-$handler->display->display_options['filters']['phone']['exposed'] = TRUE;
-$handler->display->display_options['filters']['phone']['expose']['operator_id'] = 'phone_op';
-$handler->display->display_options['filters']['phone']['expose']['label'] = 'Phone';
-$handler->display->display_options['filters']['phone']['expose']['operator'] = 'phone_op';
-$handler->display->display_options['filters']['phone']['expose']['identifier'] = 'phone';
-$handler->display->display_options['filters']['phone']['expose']['remember_roles'] = array(
+/* Filter criterion: HRJobContract Contact Work/Home Phone and E-mail Entity: Work_phone */
+$handler->display->display_options['filters']['work_phone']['id'] = 'work_phone';
+$handler->display->display_options['filters']['work_phone']['table'] = 'hrjc_contact_details';
+$handler->display->display_options['filters']['work_phone']['field'] = 'work_phone';
+$handler->display->display_options['filters']['work_phone']['relationship'] = 'hrjc_contact_details';
+$handler->display->display_options['filters']['work_phone']['operator'] = 'contains';
+$handler->display->display_options['filters']['work_phone']['group'] = 1;
+$handler->display->display_options['filters']['work_phone']['exposed'] = TRUE;
+$handler->display->display_options['filters']['work_phone']['expose']['operator_id'] = 'work_phone_op';
+$handler->display->display_options['filters']['work_phone']['expose']['label'] = 'Work_phone';
+$handler->display->display_options['filters']['work_phone']['expose']['operator'] = 'work_phone_op';
+$handler->display->display_options['filters']['work_phone']['expose']['identifier'] = 'work_phone';
+$handler->display->display_options['filters']['work_phone']['expose']['remember_roles'] = array(
   2 => '2',
   1 => 0,
   3 => 0,
-  4 => 0,
-  6 => 0,
-  5 => 0,
+  55120974 => 0,
+  17087012 => 0,
+  57573969 => 0,
 );
-$handler->display->display_options['filters']['phone']['expose']['autocomplete_filter'] = 1;
-$handler->display->display_options['filters']['phone']['expose']['autocomplete_items'] = '10';
-$handler->display->display_options['filters']['phone']['expose']['autocomplete_min_chars'] = '0';
-$handler->display->display_options['filters']['phone']['expose']['autocomplete_field'] = 'phone';
-$handler->display->display_options['filters']['phone']['expose']['autocomplete_raw_suggestion'] = 1;
-$handler->display->display_options['filters']['phone']['expose']['autocomplete_raw_dropdown'] = 1;
-$handler->display->display_options['filters']['phone']['expose']['autocomplete_dependent'] = 0;
+$handler->display->display_options['filters']['work_phone']['expose']['autocomplete_items'] = '10';
+$handler->display->display_options['filters']['work_phone']['expose']['autocomplete_min_chars'] = '0';
+$handler->display->display_options['filters']['work_phone']['expose']['autocomplete_field'] = 'work_phone';
+$handler->display->display_options['filters']['work_phone']['expose']['autocomplete_raw_suggestion'] = 1;
+$handler->display->display_options['filters']['work_phone']['expose']['autocomplete_raw_dropdown'] = 1;
+$handler->display->display_options['filters']['work_phone']['expose']['autocomplete_dependent'] = 0;
 /* Filter criterion: CiviCRM Email: Email Address */
 $handler->display->display_options['filters']['email']['id'] = 'email';
 $handler->display->display_options['filters']['email']['table'] = 'civicrm_email';
@@ -750,11 +747,12 @@ $translatables['civihr_staff_directory'] = array(
   t('CiviCRM Contact B'),
   t('Rel From A Unfiltered'),
   t('Unfiltered Managers'),
+  t('HRJobContract Contact Work/Home Phone and E-mail Entity'),
   t('Contact ID'),
   t('.'),
   t('Name'),
   t('[first_name] [last_name]'),
-  t('Work Phone'),
+  t('Work_phone'),
   t('Work Phone Extension'),
   t('Job Title'),
   t('Location'),
@@ -768,7 +766,6 @@ $translatables['civihr_staff_directory'] = array(
   t('Broken handler hrjc_role.role_star_date'),
   t('Manager'),
   t('Managers'),
-  t('Phone'),
   t('Email'),
   t('Department'),
   t('Staff directory list page'),

--- a/civihr_employee_portal/views/views_export/views_my_details_block.inc
+++ b/civihr_employee_portal/views/views_export/views_my_details_block.inc
@@ -89,6 +89,10 @@ $handler->display->display_options['relationships']['role_jobcontract_id']['id']
 $handler->display->display_options['relationships']['role_jobcontract_id']['table'] = 'hrjc_revision';
 $handler->display->display_options['relationships']['role_jobcontract_id']['field'] = 'role_jobcontract_id';
 $handler->display->display_options['relationships']['role_jobcontract_id']['relationship'] = 'hrjc_revision';
+/* Relationship: CiviCRM Contacts: HRJobContract Contact Work/Home Phone and E-mail Entity */
+$handler->display->display_options['relationships']['hrjc_contact_details']['id'] = 'hrjc_contact_details';
+$handler->display->display_options['relationships']['hrjc_contact_details']['table'] = 'civicrm_contact';
+$handler->display->display_options['relationships']['hrjc_contact_details']['field'] = 'hrjc_contact_details';
 $handler->display->display_options['defaults']['fields'] = FALSE;
 /* Field: CiviCRM Contacts: Contact ID */
 $handler->display->display_options['fields']['id']['id'] = 'id';
@@ -122,20 +126,30 @@ $handler->display->display_options['fields']['phone_ext']['location_type'] = '2'
 $handler->display->display_options['fields']['phone_ext']['location_op'] = '0';
 $handler->display->display_options['fields']['phone_ext']['is_primary'] = 0;
 $handler->display->display_options['fields']['phone_ext']['phone_type'] = '1';
+/* Field: HRJobContract Contact Work/Home Phone and E-mail Entity: Work_phone */
+$handler->display->display_options['fields']['work_phone']['id'] = 'work_phone';
+$handler->display->display_options['fields']['work_phone']['table'] = 'hrjc_contact_details';
+$handler->display->display_options['fields']['work_phone']['field'] = 'work_phone';
+$handler->display->display_options['fields']['work_phone']['relationship'] = 'hrjc_contact_details';
+$handler->display->display_options['fields']['work_phone']['exclude'] = TRUE;
+/* Field: HRJobContract Contact Work/Home Phone and E-mail Entity: Work_phone_ext */
+$handler->display->display_options['fields']['work_phone_ext']['id'] = 'work_phone_ext';
+$handler->display->display_options['fields']['work_phone_ext']['table'] = 'hrjc_contact_details';
+$handler->display->display_options['fields']['work_phone_ext']['field'] = 'work_phone_ext';
+$handler->display->display_options['fields']['work_phone_ext']['relationship'] = 'hrjc_contact_details';
+$handler->display->display_options['fields']['work_phone_ext']['exclude'] = TRUE;
 /* Field: Global: Custom text */
 $handler->display->display_options['fields']['nothing']['id'] = 'nothing';
 $handler->display->display_options['fields']['nothing']['table'] = 'views';
 $handler->display->display_options['fields']['nothing']['field'] = 'nothing';
 $handler->display->display_options['fields']['nothing']['label'] = 'Work Phone';
-$handler->display->display_options['fields']['nothing']['alter']['text'] = '[phone] ext. [phone_ext]';
-/* Field: CiviCRM Email: Email Address */
-$handler->display->display_options['fields']['email']['id'] = 'email';
-$handler->display->display_options['fields']['email']['table'] = 'civicrm_email';
-$handler->display->display_options['fields']['email']['field'] = 'email';
-$handler->display->display_options['fields']['email']['label'] = 'Work Email';
-$handler->display->display_options['fields']['email']['location_type'] = '2';
-$handler->display->display_options['fields']['email']['location_op'] = '0';
-$handler->display->display_options['fields']['email']['is_primary'] = 0;
+$handler->display->display_options['fields']['nothing']['alter']['text'] = '[work_phone] ext. [work_phone_ext]';
+/* Field: HRJobContract Contact Work/Home Phone and E-mail Entity: Work_email */
+$handler->display->display_options['fields']['work_email']['id'] = 'work_email';
+$handler->display->display_options['fields']['work_email']['table'] = 'hrjc_contact_details';
+$handler->display->display_options['fields']['work_email']['field'] = 'work_email';
+$handler->display->display_options['fields']['work_email']['relationship'] = 'hrjc_contact_details';
+$handler->display->display_options['fields']['work_email']['label'] = 'Work E-mail';
 /* Field: HRJobContract Details entity: Title */
 $handler->display->display_options['fields']['title']['id'] = 'title';
 $handler->display->display_options['fields']['title']['table'] = 'hrjc_details';
@@ -147,7 +161,6 @@ $handler->display->display_options['fields']['location']['id'] = 'location';
 $handler->display->display_options['fields']['location']['table'] = 'hrjc_details';
 $handler->display->display_options['fields']['location']['field'] = 'location';
 $handler->display->display_options['fields']['location']['relationship'] = 'details_revision_id';
-$handler->display->display_options['fields']['location']['label'] = 'Location';
 /* Field: HRJobContract Role entity: Role_title */
 $handler->display->display_options['fields']['role_title']['id'] = 'role_title';
 $handler->display->display_options['fields']['role_title']['table'] = 'hrjc_role';
@@ -221,25 +234,23 @@ $handler->display->display_options['defaults']['relationships'] = FALSE;
 $handler->display->display_options['relationships']['drupal_id']['id'] = 'drupal_id';
 $handler->display->display_options['relationships']['drupal_id']['table'] = 'civicrm_contact';
 $handler->display->display_options['relationships']['drupal_id']['field'] = 'drupal_id';
+/* Relationship: CiviCRM Contacts: HRJobContract Contact Work/Home Phone and E-mail Entity */
+$handler->display->display_options['relationships']['hrjc_contact_details']['id'] = 'hrjc_contact_details';
+$handler->display->display_options['relationships']['hrjc_contact_details']['table'] = 'civicrm_contact';
+$handler->display->display_options['relationships']['hrjc_contact_details']['field'] = 'hrjc_contact_details';
 $handler->display->display_options['defaults']['fields'] = FALSE;
-/* Field: CiviCRM Phone Details: Phone */
-$handler->display->display_options['fields']['phone']['id'] = 'phone';
-$handler->display->display_options['fields']['phone']['table'] = 'civicrm_phone';
-$handler->display->display_options['fields']['phone']['field'] = 'phone';
-$handler->display->display_options['fields']['phone']['relationship'] = 'drupal_id';
-$handler->display->display_options['fields']['phone']['label'] = 'Personal Phone';
-$handler->display->display_options['fields']['phone']['location_type'] = '1';
-$handler->display->display_options['fields']['phone']['location_op'] = '0';
-$handler->display->display_options['fields']['phone']['is_primary'] = 0;
-$handler->display->display_options['fields']['phone']['phone_type'] = '1';
-/* Field: CiviCRM Email: Email Address */
-$handler->display->display_options['fields']['email']['id'] = 'email';
-$handler->display->display_options['fields']['email']['table'] = 'civicrm_email';
-$handler->display->display_options['fields']['email']['field'] = 'email';
-$handler->display->display_options['fields']['email']['label'] = 'Personal Email';
-$handler->display->display_options['fields']['email']['location_type'] = '1';
-$handler->display->display_options['fields']['email']['location_op'] = '0';
-$handler->display->display_options['fields']['email']['is_primary'] = 0;
+/* Field: HRJobContract Contact Work/Home Phone and E-mail Entity: Home_phone */
+$handler->display->display_options['fields']['home_phone']['id'] = 'home_phone';
+$handler->display->display_options['fields']['home_phone']['table'] = 'hrjc_contact_details';
+$handler->display->display_options['fields']['home_phone']['field'] = 'home_phone';
+$handler->display->display_options['fields']['home_phone']['relationship'] = 'hrjc_contact_details';
+$handler->display->display_options['fields']['home_phone']['label'] = 'Personal Phone';
+/* Field: HRJobContract Contact Work/Home Phone and E-mail Entity: Home_email */
+$handler->display->display_options['fields']['home_email']['id'] = 'home_email';
+$handler->display->display_options['fields']['home_email']['table'] = 'hrjc_contact_details';
+$handler->display->display_options['fields']['home_email']['field'] = 'home_email';
+$handler->display->display_options['fields']['home_email']['relationship'] = 'hrjc_contact_details';
+$handler->display->display_options['fields']['home_email']['label'] = 'Personal E-mail';
 /* Field: CiviCRM Address: Full Street Address */
 $handler->display->display_options['fields']['street_address']['id'] = 'street_address';
 $handler->display->display_options['fields']['street_address']['table'] = 'civicrm_address';
@@ -319,6 +330,10 @@ $handler->display->display_options['relationships']['role_jobcontract_id']['id']
 $handler->display->display_options['relationships']['role_jobcontract_id']['table'] = 'hrjc_revision';
 $handler->display->display_options['relationships']['role_jobcontract_id']['field'] = 'role_jobcontract_id';
 $handler->display->display_options['relationships']['role_jobcontract_id']['relationship'] = 'hrjc_revision';
+/* Relationship: CiviCRM Contacts: HRJobContract Contact Work/Home Phone and E-mail Entity */
+$handler->display->display_options['relationships']['hrjc_contact_details']['id'] = 'hrjc_contact_details';
+$handler->display->display_options['relationships']['hrjc_contact_details']['table'] = 'civicrm_contact';
+$handler->display->display_options['relationships']['hrjc_contact_details']['field'] = 'hrjc_contact_details';
 $handler->display->display_options['defaults']['fields'] = FALSE;
 /* Field: CiviCRM Contacts: Contact ID */
 $handler->display->display_options['fields']['id']['id'] = 'id';
@@ -330,40 +345,30 @@ $handler->display->display_options['fields']['display_name']['table'] = 'civicrm
 $handler->display->display_options['fields']['display_name']['field'] = 'display_name';
 $handler->display->display_options['fields']['display_name']['label'] = 'Display name';
 $handler->display->display_options['fields']['display_name']['link_to_civicrm_contact'] = 0;
-/* Field: CiviCRM Phone Details: Phone */
-$handler->display->display_options['fields']['phone']['id'] = 'phone';
-$handler->display->display_options['fields']['phone']['table'] = 'civicrm_phone';
-$handler->display->display_options['fields']['phone']['field'] = 'phone';
-$handler->display->display_options['fields']['phone']['label'] = 'Work phone';
-$handler->display->display_options['fields']['phone']['exclude'] = TRUE;
-$handler->display->display_options['fields']['phone']['location_type'] = '2';
-$handler->display->display_options['fields']['phone']['location_op'] = '0';
-$handler->display->display_options['fields']['phone']['is_primary'] = 0;
-$handler->display->display_options['fields']['phone']['phone_type'] = '1';
-/* Field: CiviCRM Phone Details: Phone Number Extension */
-$handler->display->display_options['fields']['phone_ext']['id'] = 'phone_ext';
-$handler->display->display_options['fields']['phone_ext']['table'] = 'civicrm_phone';
-$handler->display->display_options['fields']['phone_ext']['field'] = 'phone_ext';
-$handler->display->display_options['fields']['phone_ext']['label'] = 'Work Phone Extension';
-$handler->display->display_options['fields']['phone_ext']['exclude'] = TRUE;
-$handler->display->display_options['fields']['phone_ext']['location_type'] = '2';
-$handler->display->display_options['fields']['phone_ext']['location_op'] = '0';
-$handler->display->display_options['fields']['phone_ext']['is_primary'] = 0;
-$handler->display->display_options['fields']['phone_ext']['phone_type'] = '1';
+/* Field: HRJobContract Contact Work/Home Phone and E-mail Entity: Work_phone */
+$handler->display->display_options['fields']['work_phone']['id'] = 'work_phone';
+$handler->display->display_options['fields']['work_phone']['table'] = 'hrjc_contact_details';
+$handler->display->display_options['fields']['work_phone']['field'] = 'work_phone';
+$handler->display->display_options['fields']['work_phone']['relationship'] = 'hrjc_contact_details';
+$handler->display->display_options['fields']['work_phone']['exclude'] = TRUE;
+/* Field: HRJobContract Contact Work/Home Phone and E-mail Entity: Work_phone_ext */
+$handler->display->display_options['fields']['work_phone_ext']['id'] = 'work_phone_ext';
+$handler->display->display_options['fields']['work_phone_ext']['table'] = 'hrjc_contact_details';
+$handler->display->display_options['fields']['work_phone_ext']['field'] = 'work_phone_ext';
+$handler->display->display_options['fields']['work_phone_ext']['relationship'] = 'hrjc_contact_details';
+$handler->display->display_options['fields']['work_phone_ext']['exclude'] = TRUE;
 /* Field: Global: Custom text */
 $handler->display->display_options['fields']['nothing_1']['id'] = 'nothing_1';
 $handler->display->display_options['fields']['nothing_1']['table'] = 'views';
 $handler->display->display_options['fields']['nothing_1']['field'] = 'nothing';
 $handler->display->display_options['fields']['nothing_1']['label'] = 'Work Phone';
-$handler->display->display_options['fields']['nothing_1']['alter']['text'] = '[phone] ext. [phone_ext]';
-/* Field: CiviCRM Email: Email Address */
-$handler->display->display_options['fields']['email']['id'] = 'email';
-$handler->display->display_options['fields']['email']['table'] = 'civicrm_email';
-$handler->display->display_options['fields']['email']['field'] = 'email';
-$handler->display->display_options['fields']['email']['label'] = 'Work Email';
-$handler->display->display_options['fields']['email']['location_type'] = '2';
-$handler->display->display_options['fields']['email']['location_op'] = '0';
-$handler->display->display_options['fields']['email']['is_primary'] = 0;
+$handler->display->display_options['fields']['nothing_1']['alter']['text'] = '[work_phone] ext. [work_phone_ext]';
+/* Field: HRJobContract Contact Work/Home Phone and E-mail Entity: Work_email */
+$handler->display->display_options['fields']['work_email']['id'] = 'work_email';
+$handler->display->display_options['fields']['work_email']['table'] = 'hrjc_contact_details';
+$handler->display->display_options['fields']['work_email']['field'] = 'work_email';
+$handler->display->display_options['fields']['work_email']['relationship'] = 'hrjc_contact_details';
+$handler->display->display_options['fields']['work_email']['label'] = 'Work Email';
 /* Field: CiviCRM Contacts: Birth Date */
 $handler->display->display_options['fields']['birth_date']['id'] = 'birth_date';
 $handler->display->display_options['fields']['birth_date']['table'] = 'civicrm_contact';
@@ -372,23 +377,18 @@ $handler->display->display_options['fields']['birth_date']['label'] = 'Date of b
 $handler->display->display_options['fields']['birth_date']['date_format'] = 'custom';
 $handler->display->display_options['fields']['birth_date']['custom_date_format'] = 'd.m.Y';
 $handler->display->display_options['fields']['birth_date']['second_date_format'] = 'long';
-/* Field: CiviCRM Phone Details: Phone */
-$handler->display->display_options['fields']['phone_1']['id'] = 'phone_1';
-$handler->display->display_options['fields']['phone_1']['table'] = 'civicrm_phone';
-$handler->display->display_options['fields']['phone_1']['field'] = 'phone';
-$handler->display->display_options['fields']['phone_1']['label'] = 'Personal Phone';
-$handler->display->display_options['fields']['phone_1']['location_type'] = '1';
-$handler->display->display_options['fields']['phone_1']['location_op'] = '0';
-$handler->display->display_options['fields']['phone_1']['is_primary'] = 0;
-$handler->display->display_options['fields']['phone_1']['phone_type'] = '1';
-/* Field: CiviCRM Email: Email Address */
-$handler->display->display_options['fields']['email_1']['id'] = 'email_1';
-$handler->display->display_options['fields']['email_1']['table'] = 'civicrm_email';
-$handler->display->display_options['fields']['email_1']['field'] = 'email';
-$handler->display->display_options['fields']['email_1']['label'] = 'Personal Email';
-$handler->display->display_options['fields']['email_1']['location_type'] = '1';
-$handler->display->display_options['fields']['email_1']['location_op'] = '0';
-$handler->display->display_options['fields']['email_1']['is_primary'] = 0;
+/* Field: HRJobContract Contact Work/Home Phone and E-mail Entity: Home_phone */
+$handler->display->display_options['fields']['home_phone']['id'] = 'home_phone';
+$handler->display->display_options['fields']['home_phone']['table'] = 'hrjc_contact_details';
+$handler->display->display_options['fields']['home_phone']['field'] = 'home_phone';
+$handler->display->display_options['fields']['home_phone']['relationship'] = 'hrjc_contact_details';
+$handler->display->display_options['fields']['home_phone']['label'] = 'Personal Phone';
+/* Field: HRJobContract Contact Work/Home Phone and E-mail Entity: Home_email */
+$handler->display->display_options['fields']['home_email']['id'] = 'home_email';
+$handler->display->display_options['fields']['home_email']['table'] = 'hrjc_contact_details';
+$handler->display->display_options['fields']['home_email']['field'] = 'home_email';
+$handler->display->display_options['fields']['home_email']['relationship'] = 'hrjc_contact_details';
+$handler->display->display_options['fields']['home_email']['label'] = 'Personal Email';
 /* Field: CiviCRM Address: Full Street Address */
 $handler->display->display_options['fields']['street_address']['id'] = 'street_address';
 $handler->display->display_options['fields']['street_address']['table'] = 'civicrm_address';
@@ -546,11 +546,14 @@ $translatables['my_details_block'] = array(
   t('Emergency Contact'),
   t('My details'),
   t('HRJobContract Role entity'),
+  t('HRJobContract Contact Work/Home Phone and E-mail Entity'),
   t('Name'),
   t('Work Phone'),
   t('Work Phone Extension'),
-  t('[phone] ext. [phone_ext]'),
-  t('Work Email'),
+  t('Work_phone'),
+  t('Work_phone_ext'),
+  t('[work_phone] ext. [work_phone_ext]'),
+  t('Work E-mail'),
   t('Designation'),
   t('Location'),
   t('Role title'),
@@ -559,7 +562,7 @@ $translatables['my_details_block'] = array(
   t('My address'),
   t('My Address Block'),
   t('Personal Phone'),
-  t('Personal Email'),
+  t('Personal E-mail'),
   t('Address'),
   t('Address Line 2'),
   t('City / Suburb'),
@@ -569,8 +572,9 @@ $translatables['my_details_block'] = array(
   t('My details (full)'),
   t('My Details'),
   t('Display name'),
-  t('Work phone'),
+  t('Work Email'),
   t('Date of birth'),
+  t('Personal Email'),
   t('Full Street Address'),
   t('Supplemental Street Address'),
   t('[street_address] <br />
@@ -590,5 +594,3 @@ $translatables['my_details_block'] = array(
   t('Notes'),
   t('Dependant(s)'),
 );
-
-

--- a/civihr_employee_portal/views/views_export/views_my_details_block.inc
+++ b/civihr_employee_portal/views/views_export/views_my_details_block.inc
@@ -106,37 +106,19 @@ $handler->display->display_options['fields']['display_name']['table'] = 'civicrm
 $handler->display->display_options['fields']['display_name']['field'] = 'display_name';
 $handler->display->display_options['fields']['display_name']['label'] = 'Name';
 $handler->display->display_options['fields']['display_name']['link_to_civicrm_contact'] = 0;
-/* Field: CiviCRM Phone Details: Phone */
-$handler->display->display_options['fields']['phone']['id'] = 'phone';
-$handler->display->display_options['fields']['phone']['table'] = 'civicrm_phone';
-$handler->display->display_options['fields']['phone']['field'] = 'phone';
-$handler->display->display_options['fields']['phone']['label'] = 'Work Phone';
-$handler->display->display_options['fields']['phone']['exclude'] = TRUE;
-$handler->display->display_options['fields']['phone']['location_type'] = '2';
-$handler->display->display_options['fields']['phone']['location_op'] = '0';
-$handler->display->display_options['fields']['phone']['is_primary'] = 0;
-$handler->display->display_options['fields']['phone']['phone_type'] = '1';
-/* Field: CiviCRM Phone Details: Phone Number Extension */
-$handler->display->display_options['fields']['phone_ext']['id'] = 'phone_ext';
-$handler->display->display_options['fields']['phone_ext']['table'] = 'civicrm_phone';
-$handler->display->display_options['fields']['phone_ext']['field'] = 'phone_ext';
-$handler->display->display_options['fields']['phone_ext']['label'] = 'Work Phone Extension';
-$handler->display->display_options['fields']['phone_ext']['exclude'] = TRUE;
-$handler->display->display_options['fields']['phone_ext']['location_type'] = '2';
-$handler->display->display_options['fields']['phone_ext']['location_op'] = '0';
-$handler->display->display_options['fields']['phone_ext']['is_primary'] = 0;
-$handler->display->display_options['fields']['phone_ext']['phone_type'] = '1';
 /* Field: HRJobContract Contact Work/Home Phone and E-mail Entity: Work_phone */
 $handler->display->display_options['fields']['work_phone']['id'] = 'work_phone';
 $handler->display->display_options['fields']['work_phone']['table'] = 'hrjc_contact_details';
 $handler->display->display_options['fields']['work_phone']['field'] = 'work_phone';
 $handler->display->display_options['fields']['work_phone']['relationship'] = 'hrjc_contact_details';
+$handler->display->display_options['fields']['work_phone']['label'] = 'Work Phone';
 $handler->display->display_options['fields']['work_phone']['exclude'] = TRUE;
 /* Field: HRJobContract Contact Work/Home Phone and E-mail Entity: Work_phone_ext */
 $handler->display->display_options['fields']['work_phone_ext']['id'] = 'work_phone_ext';
 $handler->display->display_options['fields']['work_phone_ext']['table'] = 'hrjc_contact_details';
 $handler->display->display_options['fields']['work_phone_ext']['field'] = 'work_phone_ext';
 $handler->display->display_options['fields']['work_phone_ext']['relationship'] = 'hrjc_contact_details';
+$handler->display->display_options['fields']['work_phone_ext']['label'] = 'Work Phone Extension';
 $handler->display->display_options['fields']['work_phone_ext']['exclude'] = TRUE;
 /* Field: Global: Custom text */
 $handler->display->display_options['fields']['nothing']['id'] = 'nothing';
@@ -350,12 +332,14 @@ $handler->display->display_options['fields']['work_phone']['id'] = 'work_phone';
 $handler->display->display_options['fields']['work_phone']['table'] = 'hrjc_contact_details';
 $handler->display->display_options['fields']['work_phone']['field'] = 'work_phone';
 $handler->display->display_options['fields']['work_phone']['relationship'] = 'hrjc_contact_details';
+$handler->display->display_options['fields']['work_phone']['label'] = 'Work Phone';
 $handler->display->display_options['fields']['work_phone']['exclude'] = TRUE;
 /* Field: HRJobContract Contact Work/Home Phone and E-mail Entity: Work_phone_ext */
 $handler->display->display_options['fields']['work_phone_ext']['id'] = 'work_phone_ext';
 $handler->display->display_options['fields']['work_phone_ext']['table'] = 'hrjc_contact_details';
 $handler->display->display_options['fields']['work_phone_ext']['field'] = 'work_phone_ext';
 $handler->display->display_options['fields']['work_phone_ext']['relationship'] = 'hrjc_contact_details';
+$handler->display->display_options['fields']['work_phone_ext']['label'] = 'Work Phone Extension';
 $handler->display->display_options['fields']['work_phone_ext']['exclude'] = TRUE;
 /* Field: Global: Custom text */
 $handler->display->display_options['fields']['nothing_1']['id'] = 'nothing_1';
@@ -550,8 +534,6 @@ $translatables['my_details_block'] = array(
   t('Name'),
   t('Work Phone'),
   t('Work Phone Extension'),
-  t('Work_phone'),
-  t('Work_phone_ext'),
   t('[work_phone] ext. [work_phone_ext]'),
   t('Work E-mail'),
   t('Designation'),

--- a/civihr_hrjobcontract_entities/civihr_hrjobcontract_entities.module
+++ b/civihr_hrjobcontract_entities/civihr_hrjobcontract_entities.module
@@ -1196,4 +1196,3 @@ function civihr_hrjobcontract_entities_views_api() {
     );
 }
 
-

--- a/civihr_hrjobcontract_entities/civihr_hrjobcontract_entities.module
+++ b/civihr_hrjobcontract_entities/civihr_hrjobcontract_entities.module
@@ -251,6 +251,43 @@ function civihr_hrjobcontract_entities_init() {
                     WHERE c.deleted = 0
                     ORDER BY t.job_contract_id");
 
+
+        db_query('DROP VIEW IF EXISTS hrjc_contact_details');
+        db_query("CREATE OR REPLACE VIEW hrjc_contact_details AS
+          SELECT c.id AS contact_id,
+            GROUP_CONCAT(DISTINCT CASE WHEN phone_location.name = 'Work' THEN c_phone.phone ELSE '' END
+              ORDER BY c_phone.phone DESC SEPARATOR ' ') AS work_phone,
+            GROUP_CONCAT(DISTINCT CASE WHEN phone_location.name = 'Work' THEN c_phone.phone_ext ELSE '' END 
+              ORDER BY c_phone.phone_ext DESC SEPARATOR ' ') AS work_phone_ext,
+            GROUP_CONCAT(DISTINCT CASE WHEN email_location.name = 'Work' THEN c_email.email ELSE '' END 
+              ORDER BY c_email.email DESC SEPARATOR ' ') AS work_email,
+
+            GROUP_CONCAT(DISTINCT CASE WHEN phone_location.name = 'Home' THEN c_phone.phone ELSE '' END
+              ORDER BY c_phone.phone DESC SEPARATOR ' ') AS home_phone,
+            GROUP_CONCAT(DISTINCT CASE WHEN phone_location.name = 'Home' THEN c_phone.phone_ext ELSE '' END 
+              ORDER BY c_phone.phone_ext DESC SEPARATOR ' ') AS home_phone_ext,
+            GROUP_CONCAT(DISTINCT CASE WHEN email_location.name = 'Home' THEN c_email.email ELSE '' END 
+              ORDER BY c_email.email DESC SEPARATOR ' ') AS home_email
+
+          FROM {$civi_db_name}.civicrm_contact c
+          LEFT JOIN {$civi_db_name}.civicrm_phone c_phone ON c_phone.contact_id = c.id
+          LEFT JOIN {$civi_db_name}.civicrm_location_type phone_location ON (
+            c_phone.location_type_id = phone_location.id
+            AND (phone_location.name = 'Work' OR phone_location.name = 'Home')
+          )
+          LEFT JOIN {$civi_db_name}.civicrm_email c_email ON c_email.contact_id = c.id
+          LEFT JOIN {$civi_db_name}.civicrm_location_type email_location ON (
+            c_email.location_type_id = email_location.id
+            AND (email_location.name = 'Work' OR email_location.name = 'Home')
+          )
+
+          WHERE phone_location.name = 'Work'
+          OR email_location.name = 'Work'
+          OR phone_location.name = 'Home'
+          OR email_location.name = 'Home'
+          GROUP BY contact_id
+        ");
+
         variable_set('rebuild_hrjobcontract_entities_view', 'FALSE');
     }
 }
@@ -259,7 +296,6 @@ function civihr_hrjobcontract_entities_init() {
  * Implements hook_schema_alter().
  */
 function civihr_hrjobcontract_entities_schema_alter(&$schema) {
-
     // Revision:
     $schema['hrjc_revision']['description'] = 'Views data associated with Job Contract Revision';
     $schema['hrjc_revision']['fields']['contact_id'] = array(
@@ -893,6 +929,43 @@ function civihr_hrjobcontract_entities_schema_alter(&$schema) {
     );
     $schema['hrjc_role']['primary key'] = array('jobcontract_id');
 
+  // Phone Contact Details: hrjc_contact_details
+    $schema['hrjc_contact_details']['description'] = 'Views work/home phone and e-mail data associated with Contact';
+    $schema['hrjc_contact_details']['fields']['contact_id'] = array(
+      'type' => 'int',
+      'not null' => TRUE,
+      'description' => 'Contact ID.',
+    );
+    $schema['hrjc_contact_details']['fields']['work_phone'] = array(
+      'type' => 'varchar',
+      'not null' => FALSE,
+      'description' => 'Work phone number.',
+    );
+    $schema['hrjc_contact_details']['fields']['work_phone_ext'] = array(
+      'type' => 'varchar',
+      'not null' => FALSE,
+      'description' => 'Work phone extension.',
+    );
+    $schema['hrjc_contact_details']['fields']['work_email'] = array(
+      'type' => 'varchar',
+      'not null' => FALSE,
+      'description' => 'Work e-mail.',
+    );
+    $schema['hrjc_contact_details']['fields']['home_phone'] = array(
+      'type' => 'varchar',
+      'not null' => FALSE,
+      'description' => 'Home phone number.',
+    );
+    $schema['hrjc_contact_details']['fields']['home_phone_ext'] = array(
+      'type' => 'varchar',
+      'not null' => FALSE,
+      'description' => 'Home phone extension.',
+    );
+    $schema['hrjc_contact_details']['fields']['home_email'] = array(
+      'type' => 'varchar',
+      'not null' => FALSE,
+      'description' => 'Home e-mail.',
+    );
 }
 
 /**
@@ -1053,6 +1126,25 @@ function civihr_hrjobcontract_entities_entity_info() {
         'module' => 'civicrm',// 'civihr_hrjobcontract_entities',
     );
 
+    $info['hrjobcontract_contact_info'] = array(
+      'label' => t('HRJobContract Contact Work/Home Phone and E-mail Entity'),
+      'plural label' => t('HRJobContract Contact Work/Home Phone and E-mail Entity'),
+      'description' => t('HRJobContract Contact Work/Home Phone and E-mail Entity.'),
+      'entity class' => 'Entity',
+      'controller class' => 'EntityAPIController',
+      'views controller class' => 'EntityDefaultViewsController',
+      'base table' => 'hrjc_contact_details',
+      'fieldable' => TRUE,
+      'entity keys' => array(
+          'id' => 'id',
+          'label' => 'Contact ID'
+      ),
+      'bundles' => array(),
+      'label callback' => 'entity_class_label',
+      'uri callback' => 'entity_class_uri',
+      'module' => 'civicrm',
+    );
+
     return $info;
 }
 
@@ -1090,6 +1182,8 @@ function civihr_hrjobcontract_entities_entity_property_info_alter(&$info) {
     $info['civihr_absence_activity']['properties']['absence_contact_id']['type'] = 'civicrm_contact';
     $info['civihr_length_of_service']['properties']['entity_id']['type'] = 'civicrm_contact';
 
+    // Properties for phone
+    $info['hrjobcontract_contact_info']['properties']['contact_id']['type'] = 'civicrm_contact';
 }
 
 /**
@@ -1101,3 +1195,5 @@ function civihr_hrjobcontract_entities_views_api() {
         'path' => drupal_get_path('module', 'civihr_hrjobcontract_entities') . '/views',
     );
 }
+
+


### PR DESCRIPTION
## Problem
E-mail and phone data shown on My Details view and Staff Directory view was being queried from database using ID's for location that were hard-coded on the views.  This meant if the ID's changed for any reason, information for contacts was lost on those views.

### Staff Directory - Before
![staff-before](https://cloud.githubusercontent.com/assets/21999940/22133540/c89acce8-de8e-11e6-8c2e-81424ca02999.png)

### Dashboard - Before
![dashboard-before](https://cloud.githubusercontent.com/assets/21999940/22133557/f2bdf7de-de8e-11e6-9af8-c1a7f7c9edb4.png)

### My Details - Before
![mydetails-before](https://cloud.githubusercontent.com/assets/21999940/22133546/d7906b18-de8e-11e6-99c2-63432c8a3f20.png)

## Solution
Fixed by creating a CiviHR entity built on a database view that queries work and home e-mail and phone information using location names instead of ID's.

### Staff Directory - After
![staff-after](https://cloud.githubusercontent.com/assets/21999940/22133587/2865da3c-de8f-11e6-998e-577a80988709.png)

### Dashboard - After
![dashboard-after](https://cloud.githubusercontent.com/assets/21999940/22133596/320a5ebe-de8f-11e6-8626-9a535a4d2c00.png)

### My Details - After
![mydetails-after](https://cloud.githubusercontent.com/assets/21999940/22133611/472f3058-de8f-11e6-9a98-08dbb1f7eb12.png)
