### PR TITLE
PCHR-1782: Use Human Readable Time Intervals for Length of Service

### DIFF
--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -207,55 +207,96 @@
       }
 
       // Altering Employee length of service data to show number of days into
-      // String format of Year Months and days of length of service.
-      // Finding the field called Employee length of service.
-      if($(this).find('h4').text().indexOf("Employee length of service (") >= 0 ) {
+      // String format of Year, Months and Days of length of service.
+      if(that.lengthOfServiceFilter(this)) {
          // Iterating through all the filter values.
-        $(this).find('p.chr_custom-checkbox').each(function(i){
+        $(this).find('p.chr_custom-checkbox').each(function(i) {
           // Skip the Select All checkbox from filters.
-          if (!$(this).hasClass("pvtFilterSelectAllWrap")){
-            // Fetching the Employee length of service from filter values.
-            var employee_length_service = $(this).find('span:first').text();
-            // Replacing with format string calling function as parameter.
-            $(this).find('span:first').text(that.formatLengthsOfService(employee_length_service));
+          if (!$(this).hasClass("pvtFilterSelectAllWrap")) {
+            that.lengthOfServiceValue(this);
           }
         });
       }
-
     });
   };
 
+  /*
+   * Finding the filter box for field Employee length of service.
+   *
+   *  @param {string} filter_data
+   *
+   *  @return {bool}
+   */
+  HRReport.prototype.lengthOfServiceFilter = function(filter_data) {
+    if($(filter_data).find('h4').text().indexOf("Employee length of service (") >= 0) {
+      return true;
+    }
+    return false;
+  }
+
+  /*
+   * Finding and replacing the value of Employee length of service.
+   *
+   *  @param {string} filter_selector - DOM element that has value.
+   */
+  HRReport.prototype.lengthOfServiceValue = function(filter_selector) {
+    var that = this;
+    // Fetching the Employee length of service from filter values.
+    var employee_length_service = $(filter_selector).find('span:first').text();
+    if($.isNumeric(employee_length_service)) {
+      $(filter_selector).find('span:first').text(that.formatLengthsOfService(employee_length_service));
+    }
+  }
+  
   /**
    * Processes results in people report view to format length of service for each
    * contact in a human readable form.
    *
-   * @param employee_length_service
+   * @param {string} employee_length_service - Employee length of service field value.
    *
-   * @returns string
-   *
+   * @returns {string} date_string - Date format string for provide length of service.
    */
   HRReport.prototype.formatLengthsOfService = function (employee_length_service) {
 
     var date_current = new Date();
-    var utime_target = date_current.getTime() + employee_length_service*86400*1000;
+    // Calculating unix timestamp from current time adding length of service.
+    var utime_target = date_current.getTime() + employee_length_service * (24*60*60) * 1000;
     var date_target = new Date(utime_target);
 
+    // Getting difference of Dates in integer between current and target date.
     var diff_year  = parseInt(date_target.getUTCFullYear() - date_current.getUTCFullYear());
     var diff_month = parseInt(date_target.getUTCMonth() - date_current.getUTCMonth());
     var diff_day   = parseInt(date_target.getUTCDate() - date_current.getUTCDate());
 
-    var days_in_month = [31, (date_target.getUTCFullYear()%4?29:28), 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    // Checking and assigning values for days in month considering leap year.
+    var days_in_month = [31, (date_target.getUTCFullYear() % 4 ? 28 : 29), 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
     var date_string = "";
-    while(true)
-    {
+
+    while(true) {
+      var date_noun;
       date_string = "";
-      date_string += (diff_year>0?diff_year + " years ":"");
 
-      if(diff_month<0){diff_year -= 1; diff_month += 12; continue;}
-      date_string += (diff_month>0?diff_month + " months ":"");
+      // Checking for singular or plural for year string.
+      diff_year > 1 ? date_noun = "s" : date_noun = "";
+      date_string += (diff_year > 0 ? diff_year + " year" + date_noun + " " : "");
 
-      if(diff_day<0){diff_month -= 1; diff_day += days_in_month[((11+date_target.getUTCMonth())%12)]; continue;}
-      date_string += (diff_day>0?diff_day + " days ":"");
+      if(diff_month < 0) {
+        diff_year -= 1;
+        diff_month += 12;
+        continue;
+      }
+      // Checking for singular or plural for month string.
+      diff_month > 1 ? date_noun = "s" : date_noun = "";
+      date_string += (diff_month > 0 ? diff_month + " month" + date_noun + " " : "");
+
+      if(diff_day < 0) {
+        diff_month -= 1;
+        diff_day += days_in_month[diff_month];
+        continue;
+      }
+      // Checking for singular or plural for day string.
+      diff_day > 1 ? date_noun = "s" : date_noun = "";
+      date_string += (diff_day > 0 ? diff_day + " day" + date_noun + " " : "");
       break;
     }
 

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -187,6 +187,8 @@
    *
    */
   HRReport.prototype.updateFilterbox = function() {
+
+    var that = this;
     $('.pvtFilterBox').each(function () {
       $(this).find('.pvtSearch').removeClass('pvtSearch').addClass('form-text');
       $(this).find('button').addClass('btn btn-primary btn-default btn-block');
@@ -203,7 +205,61 @@
 
         $(this).find('.pvtCheckContainer p').addClass('chr_custom-checkbox');
       }
+
+      // Altering Employee length of service data to show number of days into
+      // String format of Year Months and days of length of service.
+      // Finding the field called Employee length of service.
+      if($(this).find('h4').text().indexOf("Employee length of service (") >= 0 ) {
+         // Iterating through all the filter values.
+        $(this).find('p.chr_custom-checkbox').each(function(i){
+          // Skip the Select All checkbox from filters.
+          if (!$(this).hasClass("pvtFilterSelectAllWrap")){
+            // Fetching the Employee length of service from filter values.
+            var employee_length_service = $(this).find('span:first').text();
+            // Replacing with format string calling function as parameter.
+            $(this).find('span:first').text(that.formatLengthsOfService(employee_length_service));
+          }
+        });
+      }
+
     });
+  };
+
+  /**
+   * Processes results in people report view to format length of service for each
+   * contact in a human readable form.
+   *
+   * @param employee_length_service
+   *
+   * @returns string
+   *
+   */
+  HRReport.prototype.formatLengthsOfService = function (employee_length_service) {
+
+    var date_current = new Date();
+    var utime_target = date_current.getTime() + employee_length_service*86400*1000;
+    var date_target = new Date(utime_target);
+
+    var diff_year  = parseInt(date_target.getUTCFullYear() - date_current.getUTCFullYear());
+    var diff_month = parseInt(date_target.getUTCMonth() - date_current.getUTCMonth());
+    var diff_day   = parseInt(date_target.getUTCDate() - date_current.getUTCDate());
+
+    var days_in_month = [31, (date_target.getUTCFullYear()%4?29:28), 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    var date_string = "";
+    while(true)
+    {
+      date_string = "";
+      date_string += (diff_year>0?diff_year + " years ":"");
+
+      if(diff_month<0){diff_year -= 1; diff_month += 12; continue;}
+      date_string += (diff_month>0?diff_month + " months ":"");
+
+      if(diff_day<0){diff_month -= 1; diff_day += days_in_month[((11+date_target.getUTCMonth())%12)]; continue;}
+      date_string += (diff_day>0?diff_day + " days ":"");
+      break;
+    }
+
+    return date_string;
   };
 
   /**

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -250,57 +250,34 @@
   
   /**
    * Processes results in people report view to format length of service for each
-   * contact in a human readable form.
+   * contact in a human readable form using moment lib.
    *
    * @param {string} employee_length_service - Employee length of service field value.
    *
-   * @returns {string} date_string - Date format string for provide length of service.
+   * @returns {string} Date format string for provide length of service.
    */
   HRReport.prototype.formatLengthsOfService = function (employee_length_service) {
-
-    var date_current = new Date();
-    // Calculating unix timestamp from current time adding length of service.
-    var utime_target = date_current.getTime() + employee_length_service * (24*60*60) * 1000;
-    var date_target = new Date(utime_target);
-
-    // Getting difference of Dates in integer between current and target date.
-    var diff_year  = parseInt(date_target.getUTCFullYear() - date_current.getUTCFullYear());
-    var diff_month = parseInt(date_target.getUTCMonth() - date_current.getUTCMonth());
-    var diff_day   = parseInt(date_target.getUTCDate() - date_current.getUTCDate());
-
-    // Checking and assigning values for days in month considering leap year.
-    var days_in_month = [31, (date_target.getUTCFullYear() % 4 ? 28 : 29), 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-    var date_string = "";
-
-    while(true) {
-      var date_noun;
-      date_string = "";
-
-      // Checking for singular or plural for year string.
-      diff_year > 1 ? date_noun = "s" : date_noun = "";
-      date_string += (diff_year > 0 ? diff_year + " year" + date_noun + " " : "");
-
-      if(diff_month < 0) {
-        diff_year -= 1;
-        diff_month += 12;
-        continue;
-      }
-      // Checking for singular or plural for month string.
-      diff_month > 1 ? date_noun = "s" : date_noun = "";
-      date_string += (diff_month > 0 ? diff_month + " month" + date_noun + " " : "");
-
-      if(diff_day < 0) {
-        diff_month -= 1;
-        diff_day += days_in_month[diff_month];
-        continue;
-      }
-      // Checking for singular or plural for day string.
-      diff_day > 1 ? date_noun = "s" : date_noun = "";
-      date_string += (diff_day > 0 ? diff_day + " day" + date_noun + " " : "");
-      break;
+    var dateEnd = moment();
+    var dateStart = moment().subtract(employee_length_service, 'days');
+    if (!dateStart || !dateEnd) {
+      return null;
     }
 
-    return date_string;
+    var days, months, m, years;
+
+    m = moment(dateEnd);
+    years = m.diff(dateStart, 'years');
+
+    m.add(-years, 'years');
+    months = m.diff(dateStart, 'months');
+
+    m.add(-months, 'months');
+    days = m.diff(dateStart, 'days');
+
+    years = years > 0  ? (years > 1 ? years + ' years ' : years + ' year ') :  '';
+    months = months > 0 ? (months > 1 ? months + ' months ' : months + ' month ') :  '';
+    days = days > 0 ? (days > 1 ? days + ' days' : days + ' day') : '';
+    return (years + months + days) || '0 days';
   };
 
   /**

--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -1042,18 +1042,14 @@ function formatLengthsOfService($results) {
   foreach ($results as $key => $currentRecord) {
     if (!empty($currentRecord->civicrm_value_length_of_service_11_length_of_service)) {
       $length = [];
-      
-      $startDate = new \DateTime($currentRecord->hrjc_details_hrjc_revision_period_start_date);
-      
-      $endDate = new \DateTime($currentRecord->hrjc_details_hrjc_revision_period_start_date);
-      $endDate->add(new DateInterval("P{$currentRecord->civicrm_value_length_of_service_11_length_of_service}D"));
-      
-      $interval = $startDate->diff($endDate);
-      
+      $today = new DateTime();
+      $past = (new DateTime())->sub(new DateInterval('P' . $currentRecord->civicrm_value_length_of_service_11_length_of_service . 'D'));
+      $interval = $today->diff($past);
+
       $years = intval($interval->format('%y'));
       $months = intval($interval->format('%m'));
       $days = intval($interval->format('%d'));
-      
+
       if ($years > 0) {
         $length[] = $years > 1 ? "$years years" : "$years year";
       }
@@ -1063,7 +1059,7 @@ function formatLengthsOfService($results) {
       if ($days > 0) {
         $length[] = $days > 1 ? "$days days" : "$days day";
       }
-      
+
       $currentRecord->civicrm_value_length_of_service_11_length_of_service = implode(' ', $length);
     }
   }

--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -1026,7 +1026,7 @@ function civihr_employee_portal_views_pre_render(&$view) {
     $view->result = removeAbsencesForOtherManagers($view->result);
   }
   
-  if ($view->name == "civihr_report_people"  ) {
+  if ($view->name == "civihr_report_people" || $view->name == "civihr_report_leave_and_absence") {
     formatLengthsOfService($view->result);
   }
 }

--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -1025,6 +1025,50 @@ function civihr_employee_portal_views_pre_render(&$view) {
   if ($view->name == "approvals") {
     $view->result = removeAbsencesForOtherManagers($view->result);
   }
+  
+  if ($view->name == "civihr_report_people") {
+    formatLengthsOfService($view->result);
+  }
+}
+
+/**
+ * Processes results in people report view to format length of service for each
+ * contact in a human readable form.
+ * 
+ * @param array $results
+ *   Array of objects (stdClass) that hold data for each contact in people report.
+ */
+function formatLengthsOfService(&$results) {
+  
+  foreach ($results as $key => $currentRecord) {
+    
+    if (!empty($currentRecord->civicrm_value_length_of_service_11_length_of_service)) {
+      $length = [];
+      
+      $startDate = new \DateTime($currentRecord->hrjc_details_hrjc_revision_period_start_date);
+      
+      $endDate = new \DateTime($currentRecord->hrjc_details_hrjc_revision_period_start_date);
+      $endDate->add(new DateInterval("P{$currentRecord->civicrm_value_length_of_service_11_length_of_service}D"));
+      
+      $interval = $startDate->diff($endDate);
+      
+      $years = intval($interval->format('%y'));
+      $months = intval($interval->format('%m'));
+      $days = intval($interval->format('%d'));
+      
+      if ($years > 0) {
+        $length[] = $years > 1 ? "$years years" : "$years year";
+      }
+      if ($months > 0) {
+        $length[] = $months > 1 ? "$months months" : "$months month";
+      }
+      if ($days > 0) {
+        $length[] = $days > 1 ? "$days days" : "$days day";
+      }
+      
+      $currentRecord->civicrm_value_length_of_service_11_length_of_service = implode(' ', $length);
+    }
+  }
 }
 
 /**

--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -1026,7 +1026,7 @@ function civihr_employee_portal_views_pre_render(&$view) {
     $view->result = removeAbsencesForOtherManagers($view->result);
   }
   
-  if ($view->name == "civihr_report_people" && $view->current_display == 'civihr_report_table_people' ) {
+  if ($view->name == "civihr_report_people"  ) {
     formatLengthsOfService($view->result);
   }
 }

--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -1039,9 +1039,7 @@ function civihr_employee_portal_views_pre_render(&$view) {
  *   Array of objects (stdClass) that hold data for each contact in people report.
  */
 function formatLengthsOfService($results) {
-  
   foreach ($results as $key => $currentRecord) {
-    
     if (!empty($currentRecord->civicrm_value_length_of_service_11_length_of_service)) {
       $length = [];
       

--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -1026,7 +1026,7 @@ function civihr_employee_portal_views_pre_render(&$view) {
     $view->result = removeAbsencesForOtherManagers($view->result);
   }
   
-  if ($view->name == "civihr_report_people") {
+  if ($view->name == "civihr_report_people" && $view->current_display == 'civihr_report_table_people' ) {
     formatLengthsOfService($view->result);
   }
 }
@@ -1038,7 +1038,7 @@ function civihr_employee_portal_views_pre_render(&$view) {
  * @param array $results
  *   Array of objects (stdClass) that hold data for each contact in people report.
  */
-function formatLengthsOfService(&$results) {
+function formatLengthsOfService($results) {
   
   foreach ($results as $key => $currentRecord) {
     


### PR DESCRIPTION
## Problem
Length of service in people reports was being shown in number of days since start date of contract. 

![before](https://cloud.githubusercontent.com/assets/21999940/22205640/babe13c8-e145-11e6-8500-3e9bd1bd918f.png)
Pivot table :
<img width="1279" alt="screen shot 2017-01-31 at 2 16 31 pm" src="https://cloud.githubusercontent.com/assets/2689257/22457881/f0303a1a-e7bf-11e6-8cfc-a7d389c1a2a4.png">

## Solution
Implemented human readable format: "%y years %m months %d days", using civihr_employee_portal_views_pre_render hook. Each part of the interval is used only if it is more than zero.  Plurals and singulars for years, month and days are also taken into account in final rendering of length of service.
For Pivot table: its has been handled using updateFilterbox function under report.js to update length of service to proper format.

![after](https://cloud.githubusercontent.com/assets/21999940/22205642/bf3c3484-e145-11e6-8ca7-158cc46bb9b1.png)
Pivot table :
<img width="1279" alt="screen shot 2017-01-31 at 2 09 05 pm" src="https://cloud.githubusercontent.com/assets/2689257/22457885/fe429f8a-e7bf-11e6-993e-aa61ca522a02.png">

