### PR TITLE
PCHR-1857: Changing view field to show Location label for Reports page.

### DIFF
--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.views_default.inc
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.views_default.inc
@@ -563,12 +563,12 @@ Type ID: [activity_type_id] '),
   $handler->display->display_options['fields']['end_reason']['table'] = 'hrjc_details';
   $handler->display->display_options['fields']['end_reason']['field'] = 'end_reason';
   $handler->display->display_options['fields']['end_reason']['relationship'] = 'details_revision_id';
-  /* Field: HRJobContract Details entity: Location */
-  $handler->display->display_options['fields']['location']['id'] = 'location';
-  $handler->display->display_options['fields']['location']['table'] = 'hrjc_details';
-  $handler->display->display_options['fields']['location']['field'] = 'location';
-  $handler->display->display_options['fields']['location']['relationship'] = 'details_revision_id';
-  $handler->display->display_options['fields']['location']['label'] = 'Contract Normal Place of Work';
+  /* Field: HRJobContract Details entity: Location_label */
+  $handler->display->display_options['fields']['location_label']['id'] = 'location_label';
+  $handler->display->display_options['fields']['location_label']['table'] = 'hrjc_details';
+  $handler->display->display_options['fields']['location_label']['field'] = 'location_label';
+  $handler->display->display_options['fields']['location_label']['relationship'] = 'details_revision_id';
+  $handler->display->display_options['fields']['location_label']['label'] = 'Contract Normal Place of Work';
   /* Field: HRJobContract Hour entity: Contract location standard hours */
   $handler->display->display_options['fields']['location_standard_hours']['id'] = 'location_standard_hours';
   $handler->display->display_options['fields']['location_standard_hours']['table'] = 'hrjc_hour';

--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.views_default.inc
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.views_default.inc
@@ -1562,12 +1562,12 @@ Type ID: [activity_type_id] '),
   $handler->display->display_options['fields']['end_reason']['table'] = 'hrjc_details';
   $handler->display->display_options['fields']['end_reason']['field'] = 'end_reason';
   $handler->display->display_options['fields']['end_reason']['relationship'] = 'details_revision_id';
-  /* Field: HRJobContract Details entity: Location */
-  $handler->display->display_options['fields']['location']['id'] = 'location';
-  $handler->display->display_options['fields']['location']['table'] = 'hrjc_details';
-  $handler->display->display_options['fields']['location']['field'] = 'location';
-  $handler->display->display_options['fields']['location']['relationship'] = 'details_revision_id';
-  $handler->display->display_options['fields']['location']['label'] = 'Contract Normal Place of Work';
+  /* Field: HRJobContract Details entity: Location_label */
+  $handler->display->display_options['fields']['location_label']['id'] = 'location_label';
+  $handler->display->display_options['fields']['location_label']['table'] = 'hrjc_details';
+  $handler->display->display_options['fields']['location_label']['field'] = 'location_label';
+  $handler->display->display_options['fields']['location_label']['relationship'] = 'details_revision_id';
+  $handler->display->display_options['fields']['location_label']['label'] = 'Contract Normal Place of Work';
   /* Field: HRJobContract Hour entity: Contract location standard hours */
   $handler->display->display_options['fields']['location_standard_hours']['id'] = 'location_standard_hours';
   $handler->display->display_options['fields']['location_standard_hours']['table'] = 'hrjc_hour';


### PR DESCRIPTION
Problem:
SSP reports pull values instead of labels for Contract Normal place of work field value.

Solution:
1. Reports are shown using CiviHR Reports - People view & CiviHR Report - Leave and Absence, Reports were showing Contract Normal place of work id because it was shown using wrong field type called location.
2. Changed field to Location Label that pulls the Label  ( Contract Normal place of work ) and displays accordingly on Reports page.

Before:
<img width="559" alt="screen shot 2017-01-10 at 15 14 18" src="https://cloud.githubusercontent.com/assets/2689257/22292121/cf21cdf0-e32f-11e6-9b56-fc42a9fa1cea.png">

After:
<img width="1147" alt="screen shot 2017-01-25 at 6 54 56 pm" src="https://cloud.githubusercontent.com/assets/2689257/22292132/d8566f3e-e32f-11e6-9e1a-bb9d90924e09.png">


