### PR TITLE
PCHR-1889: Removing Role contextual filter validation for Reports.

### DIFF
--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.views_default.inc
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.views_default.inc
@@ -1822,44 +1822,6 @@ return date(\'Y-m-d\');';
   $handler->display->display_options['arguments']['period_end_date']['summary_options']['items_per_page'] = '25';
   $handler->display->display_options['arguments']['period_end_date']['civihr_range'] = '>=';
   $handler->display->display_options['arguments']['period_end_date']['civihr_range_empty'] = '1';
-  /* Contextual filter: HRJobContract Role entity: Role start date */
-  $handler->display->display_options['arguments']['role_start_date']['id'] = 'role_start_date';
-  $handler->display->display_options['arguments']['role_start_date']['table'] = 'hrjc_role';
-  $handler->display->display_options['arguments']['role_start_date']['field'] = 'role_start_date';
-  $handler->display->display_options['arguments']['role_start_date']['relationship'] = 'role_jobcontract_id';
-  $handler->display->display_options['arguments']['role_start_date']['default_action'] = 'default';
-  $handler->display->display_options['arguments']['role_start_date']['default_argument_type'] = 'php';
-  $handler->display->display_options['arguments']['role_start_date']['default_argument_options']['code'] = '$date_filter = !empty($_REQUEST[\'between_date_filter\']) ? $_REQUEST[\'between_date_filter\'] : null;
-if (!empty($date_filter[\'value\'])) {
-    $expl = explode(\'/\', $date_filter[\'value\']);
-if (count($expl) === 1) { return $date_filter[\'value\']; }
-    return $expl[2] . \'-\' . $expl[1] . \'-\' . $expl[0];
-}
-return date(\'Y-m-d\');';
-  $handler->display->display_options['arguments']['role_start_date']['summary']['number_of_records'] = '0';
-  $handler->display->display_options['arguments']['role_start_date']['summary']['format'] = 'default_summary';
-  $handler->display->display_options['arguments']['role_start_date']['summary_options']['items_per_page'] = '25';
-  $handler->display->display_options['arguments']['role_start_date']['civihr_range'] = '<=';
-  $handler->display->display_options['arguments']['role_start_date']['civihr_range_empty'] = '0';
-  /* Contextual filter: HRJobContract Role entity: Role end date */
-  $handler->display->display_options['arguments']['role_end_date']['id'] = 'role_end_date';
-  $handler->display->display_options['arguments']['role_end_date']['table'] = 'hrjc_role';
-  $handler->display->display_options['arguments']['role_end_date']['field'] = 'role_end_date';
-  $handler->display->display_options['arguments']['role_end_date']['relationship'] = 'role_jobcontract_id';
-  $handler->display->display_options['arguments']['role_end_date']['default_action'] = 'default';
-  $handler->display->display_options['arguments']['role_end_date']['default_argument_type'] = 'php';
-  $handler->display->display_options['arguments']['role_end_date']['default_argument_options']['code'] = '$date_filter = !empty($_REQUEST[\'between_date_filter\']) ? $_REQUEST[\'between_date_filter\'] : null;
-if (!empty($date_filter[\'value\'])) {
-    $expl = explode(\'/\', $date_filter[\'value\']);
-if (count($expl) === 1) { return $date_filter[\'value\']; }
-    return $expl[2] . \'-\' . $expl[1] . \'-\' . $expl[0];
-}
-return date(\'Y-m-d\');';
-  $handler->display->display_options['arguments']['role_end_date']['summary']['number_of_records'] = '0';
-  $handler->display->display_options['arguments']['role_end_date']['summary']['format'] = 'default_summary';
-  $handler->display->display_options['arguments']['role_end_date']['summary_options']['items_per_page'] = '25';
-  $handler->display->display_options['arguments']['role_end_date']['civihr_range'] = '>=';
-  $handler->display->display_options['arguments']['role_end_date']['civihr_range_empty'] = '1';
   /* Filter criterion: CiviCRM Contacts: Is Deleted */
   $handler->display->display_options['filters']['is_deleted']['id'] = 'is_deleted';
   $handler->display->display_options['filters']['is_deleted']['table'] = 'civicrm_contact';


### PR DESCRIPTION
## Problem:
Report data picks up only staff with active job contract and active role at the same time. If that staff has no roles, or past or future role, they are not picked up in reports data.

## Solution:
1.As the result should include those have active Contract and should not be dependent on any kind of Role entity status we need to remove Role (HRJobContract Role entity) HRJobContract Role entity: Role start date and (HRJobContract Role entity) HRJobContract Role entity: Role end date Contextual Filters validation from view because it always checks for dates of Role regardless of any type of Contract attached to entity so even if people has Active contract and no Active Roles attached it won't show on people list.

2.Removed (HRJobContract Role entity) HRJobContract Role entity: Role start date and (HRJobContract Role entity) HRJobContract Role entity: Role end date from CONTEXTUAL FILTERS.

Example report for person : Mr. Adok Abram
## Before:
![image-2017-01-19-16-12-20-567](https://cloud.githubusercontent.com/assets/2689257/22321398/744395fe-e3ba-11e6-8408-5d65bd1a34e7.png)

## After:
<img width="1275" alt="screen shot 2017-01-26 at 11 26 56 am" src="https://cloud.githubusercontent.com/assets/2689257/22321409/8ceb36de-e3ba-11e6-8512-17935e5264ce.png">
