### PR TITLE
PCHR-1870: Adding destination parameters while user login and redirection.

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5918,14 +5918,14 @@ function civihr_employee_portal_user_login_validate(&$form, &$form_state) {
 }
 
 function civihr_employee_portal_user_login_submit(&$form, &$form_state) {
+  $destination = !empty($_REQUEST['destination']) ? rawurldecode($_REQUEST['destination']) : '';
 
-    $destination = !empty($_REQUEST['destination']) ? $_REQUEST['destination'] : '';
-    if ($form_state['input']['forgot-password']) {
-        user_pass_submit($form, $form_state);
-        _drupal_session_write('custom_login_success_message', t('Details sent!'));
-        drupal_goto($destination);
-        return true;
-    }
+  if ($form_state['input']['forgot-password']) {
+    user_pass_submit($form, $form_state);
+    _drupal_session_write('custom_login_success_message', t('Details sent!'));
+    drupal_goto($destination);
+    return true;
+  }
 }
 
 /**
@@ -5936,10 +5936,10 @@ function civihr_employee_portal_user_login(&$edit, $account) {
   if (!isset($_POST['form_id']) || $_POST['form_id'] != 'user_pass_reset') {
     $sspEntryPath = 'dashboard';
     $civicrmEntryPath = 'civicrm/tasksassignments/dashboard#/tasks';
-    if (current_path() != drupal_get_destination()['destination']) {
-      $civicrmEntryPath = $_GET['destination'];
+
+    if (current_path() == drupal_get_destination()['destination']) {
+      $_GET['destination'] = user_access('access CiviCRM') ? $civicrmEntryPath : $sspEntryPath;
     }
-    $_GET['destination'] = user_access('access CiviCRM') ? $civicrmEntryPath : $sspEntryPath;
   }
 }
 
@@ -7229,6 +7229,7 @@ function _user_redirection() {
   }
 
   $current_path = request_path();
+  $requestURI = rawurlencode(request_uri());
   $user_is_anonymous = $user->uid == 0;
 
   $allowed_paths = [
@@ -7246,7 +7247,7 @@ function _user_redirection() {
       $current_path == 'user/register') {
       $redirect_path = 'welcome-page';
       if ($current_path) {
-        $redirect_path .= "?destination={$current_path}";
+        $redirect_path .= "?destination={$requestURI}";
       }
     }
   }

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5929,12 +5929,17 @@ function civihr_employee_portal_user_login_submit(&$form, &$form_state) {
 }
 
 /**
- * Implements hook_user_login
+ * Implements hook_user_login().
  */
 function civihr_employee_portal_user_login(&$edit, $account) {
-  global $base_url;
+
   if (!isset($_POST['form_id']) || $_POST['form_id'] != 'user_pass_reset') {
-    $_GET['destination'] = user_access('access CiviCRM') ?  'civicrm/tasksassignments/dashboard#/tasks' : 'dashboard';
+    $sspEntryPath = 'dashboard';
+    $civicrmEntryPath = 'civicrm/tasksassignments/dashboard#/tasks';
+    if (current_path() != drupal_get_destination()['destination']) {
+      $civicrmEntryPath = $_GET['destination'];
+    }
+    $_GET['destination'] = user_access('access CiviCRM') ? $civicrmEntryPath : $sspEntryPath;
   }
 }
 
@@ -7240,6 +7245,9 @@ function _user_redirection() {
     if ((!in_array($current_path, $allowed_paths) && substr($current_path, 0, 4) !== 'user') ||
       $current_path == 'user/register') {
       $redirect_path = 'welcome-page';
+      if ($current_path) {
+        $redirect_path .= "?destination={$current_path}";
+      }
     }
   }
   else if (in_array($current_path, ['', 'civicrm', 'civicrm/dashboard'])) {


### PR DESCRIPTION
**Problem**
In civihr after login you always get redirected to T&A dashboard (if you are admin) or SSP (if you don't have access civicrm permission) as required.
This should only happen when entered URL was /. In other cases after successful login user should be redirected to the URL they tried before login page redirect.

**Solution**
Added destination parameter to _user_redirection function that redirects depending upon the user state and permissions. And after login it should redirect to last page they navigated from thats handled using hook  user login function to route to required destination after checking permissions for that page and user.