### PR TITLE
PCHR-1944: Add Toil Credits to Balance in Dashboard's My Leave Block

### DIFF
--- a/civihr_employee_portal/views/includes/civihr_employee_portal_handler_absence_table_header_block_area.inc
+++ b/civihr_employee_portal/views/includes/civihr_employee_portal_handler_absence_table_header_block_area.inc
@@ -98,7 +98,7 @@ class civihr_employee_portal_handler_absence_table_header_block_area extends vie
         $row['type_' . $typeId] = '';
       }
       $row['type_' . $activityAbsenceTypeIds[$absence->absence_list_activity_type_id]] = ($absence->absence_list_is_credit ? '+ ' : '- ') . $amount;
-      $entitlements[$activityAbsenceTypeIds[$absence->absence_list_activity_type_id]] -= $amount;
+      $entitlements[$activityAbsenceTypeIds[$absence->absence_list_activity_type_id]] += ($absence->absence_list_is_credit ? $amount : -$amount);
       $rows[] = $row;
     }
 


### PR DESCRIPTION
## Problem
Toil credits (and all leave credits, for that matter), where being subtracted from entitlement balance in dashboard My Leave block, instead of being added.
![before](https://cloud.githubusercontent.com/assets/21999940/22549914/bc600da2-e91b-11e6-8dfa-ade70c03d35e.png)

## Solution
Fixed by conditionally adding/subtracting amount of days in leave request, depending on if its a credit or debit to entitlement.
![after](https://cloud.githubusercontent.com/assets/21999940/22549929/c3fc9ae4-e91b-11e6-81fb-45159d42dcbb.png)
