### PR TITLE
PCHR-1975: Added new role civihr_admin_local and updated required permissions.

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.install
+++ b/civihr_employee_portal/civihr_employee_portal.install
@@ -91,3 +91,16 @@ function civihr_employee_portal_update_7005() {
   $schema = module_invoke('civihr_employee_portal', 'schema');
   db_create_table('reports_configuration', $schema['reports_configuration']);
 }
+
+/**
+ * Create civihr_admin_local Role for existing sites.
+ */
+function civihr_employee_portal_update_7006() {
+  if (!array_search('civihr_admin_local', user_roles())) {
+    $role = new stdClass();
+    $role->name = 'civihr_admin_local';
+    $role->machine_name = 'civihr_admin_local';
+    user_role_save($role);
+  }
+}
+

--- a/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
+++ b/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
@@ -25,6 +25,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
       'civihr_manager' => 'civihr_manager',
     ),
     'module' => 'civicrm',
@@ -36,6 +37,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -62,6 +64,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -72,6 +75,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -89,6 +93,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -99,6 +104,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -108,6 +114,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'access administration pages',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'system',
   );
@@ -138,6 +145,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'access all views',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'views',
   );
@@ -147,6 +155,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'access all webform results',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'webform',
   );
@@ -168,6 +177,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -189,6 +199,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'node',
   );
@@ -217,6 +228,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -237,6 +249,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
       'civihr_manager' => 'civihr_manager',
       'civihr_staff' => 'civihr_staff',
     ),
@@ -249,6 +262,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
       'civihr_manager' => 'civihr_manager',
     ),
     'module' => 'civihr_employee_portal',
@@ -269,6 +283,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -278,6 +293,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'access own webform results',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'webform',
   );
@@ -287,6 +303,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'access own webform submissions',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'webform',
   );
@@ -297,6 +314,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
       'civihr_manager' => 'civihr_manager',
       'civihr_staff' => 'civihr_staff',
     ),
@@ -308,6 +326,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'access rules debug',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'rules',
   );
@@ -318,6 +337,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'system',
   );
@@ -327,6 +347,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'access site reports',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'system',
   );
@@ -336,6 +357,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'access subpermission form',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'subpermissions',
   );
@@ -345,6 +367,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'access toolbar',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'toolbar',
   );
@@ -355,6 +378,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -364,6 +388,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'access user profiles',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'user',
   );
@@ -374,6 +399,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'administerusersbyrole',
   );
@@ -393,6 +419,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -403,6 +430,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -412,6 +440,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer CiviCRM Entity',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm_entity',
   );
@@ -440,6 +469,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -450,6 +480,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -459,6 +490,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer actions',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'system',
   );
@@ -468,6 +500,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer advanced pane settings',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'panels',
   );
@@ -477,6 +510,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer blocks',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'block',
   );
@@ -486,6 +520,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer browser class',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'browserclass',
   );
@@ -495,6 +530,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer comments',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'comment',
   );
@@ -504,6 +540,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer content types',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'node',
   );
@@ -514,6 +551,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -523,6 +561,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer features',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'features',
   );
@@ -532,6 +571,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer fields',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'field',
   );
@@ -541,6 +581,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer filters',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'filter',
   );
@@ -550,6 +591,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer image styles',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'image',
   );
@@ -559,6 +601,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer languages',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'locale',
   );
@@ -568,6 +611,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer mailsystem',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'mailsystem',
   );
@@ -586,6 +630,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer modules',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'system',
   );
@@ -595,6 +640,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer nodes',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'node',
   );
@@ -604,6 +650,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer page manager',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'page_manager',
   );
@@ -613,6 +660,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer pane access',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'panels',
   );
@@ -622,6 +670,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer panels layouts',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'panels',
   );
@@ -631,6 +680,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer panels styles',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'panels',
   );
@@ -647,6 +697,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer permissions',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'user',
   );
@@ -664,6 +715,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -688,6 +740,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -697,6 +750,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer rules',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'rules',
   );
@@ -706,6 +760,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer search',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'search',
   );
@@ -715,6 +770,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer site configuration',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'system',
   );
@@ -724,6 +780,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer software updates',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'system',
   );
@@ -733,6 +790,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer subpermission',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'subpermissions',
   );
@@ -742,6 +800,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer taxonomy',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'taxonomy',
   );
@@ -751,6 +810,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer themes',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'system',
   );
@@ -760,6 +820,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer tipsy',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'tipsy',
   );
@@ -769,6 +830,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer url aliases',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'path',
   );
@@ -778,6 +840,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer userprotect',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'userprotect',
   );
@@ -788,6 +851,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'user',
   );
@@ -797,6 +861,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer uuid',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'uuid',
   );
@@ -806,6 +871,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer views',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'views',
   );
@@ -815,6 +881,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'assign all roles',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'role_delegation',
   );
@@ -835,6 +902,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'role_delegation',
   );
@@ -845,6 +913,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'role_delegation',
   );
@@ -854,6 +923,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'block IP addresses',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'system',
   );
@@ -863,6 +933,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'bypass node access',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'node',
   );
@@ -872,6 +943,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'bypass rules access',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'rules',
   );
@@ -881,6 +953,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'can create and edit tasks',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civihr_employee_portal',
   );
@@ -890,6 +963,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'cancel account',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'user',
   );
@@ -900,6 +974,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'administerusersbyrole',
   );
@@ -910,6 +985,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'administerusersbyrole',
   );
@@ -930,6 +1006,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'administerusersbyrole',
   );
@@ -939,6 +1016,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'change document status',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civihr_employee_portal',
   );
@@ -948,6 +1026,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'change layouts in place editing',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'panels',
   );
@@ -957,6 +1036,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'change own e-mail',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'userprotect',
   );
@@ -966,6 +1046,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'change own openid',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'userprotect',
   );
@@ -976,6 +1057,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
       'civihr_manager' => 'civihr_manager',
       'civihr_staff' => 'civihr_staff',
     ),
@@ -987,6 +1069,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'change own username',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'user',
   );
@@ -996,6 +1079,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'civicrm_entity.rules.administer',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm_entity',
   );
@@ -1005,6 +1089,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'create article content',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'node',
   );
@@ -1015,6 +1100,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'node',
   );
@@ -1031,6 +1117,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'create page content',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'node',
   );
@@ -1040,6 +1127,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'create url aliases',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'path',
   );
@@ -1050,6 +1138,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'administerusersbyrole',
   );
@@ -1067,6 +1156,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -1077,6 +1167,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -1087,6 +1178,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -1103,6 +1195,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'delete all webform submissions',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'webform',
   );
@@ -1112,6 +1205,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'delete any article content',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'node',
   );
@@ -1122,6 +1216,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'node',
   );
@@ -1131,6 +1226,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'delete any page content',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'node',
   );
@@ -1148,6 +1244,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -1166,6 +1263,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'delete own article content',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'node',
   );
@@ -1176,6 +1274,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'node',
   );
@@ -1192,6 +1291,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'delete own page content',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'node',
   );
@@ -1208,6 +1308,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'delete own webform submissions',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'webform',
   );
@@ -1217,6 +1318,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'delete revisions',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'node',
   );
@@ -1227,6 +1329,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'taxonomy',
   );
@@ -1236,6 +1339,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'delete terms in tags',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'taxonomy',
   );
@@ -1246,6 +1350,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -1256,6 +1361,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -1282,6 +1388,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'edit all webform submissions',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'webform',
   );
@@ -1291,6 +1398,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'edit any article content',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'node',
   );
@@ -1301,6 +1409,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'node',
   );
@@ -1310,6 +1419,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'edit any page content',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'node',
   );
@@ -1326,6 +1436,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'edit api keys',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -1336,6 +1447,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -1345,6 +1457,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'edit message templates',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -1365,6 +1478,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -1384,6 +1498,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'edit own api keys',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -1393,6 +1508,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'edit own article content',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'node',
   );
@@ -1402,6 +1518,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'edit own comments',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'comment',
   );
@@ -1412,6 +1529,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'node',
   );
@@ -1428,6 +1546,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'edit own page content',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'node',
   );
@@ -1444,6 +1563,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'edit own webform submissions',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'webform',
   );
@@ -1454,6 +1574,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'taxonomy',
   );
@@ -1463,6 +1584,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'edit terms in tags',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'taxonomy',
   );
@@ -1473,6 +1595,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'administerusersbyrole',
   );
@@ -1483,6 +1606,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'administerusersbyrole',
   );
@@ -1503,6 +1627,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'administerusersbyrole',
   );
@@ -1512,6 +1637,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'edit webform components',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'webform',
   );
@@ -1522,6 +1648,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -1538,6 +1665,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'export nodes',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'node_export',
   );
@@ -1554,6 +1682,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'export own nodes',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'node_export',
   );
@@ -1572,6 +1701,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'generate features',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'features',
   );
@@ -1582,6 +1712,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -1592,6 +1723,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -1601,6 +1733,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'manage features',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'features',
   );
@@ -1630,6 +1763,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'manage leave and absences in ssp',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civihr_employee_portal',
   );
@@ -1640,6 +1774,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -1650,6 +1785,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -1670,6 +1806,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -1680,6 +1817,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -1690,6 +1828,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -1714,6 +1853,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -1723,6 +1863,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'rename features',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'features',
   );
@@ -1732,6 +1873,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'revert revisions',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'node',
   );
@@ -1741,6 +1883,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'search content',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'search',
   );
@@ -1751,6 +1894,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
       'civihr_manager' => 'civihr_manager',
       'civihr_staff' => 'civihr_staff',
     ),
@@ -1762,6 +1906,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'select account cancellation method',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'user',
   );
@@ -1781,6 +1926,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -1807,6 +1953,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'translate interface',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'locale',
   );
@@ -1816,6 +1963,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'use PHP to import nodes',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'node_export',
   );
@@ -1825,6 +1973,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'use advanced search',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'search',
   );
@@ -1834,6 +1983,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'use ctools import',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'ctools',
   );
@@ -1843,6 +1993,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'use ipe with page manager',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'panels',
   );
@@ -1852,6 +2003,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'use page manager',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'page_manager',
   );
@@ -1861,6 +2013,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'use panels caching features',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'panels',
   );
@@ -1870,6 +2023,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'use panels dashboard',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'panels',
   );
@@ -1879,6 +2033,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'use panels in place editing',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'panels',
   );
@@ -1888,6 +2043,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'use panels locks',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'panels',
   );
@@ -1908,6 +2064,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'use text format full_html',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'filter',
   );
@@ -1918,6 +2075,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -1928,6 +2086,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -1938,6 +2097,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
       'civihr_manager' => 'civihr_manager',
     ),
     'module' => 'civicrm',
@@ -1966,6 +2126,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -1976,6 +2137,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
       'civihr_manager' => 'civihr_manager',
       'civihr_staff' => 'civihr_staff',
     ),
@@ -1988,6 +2150,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'civicrm',
   );
@@ -1998,6 +2161,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
       'civihr_manager' => 'civihr_manager',
       'civihr_staff' => 'civihr_staff',
     ),
@@ -2007,7 +2171,9 @@ function civihr_default_permissions_user_default_permissions() {
   // Exported permission: 'view my contact'.
   $permissions['view my contact'] = array(
     'name' => 'view my contact',
-    'roles' => array(),
+    'roles' => array(
+      'civihr_admin_local' => 'civihr_admin_local',
+    ),
     'module' => 'civicrm',
   );
 
@@ -2017,6 +2183,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
       'civihr_manager' => 'civihr_manager',
       'civihr_staff' => 'civihr_staff',
     ),
@@ -2036,6 +2203,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
       'civihr_manager' => 'civihr_manager',
       'civihr_staff' => 'civihr_staff',
     ),
@@ -2048,6 +2216,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
       'civihr_manager' => 'civihr_manager',
       'civihr_staff' => 'civihr_staff',
     ),
@@ -2060,6 +2229,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
       'civihr_manager' => 'civihr_manager',
       'civihr_staff' => 'civihr_staff',
     ),
@@ -2078,6 +2248,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'view own unpublished content',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'node',
   );
@@ -2087,6 +2258,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'view pane admin links',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'panels',
   );
@@ -2103,6 +2275,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'view revisions',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'node',
   );
@@ -2113,6 +2286,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
       'civihr_manager' => 'civihr_manager',
       'civihr_staff' => 'civihr_staff',
     ),
@@ -2124,6 +2298,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'view the administration theme',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'system',
   );
@@ -2134,6 +2309,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
       'civihr_manager' => 'civihr_manager',
       'civihr_staff' => 'civihr_staff',
     ),

--- a/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_role.inc
+++ b/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_role.inc
@@ -17,6 +17,13 @@ function civihr_default_permissions_user_default_roles() {
     'machine_name' => 'civihr_admin',
   );
 
+  // Exported role: civihr_admin_local.
+  $roles['civihr_admin_local'] = array(
+    'name' => 'civihr_admin_local',
+    'weight' => 6,
+    'machine_name' => 'civihr_admin_local',
+  );
+
   // Exported role: civihr_manager.
   $roles['civihr_manager'] = array(
     'name' => 'civihr_manager',

--- a/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.info
+++ b/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.info
@@ -271,5 +271,6 @@ features[user_permission][] = view staff directory
 features[user_permission][] = view the administration theme
 features[user_permission][] = view vacancies
 features[user_role][] = civihr_admin
+features[user_role][] = civihr_admin_local
 features[user_role][] = civihr_manager
 features[user_role][] = civihr_staff


### PR DESCRIPTION
**Task**
Create civihr_admin_local role for all the new and existing civihr sites as the new default role with required permissions from page https://compucorp.atlassian.net/wiki/display/PCHR/Drupal+permissions+configuration.

**Solution**
1. Created role using hook_update to add to existing sites with the required permissions packaged into default_permissions feature module.
2. For adding new role for all the new civihr sites its handled using buildkit hr16 config https://github.com/civicrm/civicrm-buildkit/pull/303.