### PR TITLE
PCHR-1976: Log State of Periods Cache on Start Date Validation of Leave Request

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -839,39 +839,50 @@ function civihr_employee_portal_views_default_views() {
 }
 
 /**
- * Function for caching date periods returned from CiviCRM (avoiding expensive DB calls for each dashboard page hit)
+ * Function for caching date periods returned from CiviCRM (avoiding expensive 
+ * DB calls for each dashboard page hit)
  */
 function get_civihr_date_periods() {
 
-    $periods_data = &drupal_static(__FUNCTION__);
+  $periods_data = &drupal_static(__FUNCTION__);
 
-    if (!isset($periods_data)) {
-        if ($cache = cache_get('civihr_date_periods')) {
-            $periods_data = $cache->data;
-        }
-        else {
-
-            try {
-
-                // Civi init
-                civicrm_initialize();
-
-                $res = civicrm_api3('HRAbsencePeriod', 'get', array('options' => array('sort' => "start_date DESC")));
-                $periods_data = $res['values'];
-                watchdog('DB hit', 'DB');
-
-            }
-
-            catch (CiviCRM_API3_Exception $e) {
-                $error = $e->getMessage();
-            }
-
-            // Cache the date periods for 5 minutes
-            cache_set('civihr_date_periods', $periods_data, 'cache', time() + 360);
-        }
+  if (!isset($periods_data)) {
+    if ($cache = cache_get('civihr_date_periods')) {
+      $periods_data = $cache->data;
+      watchdog(
+        'CiviHR Period Cache', 
+        'Periods found in cache: <br/><pre>' . print_r($periods_data, true) . '</pre>'
+      );
     }
+    else {
+      try {
+        // Civi init
+        civicrm_initialize();
 
-    return $periods_data;
+        $res = civicrm_api3('HRAbsencePeriod', 'get', ['options' => ['sort' => "start_date DESC"]]);
+        $periods_data = $res['values'];
+        watchdog('DB hit', 'DB');
+      }
+      catch (CiviCRM_API3_Exception $e) {
+          $error = $e->getMessage();
+          watchdog(
+            'CiviHR Period Cache', 
+            "Error obtaining periods from DB: $error ",
+            array(),
+            WATCHDOG_ALERT
+          );
+      }
+
+      // Cache the date periods for 5 minutes
+      cache_set('civihr_date_periods', $periods_data, 'cache', time() + 360);
+      watchdog(
+        'CiviHR Period Cache', 
+        'Periods obtained from DB and stored in cache: <br/><pre>' . print_r($periods_data, true) . '</pre>'
+      );
+    }
+  }
+
+  return $periods_data;
 }
 
 /**

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -873,8 +873,7 @@ function get_civihr_date_periods() {
           );
       }
 
-      // Cache the date periods for 5 minutes
-      cache_set('civihr_date_periods', $periods_data, 'cache', time() + 360);
+      cache_set('civihr_date_periods', $periods_data, 'cache', strtotime('+6 minutes'));
       watchdog(
         'CiviHR Period Cache', 
         'Periods obtained from DB and stored in cache: <br/><pre>' . print_r($periods_data, true) . '</pre>'

--- a/civihr_employee_portal/src/Forms/AbsenceRequestForm.php
+++ b/civihr_employee_portal/src/Forms/AbsenceRequestForm.php
@@ -544,6 +544,15 @@ class AbsenceRequestForm {
             }
         }
 
+        if ($period_id == null) {
+          watchdog(
+            'CiviHR Period Cache', 
+            'Period for ' . implode('-', $start_date) . ' not found in period cache.  Cache data: <br/><pre>' . print_r(get_civihr_date_periods(), true) . '</pre>',
+            array(),
+            WATCHDOG_ALERT
+          );
+        }
+
         return $period_id;
     }
 


### PR DESCRIPTION
On undetermined occasions, trying to add a leave request will show an error message saying "This date period is not yet defined", even if the period for the given start date is properly defined.

Validation of leave request start dates against configured periods in CiviHR is done using data stored in drupal cache, which is built the first time a date is validated and expires every 6 minutes.  Watchdog log calls were added when setting and retrieving the data to cache, and on validation failure of leave request start date, to gain further inisght on the problem and plan a proper solution.