### PR TITLE
PCHR-2075: Make the attachment upload token available in the "My Leave" and "Manager Leave" pages

### DIFF
--- a/civihr_employee_portal/civihr_leave_absences/civihr_leave_absences.module
+++ b/civihr_employee_portal/civihr_leave_absences/civihr_leave_absences.module
@@ -50,7 +50,16 @@ function civihr_leave_absences_block_view($delta = '') {
 function civihr_leave_absences_init() {
   if (!_isCiviCRM()) {
     $baseURL = CRM_Extension_System::singleton()->getMapper()->keyToUrl('uk.co.compucorp.civicrm.hrleaveandabsences');
-    drupal_add_js(array('civihr_leave_absences' => array('baseURL' => $baseURL)), 'setting');
+    $attachmentToken = CRM_Core_Page_AJAX_Attachment::createToken();
+
+    $settings = [
+      'civihr_leave_absences' => [
+        'baseURL' => $baseURL,
+        'attachmentToken' => $attachmentToken
+      ]
+    ];
+    drupal_add_js($settings, 'setting');
+
     _civihr_leave_absences_push_permissions();
   }
 }

--- a/civihr_employee_portal/civihr_leave_absences/templates/manager_leave.html
+++ b/civihr_employee_portal/civihr_leave_absences/templates/manager_leave.html
@@ -6,6 +6,7 @@
   // the expected (by the app) CRM.vars.leaveAndAbsences object
   CRM.vars.leaveAndAbsences = {
     baseURL: Drupal.settings.civihr_leave_absences.baseURL,
-    contactId: Drupal.settings.currentCiviCRMUserId
+    contactId: Drupal.settings.currentCiviCRMUserId,
+    attachmentToken: Drupal.settings.civihr_leave_absences.attachmentToken
   };
 </script>

--- a/civihr_employee_portal/civihr_leave_absences/templates/my_leave.html
+++ b/civihr_employee_portal/civihr_leave_absences/templates/my_leave.html
@@ -6,6 +6,7 @@
   // the expected (by the app) CRM.vars.leaveAndAbsences object
   CRM.vars.leaveAndAbsences = {
     baseURL: Drupal.settings.civihr_leave_absences.baseURL,
-    contactId: Drupal.settings.currentCiviCRMUserId
+    contactId: Drupal.settings.currentCiviCRMUserId,
+    attachmentToken: Drupal.settings.civihr_leave_absences.attachmentToken
   };
 </script>


### PR DESCRIPTION
### Problem

In order to upload files in CiviCRM using the Attachment API and the related callback URL (civicrm/ajax/attachment), we need to pass along an attachment token. This token is created in the backend, using the `CRM_Core_Page_AJAX_Attachment::createToken()` method, but it's not available in the frontend where it's required to send the upload data.

Uploads are necessary to add attachments to the Leave Requests. This can be done in 2 places of the SSP: The "My Leave" and the "Manager Leave" pages. So we need the token available in both.

### Solution
In `civihr_leave_absences_init()`, the attachment token is added to the Drupal settings. In `my-leave.html` and `manager-leave.html`, we fetch the info from the Drupal settings and add it to `CRM.vars.leaveAndAbsences.attachmentToken`