### PR TITLE
PCHR-1890: Fix filtering on staff directory

### DIFF
--- a/civihr_employee_portal/tdd/HelperFunctionsTest.php
+++ b/civihr_employee_portal/tdd/HelperFunctionsTest.php
@@ -1,0 +1,43 @@
+<?php
+
+require_once __DIR__ . '/../views/civihr_employee_portal.views.inc';
+
+class HelperFunctionsTest extends PHPUnit_Framework_TestCase
+{
+  protected $sampleWherePart = [
+    [
+      'conditions' => [
+        [
+          'field' => 'foo1',
+          'value' => 'bar1'
+        ],
+        [
+          'field' => 'foo2',
+          'value' => 'bar2'
+        ],
+      ]
+    ],
+    [
+      'conditions' => [
+        [
+          'field' => 'foo3',
+          'value' => 'bar3'
+        ],
+        [
+          'field' => 'foo4',
+          'value' => 'bar4'
+        ],
+      ]
+    ]
+  ];
+
+  public function testGetWhereParts() {
+    $parts = [];
+    get_where_parts($this->sampleWherePart, $parts);
+    $expectedCount = 4;
+    $this->assertCount($expectedCount, $parts);
+    for ($i = 1; $i < $expectedCount + 1; $i++) {
+      $this->assertEquals('bar' . $i, $parts['foo' . $i]);
+    }
+  }
+}

--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -1144,13 +1144,36 @@ function removeInactiveManagers($results = array()) {
 }
 
 /**
+ * Implements hook_views_query_alter
+ *
+ * @param view $view
+ * @param views_plugin_query_default $query
+ */
+function civihr_employee_portal_views_query_alter(&$view, &$query) {
+  if ($view->name !== 'civihr_staff_directory') {
+    return;
+  }
+
+  $queryParts = array();
+  get_where_fields($query->where, $queryParts);
+  $departmentField = 'hrjc_role_hrjc_revision.role_department';
+  $roleEndField = 'hrjc_role_hrjc_revision.role_end_date';
+
+  // if department is set we must limit to only current roles
+  if (!empty($queryParts[$departmentField])) {
+    $group = $query->set_where_group('OR'); // add a new WHERE group
+    $query->add_where($group, $roleEndField, date('Y-m-d'), '>=');
+    $query->add_where($group, $roleEndField, NULL, 'IS');
+  }
+}
+
+/**
  * Implements hook_views_pre_view().
  * @param $view
  * @param $display_id
  * @param $args
  */
 function civihr_employee_portal_views_pre_view(&$view, &$display_id, &$args) {
-
   // Custom configuration start for items per page
   if (($view->name == 'civihr_staff_directory' && $display_id == 'page') ||
           ($view->name == 'hr_documents' && $display_id == 'hr_resources')) {
@@ -1166,3 +1189,23 @@ function civihr_employee_portal_views_pre_view(&$view, &$display_id, &$args) {
     );
   }
 }
+
+/**
+ * @param mixed $part The $query->where part
+ * @param array $fields An array to store the fields
+ */
+function get_where_fields($part, &$fields) {
+  if (isset($part['conditions'])) {
+    $part = $part['conditions'];
+  }
+  if (isset($part['field']) && $part['field'] instanceof DatabaseCondition){
+    $part = $part['field']->conditions();
+  }
+  if (isset($part['field'])) {
+    $fields[$part['field']] = $part['value'];
+  } elseif (is_array($part)) {
+    foreach ($part as $item) {
+      get_where_fields($item, $fields);
+    }
+  }
+};

--- a/civihr_employee_portal/views/views_export/views_hr_staff_directory.inc
+++ b/civihr_employee_portal/views/views_export/views_hr_staff_directory.inc
@@ -656,19 +656,7 @@ $handler->display->display_options['arguments']['effective_end_date']['summary']
 $handler->display->display_options['arguments']['effective_end_date']['summary_options']['items_per_page'] = '25';
 $handler->display->display_options['arguments']['effective_end_date']['civihr_range'] = '>=';
 $handler->display->display_options['arguments']['effective_end_date']['civihr_range_empty'] = '1';
-/* Contextual filter: HRJobContract Role entity: Role end date */
-$handler->display->display_options['arguments']['role_end_date']['id'] = 'role_end_date';
-$handler->display->display_options['arguments']['role_end_date']['table'] = 'hrjc_role';
-$handler->display->display_options['arguments']['role_end_date']['field'] = 'role_end_date';
-$handler->display->display_options['arguments']['role_end_date']['relationship'] = 'role_jobcontract_id';
-$handler->display->display_options['arguments']['role_end_date']['default_action'] = 'default';
-$handler->display->display_options['arguments']['role_end_date']['default_argument_type'] = 'php';
-$handler->display->display_options['arguments']['role_end_date']['default_argument_options']['code'] = 'return date(\'Y-m-d\');';
-$handler->display->display_options['arguments']['role_end_date']['summary']['number_of_records'] = '0';
-$handler->display->display_options['arguments']['role_end_date']['summary']['format'] = 'default_summary';
-$handler->display->display_options['arguments']['role_end_date']['summary_options']['items_per_page'] = '25';
-$handler->display->display_options['arguments']['role_end_date']['civihr_range'] = '>=';
-$handler->display->display_options['arguments']['role_end_date']['civihr_range_empty'] = '1';
+
 $handler->display->display_options['merge_rows'] = TRUE;
 $handler->display->display_options['field_config'] = array(
   'id' => array(


### PR DESCRIPTION
## Problem

A contextual filter was added to ensure only active roles are shown [in a previous ticket](https://compucorp.atlassian.net/browse/PCHR-1767). This had the side effect of only showing users with active roles in the staff directory.

The desired logic is to show all users with an active contract regardless of roles. We only care about the role if filtering by department.

## Solution

- Remove the contextual filter for role end.
- Add a hook to add this filter only if the department filter is set

### Notes 

- I wasn't sure where to put the `get_where_fields` function. If there was some util file it would probably be better to put it there.
- I ran the tests, but they are very basic. Of course it would be nice to have access to the `\view` class, but I'm not sure if the tests should depend on classes outside of the project.