### PR TITLE
PCHR-1890: Fix filtering on staff directory

### DIFF
--- a/civihr_employee_portal/tdd/HelperFunctionsTest.php
+++ b/civihr_employee_portal/tdd/HelperFunctionsTest.php
@@ -30,9 +30,9 @@ class HelperFunctionsTest extends PHPUnit_Framework_TestCase {
     ]
   ];
 
-  public function testGetWhereParts() {
+  public function testGetWhereFields() {
     $parts = [];
-    get_where_parts($this->sampleWherePart, $parts);
+    getWhereFields($this->sampleWherePart, $parts);
     $expectedCount = 4;
     $this->assertCount($expectedCount, $parts);
     for ($i = 1; $i < $expectedCount + 1; $i++) {

--- a/civihr_employee_portal/tdd/HelperFunctionsTest.php
+++ b/civihr_employee_portal/tdd/HelperFunctionsTest.php
@@ -1,0 +1,43 @@
+<?php
+
+require_once __DIR__ . '/../views/civihr_employee_portal.views.inc';
+
+class HelperFunctionsTest extends PHPUnit_Framework_TestCase {
+  protected $sampleWherePart = [
+    [
+      'conditions' => [
+        [
+          'field' => 'foo1',
+          'value' => 'bar1'
+        ],
+        [
+          'field' => 'foo2',
+          'value' => 'bar2'
+        ],
+      ]
+    ],
+    [
+      'conditions' => [
+        [
+          'field' => 'foo3',
+          'value' => 'bar3'
+        ],
+        [
+          'field' => 'foo4',
+          'value' => 'bar4'
+        ],
+      ]
+    ]
+  ];
+
+  public function testGetWhereParts() {
+    $parts = [];
+    get_where_parts($this->sampleWherePart, $parts);
+    $expectedCount = 4;
+    $this->assertCount($expectedCount, $parts);
+    for ($i = 1; $i < $expectedCount + 1; $i++) {
+      $this->assertEquals('bar' . $i, $parts['foo' . $i]);
+    }
+  }
+
+}

--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -1118,7 +1118,8 @@ function removeAdditionalCommas($view) {
 }
 
 /**
- * Removes results for relationships starting in future or ending in past
+ * Sets the manager display name to NULL for contacts with manager relationships
+ * starting in the future or ending in the past to hide them from the view
  *
  * @param \stdClass[] $results
  *

--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -1118,13 +1118,14 @@ function removeAdditionalCommas($view) {
 }
 
 /**
- * Sets the name to NULL for relationships starting in future or ending in past
+ * Removes results for relationships starting in future or ending in past
  *
- * @param array $results
+ * @param \stdClass[] $results
+ *
  * @return array
  */
 function removeInactiveManagers($results = []) {
-  $endField = 'civicrm_relationship_end_date';
+  $endField = 'civicrm_relationship_civicrm_contact_1_end_date';
   $startField = 'civicrm_relationship_civicrm_contact_1_start_date';
   $startOfToday = new \DateTime('today 00:00:00');
   $endOfToday = new \DateTime('today 23:59:59');
@@ -1148,6 +1149,8 @@ function removeInactiveManagers($results = []) {
 }
 
 /**
+ * Removes titles and locations from inactive roles for the result
+ *
  * @param \stdClass[] $results
  *
  * @return array

--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -1020,12 +1020,12 @@ function civihr_employee_portal_views_pre_render(&$view) {
   }
   if ($view->name == "civihr_staff_directory") {
     $view->result = removeInactiveManagers($view->result);
-    $view->result = removeInactiveDepartments($view->result);
+    $view->result = removeInactiveRoleDetails($view->result);
   }
   if ($view->name == "approvals") {
     $view->result = removeAbsencesForOtherManagers($view->result);
   }
-  
+
   if ($view->name == "civihr_report_people" || $view->name == "civihr_report_leave_and_absence") {
     formatLengthsOfService($view->result);
   }
@@ -1034,7 +1034,7 @@ function civihr_employee_portal_views_pre_render(&$view) {
 /**
  * Processes results in people report view to format length of service for each
  * contact in a human readable form.
- * 
+ *
  * @param array $results
  *   Array of objects (stdClass) that hold data for each contact in people report.
  */
@@ -1117,29 +1117,61 @@ function removeAdditionalCommas($view) {
   return $fieldsToClean;
 }
 
-function removeInactiveDepartments($results = array()) {
-  foreach ($results as $key => $value) {
-    $startDate = !empty($value->hrjc_role_civicrm_contact_start_date) ? $value->hrjc_role_civicrm_contact_start_date : NULL;
-    $endDate = !empty($value->hrjc_role_civicrm_contact_end_date) ? $value->hrjc_role_civicrm_contact_end_date : NULL;
+/**
+ * Sets the name to NULL for relationships starting in future or ending in past
+ *
+ * @param array $results
+ * @return array
+ */
+function removeInactiveManagers($results = []) {
+  $endField = 'civicrm_relationship_end_date';
+  $startField = 'civicrm_relationship_civicrm_contact_1_start_date';
+  $startOfToday = new \DateTime('today 00:00:00');
+  $endOfToday = new \DateTime('today 23:59:59');
 
-    if (($endDate && $endDate < date('Y-m-d h:i:s') && $endDate != "0000-00-00 00:00:00") ||
-            ($startDate && $startDate > date('Y-m-d h:i:s'))
-    ) {
-      $value->hrjc_role_civicrm_contact_department = NULL;
+  $startDates = [];
+
+  foreach ($results as $key => $value) {
+    $end = $value->$endField ? new \DateTime($value->$endField) : NULL;
+    $start = $value->$startField ? new \DateTime($value->$startField) : NULL;
+    $startDates[] = $start;
+    $isActive = $value->civicrm_relationship_is_active == 1;
+    $isPast = $end && $end < $startOfToday;
+    $isFuture = $start > $endOfToday;
+
+    if (!$isActive || $isPast || $isFuture) {
+      unset($results[$key]);
     }
   }
+
   return $results;
 }
 
-function removeInactiveManagers($results = array()) {
-  foreach ($results as $key => $value) {
-    if ($value->civicrm_relationship_is_active == 0 ||
-            ($value->civicrm_relationship_end_date < date('Y-m-d') && $value->civicrm_relationship_end_date != NULL) ||
-            $value->civicrm_relationship_start_date > date('Y-m-d')) {
-      $value->civicrm_contact_civicrm_relationship_first_name = NULL;
-      $value->civicrm_contact_civicrm_relationship_last_name = NULL;
+/**
+ * @param \stdClass[] $results
+ *
+ * @return array
+ */
+function removeInactiveRoleDetails($results = []) {
+  $endField = 'hrjc_role_hrjc_revision_role_end_date';
+  $startField = 'hrjc_role_hrjc_revision_role_start_date';
+  $titleField = 'hrjc_role_hrjc_revision_role_title';
+  $locationField = 'hrjc_role_hrjc_revision_role_location';
+  $startOfToday = new \DateTime('today 00:00:00');
+  $endOfToday = new \DateTime('today 23:59:59');
+
+  foreach ($results as $key => $row) {
+    $roleEnd = $row->$endField ? new \DateTime($row->$endField) : NULL;
+    $roleStart = $row->$startField ? new \DateTime($row->$startField) : NULL;
+    $isPastRole = $roleEnd && $roleEnd < $startOfToday;
+    $isFutureRole = $roleStart && $roleStart > $endOfToday;
+
+    if ($isPastRole || $isFutureRole) {
+      $row->$titleField = NULL;
+      $row->$locationField = NULL;
     }
   }
+
   return $results;
 }
 

--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -1144,13 +1144,36 @@ function removeInactiveManagers($results = array()) {
 }
 
 /**
+ * Implements hook_views_query_alter().
+ *
+ * @param view $view
+ * @param views_plugin_query_default $query
+ */
+function civihr_employee_portal_views_query_alter(&$view, &$query) {
+  if ($view->name !== 'civihr_staff_directory') {
+    return;
+  }
+
+  $queryParts = [];
+  getWhereFields($query->where, $queryParts);
+  $departmentField = 'hrjc_role_hrjc_revision.role_department';
+  $roleEndField = 'hrjc_role_hrjc_revision.role_end_date';
+
+  // if department is set we must limit to only current roles
+  if (!empty($queryParts[$departmentField])) {
+    $group = $query->set_where_group('OR'); // add a new WHERE group
+    $query->add_where($group, $roleEndField, date('Y-m-d'), '>=');
+    $query->add_where($group, $roleEndField, NULL, 'IS');
+  }
+}
+
+/**
  * Implements hook_views_pre_view().
  * @param $view
  * @param $display_id
  * @param $args
  */
 function civihr_employee_portal_views_pre_view(&$view, &$display_id, &$args) {
-
   // Custom configuration start for items per page
   if (($view->name == 'civihr_staff_directory' && $display_id == 'page') ||
           ($view->name == 'hr_documents' && $display_id == 'hr_resources')) {
@@ -1166,3 +1189,29 @@ function civihr_employee_portal_views_pre_view(&$view, &$display_id, &$args) {
     );
   }
 }
+
+/**
+ * Takes the where part of a query and returns an array of fields => values
+ *
+ * @param mixed $part
+ *  The $query->where part
+ * @param array $fields
+ *  An array to store the fields
+ */
+function getWhereFields($part, &$fields) {
+  if (isset($part['conditions'])) {
+    $part = $part['conditions'];
+  }
+  if (isset($part['field']) && $part['field'] instanceof DatabaseCondition) {
+    $part = $part['field']->conditions();
+  }
+
+  if (isset($part['field'])) {
+    $fields[$part['field']] = $part['value'];
+  }
+  elseif (is_array($part)) {
+    foreach ($part as $item) {
+      getWhereFields($item, $fields);
+    }
+  }
+};

--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -1127,6 +1127,7 @@ function removeAdditionalCommas($view) {
 function removeInactiveManagers($results = []) {
   $endField = 'civicrm_relationship_civicrm_contact_1_end_date';
   $startField = 'civicrm_relationship_civicrm_contact_1_start_date';
+  $managerField = 'civicrm_contact_civicrm_relationship_1_display_name';
   $startOfToday = new \DateTime('today 00:00:00');
   $endOfToday = new \DateTime('today 23:59:59');
 
@@ -1141,7 +1142,7 @@ function removeInactiveManagers($results = []) {
     $isFuture = $start > $endOfToday;
 
     if (!$isActive || $isPast || $isFuture) {
-      unset($results[$key]);
+      $value->$managerField = NULL;
     }
   }
 

--- a/civihr_employee_portal/views/views_export/views_hr_staff_directory.inc
+++ b/civihr_employee_portal/views/views_export/views_hr_staff_directory.inc
@@ -656,19 +656,7 @@ $handler->display->display_options['arguments']['effective_end_date']['summary']
 $handler->display->display_options['arguments']['effective_end_date']['summary_options']['items_per_page'] = '25';
 $handler->display->display_options['arguments']['effective_end_date']['civihr_range'] = '>=';
 $handler->display->display_options['arguments']['effective_end_date']['civihr_range_empty'] = '1';
-/* Contextual filter: HRJobContract Role entity: Role end date */
-$handler->display->display_options['arguments']['role_end_date']['id'] = 'role_end_date';
-$handler->display->display_options['arguments']['role_end_date']['table'] = 'hrjc_role';
-$handler->display->display_options['arguments']['role_end_date']['field'] = 'role_end_date';
-$handler->display->display_options['arguments']['role_end_date']['relationship'] = 'role_jobcontract_id';
-$handler->display->display_options['arguments']['role_end_date']['default_action'] = 'default';
-$handler->display->display_options['arguments']['role_end_date']['default_argument_type'] = 'php';
-$handler->display->display_options['arguments']['role_end_date']['default_argument_options']['code'] = 'return date(\'Y-m-d\');';
-$handler->display->display_options['arguments']['role_end_date']['summary']['number_of_records'] = '0';
-$handler->display->display_options['arguments']['role_end_date']['summary']['format'] = 'default_summary';
-$handler->display->display_options['arguments']['role_end_date']['summary_options']['items_per_page'] = '25';
-$handler->display->display_options['arguments']['role_end_date']['civihr_range'] = '>=';
-$handler->display->display_options['arguments']['role_end_date']['civihr_range_empty'] = '1';
+
 $handler->display->display_options['merge_rows'] = TRUE;
 $handler->display->display_options['field_config'] = array(
   'id' => array(

--- a/civihr_employee_portal/views/views_export/views_hr_staff_directory.inc
+++ b/civihr_employee_portal/views/views_export/views_hr_staff_directory.inc
@@ -348,6 +348,7 @@ $handler->display->display_options['fields']['department_list']['label'] = 'Depa
 $handler->display->display_options['fields']['end_date']['id'] = 'end_date';
 $handler->display->display_options['fields']['end_date']['table'] = 'civicrm_relationship';
 $handler->display->display_options['fields']['end_date']['field'] = 'end_date';
+$handler->display->display_options['fields']['end_date']['relationship'] = 'relationship_id_a_1';
 $handler->display->display_options['fields']['end_date']['exclude'] = TRUE;
 $handler->display->display_options['fields']['end_date']['date_format'] = 'long';
 $handler->display->display_options['fields']['end_date']['second_date_format'] = 'long';

--- a/civihr_employee_portal/views/views_export/views_hr_staff_directory.inc
+++ b/civihr_employee_portal/views/views_export/views_hr_staff_directory.inc
@@ -46,7 +46,7 @@ $handler->display->display_options['style_options']['columns'] = array(
   'work_phone_ext' => 'work_phone_ext',
   'title' => 'title',
   'email_1' => 'email_1',
-  'location_label' => 'location_label',
+  'role_location' => 'role_location',
   'contract_type' => 'contract_type',
   'department' => 'department',
   'department_list' => 'department_list',
@@ -123,7 +123,7 @@ $handler->display->display_options['style_options']['info'] = array(
     'separator' => '',
     'empty_column' => 0,
   ),
-  'location_label' => array(
+  'role_location' => array(
     'sortable' => 1,
     'default_sort_order' => 'asc',
     'align' => '',
@@ -180,6 +180,8 @@ $handler->display->display_options['style_options']['info'] = array(
     'empty_column' => 0,
   ),
   'start_date_1' => array(
+    'sortable' => 0,
+    'default_sort_order' => 'asc',
     'align' => '',
     'separator' => '',
     'empty_column' => 0,
@@ -239,7 +241,6 @@ $handler->display->display_options['relationships']['relationship_id_a']['relati
 $handler->display->display_options['relationships']['contact_id_b_']['id'] = 'contact_id_b_';
 $handler->display->display_options['relationships']['contact_id_b_']['table'] = 'civicrm_relationship';
 $handler->display->display_options['relationships']['contact_id_b_']['field'] = 'contact_id_b_';
-$handler->display->display_options['relationships']['contact_id_b_']['relationship'] = 'relationship_id_a';
 /* Relationship: CiviCRM Contacts: CiviCRM Relationship (starting from contact A) */
 $handler->display->display_options['relationships']['relationship_id_a_1']['id'] = 'relationship_id_a_1';
 $handler->display->display_options['relationships']['relationship_id_a_1']['table'] = 'civicrm_contact';
@@ -303,11 +304,11 @@ $handler->display->display_options['fields']['work_phone_ext']['table'] = 'hrjc_
 $handler->display->display_options['fields']['work_phone_ext']['field'] = 'work_phone_ext';
 $handler->display->display_options['fields']['work_phone_ext']['relationship'] = 'hrjc_contact_details';
 $handler->display->display_options['fields']['work_phone_ext']['label'] = 'Work Phone Extension';
-/* Field: HRJobContract Details entity: Title */
+/* Field: HRJobContract Role entity: Role_title */
 $handler->display->display_options['fields']['title']['id'] = 'title';
-$handler->display->display_options['fields']['title']['table'] = 'hrjc_details';
-$handler->display->display_options['fields']['title']['field'] = 'title';
-$handler->display->display_options['fields']['title']['relationship'] = 'details_revision_id';
+$handler->display->display_options['fields']['title']['table'] = 'hrjc_role';
+$handler->display->display_options['fields']['title']['field'] = 'role_title';
+$handler->display->display_options['fields']['title']['relationship'] = 'role_jobcontract_id';
 $handler->display->display_options['fields']['title']['label'] = 'Job Title';
 /* Field: CiviCRM Email: Email Address */
 $handler->display->display_options['fields']['email_1']['id'] = 'email_1';
@@ -317,12 +318,13 @@ $handler->display->display_options['fields']['email_1']['relationship'] = 'id';
 $handler->display->display_options['fields']['email_1']['location_type'] = '0';
 $handler->display->display_options['fields']['email_1']['location_op'] = '0';
 $handler->display->display_options['fields']['email_1']['is_primary'] = 0;
-/* Field: HRJobContract Details entity: Location_label */
-$handler->display->display_options['fields']['location_label']['id'] = 'location_label';
-$handler->display->display_options['fields']['location_label']['table'] = 'hrjc_details';
-$handler->display->display_options['fields']['location_label']['field'] = 'location_label';
-$handler->display->display_options['fields']['location_label']['relationship'] = 'details_revision_id';
-$handler->display->display_options['fields']['location_label']['label'] = 'Location';
+/* Field: HRJobContract Role entity: Role_location */
+$handler->display->display_options['fields']['role_location']['id'] = 'role_location';
+$handler->display->display_options['fields']['role_location']['table'] = 'hrjc_role';
+$handler->display->display_options['fields']['role_location']['field'] = 'role_location';
+$handler->display->display_options['fields']['role_location']['relationship'] = 'role_jobcontract_id';
+$handler->display->display_options['fields']['role_location']['label'] = 'Location';
+$handler->display->display_options['fields']['role_location']['element_label_colon'] = FALSE;
 /* Field: HRJobContract Details entity: Contract_type */
 $handler->display->display_options['fields']['contract_type']['id'] = 'contract_type';
 $handler->display->display_options['fields']['contract_type']['table'] = 'hrjc_details';
@@ -355,23 +357,24 @@ $handler->display->display_options['fields']['is_active']['table'] = 'civicrm_re
 $handler->display->display_options['fields']['is_active']['field'] = 'is_active';
 $handler->display->display_options['fields']['is_active']['exclude'] = TRUE;
 $handler->display->display_options['fields']['is_active']['not'] = 0;
-/* Field: CiviCRM Relationships: Start Date */
+/* Field: relationship_start_date */
 $handler->display->display_options['fields']['start_date']['id'] = 'start_date';
 $handler->display->display_options['fields']['start_date']['table'] = 'civicrm_relationship';
 $handler->display->display_options['fields']['start_date']['field'] = 'start_date';
+$handler->display->display_options['fields']['start_date']['relationship'] = 'relationship_id_a_1';
+$handler->display->display_options['fields']['start_date']['ui_name'] = 'relationship_start_date';
 $handler->display->display_options['fields']['start_date']['exclude'] = TRUE;
 $handler->display->display_options['fields']['start_date']['date_format'] = 'long';
-$handler->display->display_options['fields']['start_date']['second_date_format'] = 'long';
 /* Field: HRJobContract Role entity: Role end date */
 $handler->display->display_options['fields']['end_date_1']['id'] = 'end_date_1';
 $handler->display->display_options['fields']['end_date_1']['table'] = 'hrjc_role';
 $handler->display->display_options['fields']['end_date_1']['field'] = 'role_end_date';
 $handler->display->display_options['fields']['end_date_1']['relationship'] = 'role_jobcontract_id';
 $handler->display->display_options['fields']['end_date_1']['exclude'] = TRUE;
-/* Field: Broken/missing handler */
+/* Field: HRJobContract Role entity: Role start date */
 $handler->display->display_options['fields']['start_date_1']['id'] = 'start_date_1';
 $handler->display->display_options['fields']['start_date_1']['table'] = 'hrjc_role';
-$handler->display->display_options['fields']['start_date_1']['field'] = 'role_star_date';
+$handler->display->display_options['fields']['start_date_1']['field'] = 'role_start_date';
 $handler->display->display_options['fields']['start_date_1']['relationship'] = 'role_jobcontract_id';
 $handler->display->display_options['fields']['start_date_1']['exclude'] = TRUE;
 /* Field: CiviCRM Contacts: Display Name */
@@ -427,33 +430,33 @@ $handler->display->display_options['filters']['display_name']['expose']['autocom
 $handler->display->display_options['filters']['display_name']['expose']['autocomplete_raw_suggestion'] = 0;
 $handler->display->display_options['filters']['display_name']['expose']['autocomplete_raw_dropdown'] = 0;
 $handler->display->display_options['filters']['display_name']['expose']['autocomplete_dependent'] = 0;
-/* Filter criterion: HRJobContract Details entity: Title */
-$handler->display->display_options['filters']['title']['id'] = 'title';
-$handler->display->display_options['filters']['title']['table'] = 'hrjc_details';
-$handler->display->display_options['filters']['title']['field'] = 'title';
-$handler->display->display_options['filters']['title']['relationship'] = 'details_revision_id';
-$handler->display->display_options['filters']['title']['operator'] = 'contains';
-$handler->display->display_options['filters']['title']['group'] = 1;
-$handler->display->display_options['filters']['title']['exposed'] = TRUE;
-$handler->display->display_options['filters']['title']['expose']['operator_id'] = 'title_op';
-$handler->display->display_options['filters']['title']['expose']['label'] = 'Job Title';
-$handler->display->display_options['filters']['title']['expose']['operator'] = 'title_op';
-$handler->display->display_options['filters']['title']['expose']['identifier'] = 'title';
-$handler->display->display_options['filters']['title']['expose']['remember_roles'] = array(
+/* Filter criterion: HRJobContract Role entity: Role_title */
+$handler->display->display_options['filters']['role_title']['id'] = 'role_title';
+$handler->display->display_options['filters']['role_title']['table'] = 'hrjc_role';
+$handler->display->display_options['filters']['role_title']['field'] = 'role_title';
+$handler->display->display_options['filters']['role_title']['relationship'] = 'role_jobcontract_id';
+$handler->display->display_options['filters']['role_title']['operator'] = 'contains';
+$handler->display->display_options['filters']['role_title']['group'] = 1;
+$handler->display->display_options['filters']['role_title']['exposed'] = TRUE;
+$handler->display->display_options['filters']['role_title']['expose']['operator_id'] = 'role_title_op';
+$handler->display->display_options['filters']['role_title']['expose']['label'] = 'Job Title';
+$handler->display->display_options['filters']['role_title']['expose']['operator'] = 'role_title_op';
+$handler->display->display_options['filters']['role_title']['expose']['identifier'] = 'role_title';
+$handler->display->display_options['filters']['role_title']['expose']['remember_roles'] = array(
   2 => '2',
   1 => 0,
   3 => 0,
-  4 => 0,
-  6 => 0,
-  5 => 0,
+  55120974 => 0,
+  17087012 => 0,
+  57573969 => 0,
 );
-$handler->display->display_options['filters']['title']['expose']['autocomplete_filter'] = 1;
-$handler->display->display_options['filters']['title']['expose']['autocomplete_items'] = '10';
-$handler->display->display_options['filters']['title']['expose']['autocomplete_min_chars'] = '0';
-$handler->display->display_options['filters']['title']['expose']['autocomplete_field'] = 'title';
-$handler->display->display_options['filters']['title']['expose']['autocomplete_raw_suggestion'] = 1;
-$handler->display->display_options['filters']['title']['expose']['autocomplete_raw_dropdown'] = 1;
-$handler->display->display_options['filters']['title']['expose']['autocomplete_dependent'] = 0;
+$handler->display->display_options['filters']['role_title']['expose']['autocomplete_filter'] = 1;
+$handler->display->display_options['filters']['role_title']['expose']['autocomplete_items'] = '10';
+$handler->display->display_options['filters']['role_title']['expose']['autocomplete_min_chars'] = '0';
+$handler->display->display_options['filters']['role_title']['expose']['autocomplete_field'] = 'title';
+$handler->display->display_options['filters']['role_title']['expose']['autocomplete_raw_suggestion'] = 1;
+$handler->display->display_options['filters']['role_title']['expose']['autocomplete_raw_dropdown'] = 1;
+$handler->display->display_options['filters']['role_title']['expose']['autocomplete_dependent'] = 0;
 /* Filter criterion: HRJobContract Contact Work/Home Phone and E-mail Entity: Work_phone */
 $handler->display->display_options['filters']['work_phone']['id'] = 'work_phone';
 $handler->display->display_options['filters']['work_phone']['table'] = 'hrjc_contact_details';
@@ -534,33 +537,6 @@ $handler->display->display_options['filters']['department']['expose']['autocompl
 $handler->display->display_options['filters']['department']['expose']['autocomplete_raw_suggestion'] = 1;
 $handler->display->display_options['filters']['department']['expose']['autocomplete_raw_dropdown'] = 1;
 $handler->display->display_options['filters']['department']['expose']['autocomplete_dependent'] = 0;
-/* Filter criterion: HRJobContract Details entity: Location_label */
-$handler->display->display_options['filters']['location_label']['id'] = 'location_label';
-$handler->display->display_options['filters']['location_label']['table'] = 'hrjc_details';
-$handler->display->display_options['filters']['location_label']['field'] = 'location_label';
-$handler->display->display_options['filters']['location_label']['relationship'] = 'details_revision_id';
-$handler->display->display_options['filters']['location_label']['operator'] = 'contains';
-$handler->display->display_options['filters']['location_label']['group'] = 1;
-$handler->display->display_options['filters']['location_label']['exposed'] = TRUE;
-$handler->display->display_options['filters']['location_label']['expose']['operator_id'] = 'location_label_op';
-$handler->display->display_options['filters']['location_label']['expose']['label'] = 'Location';
-$handler->display->display_options['filters']['location_label']['expose']['operator'] = 'location_label_op';
-$handler->display->display_options['filters']['location_label']['expose']['identifier'] = 'location_label';
-$handler->display->display_options['filters']['location_label']['expose']['remember_roles'] = array(
-  2 => '2',
-  1 => 0,
-  3 => 0,
-  55120974 => 0,
-  17087012 => 0,
-  57573969 => 0,
-);
-$handler->display->display_options['filters']['location_label']['expose']['autocomplete_filter'] = 1;
-$handler->display->display_options['filters']['location_label']['expose']['autocomplete_items'] = '10';
-$handler->display->display_options['filters']['location_label']['expose']['autocomplete_min_chars'] = '0';
-$handler->display->display_options['filters']['location_label']['expose']['autocomplete_field'] = 'location_label';
-$handler->display->display_options['filters']['location_label']['expose']['autocomplete_raw_suggestion'] = 1;
-$handler->display->display_options['filters']['location_label']['expose']['autocomplete_raw_dropdown'] = 1;
-$handler->display->display_options['filters']['location_label']['expose']['autocomplete_dependent'] = 0;
 /* Filter criterion: CiviCRM Contacts: Display Name */
 $handler->display->display_options['filters']['display_name_1']['id'] = 'display_name_1';
 $handler->display->display_options['filters']['display_name_1']['table'] = 'civicrm_contact';
@@ -752,7 +728,7 @@ $translatables['civihr_staff_directory'] = array(
   t('Is Relationship Active'),
   t('Start Date'),
   t('Role end date'),
-  t('Broken handler hrjc_role.role_star_date'),
+  t('Role start date'),
   t('Manager'),
   t('Managers'),
   t('Email'),


### PR DESCRIPTION
## Problem

A contextual filter was added to ensure only active roles are shown [in a previous ticket](https://compucorp.atlassian.net/browse/PCHR-1767). This had the side effect of only showing users with active roles in the staff directory.

The desired logic is to show all users with an active contract regardless of roles. We only care about the role if filtering by department.

In addition the rules for what to show have changed:

- Instead of showing contract title we show role titlles
- Instead of showing contract location we show role locations

Also a bug where managers with relationships starting in the future was fixed as part of this.

## Solution

- Remove the contextual filter for role end.
- Add a hook to add this filter only if the department filter is set

### Notes 

- I wasn't sure where to put the `get_where_fields` function. If there was some util file it would probably be better to put it there.
- I ran the tests, but they are very basic. Of course it would be nice to have access to the `\view` class, but I'm not sure if the tests should depend on classes outside of the project.


This is a duplicate of [PR 278](https://github.com/compucorp/civihr-employee-portal/pull/278#discussion_r106401993) which used the wrong ticket number in the branch and commits