### PR TITLE
FAR-143: Fix JOIN on absence_approval_list view

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -374,7 +374,7 @@ function _rebuild_absence_list_view() {
                         ON request.activity_type_id = absence_type_debit.debit_activity_type_id
                         LEFT JOIN " . $civi_db_name . ".civicrm_hrabsence_type absence_type_credit
                         ON request.activity_type_id = absence_type_credit.credit_activity_type_id
-                        INNER JOIN " . $civi_db_name . ".civicrm_uf_match drupal_contact
+                        LEFT JOIN " . $civi_db_name . ".civicrm_uf_match drupal_contact
                         ON tgt.contact_id = drupal_contact.contact_id
                         WHERE (request.activity_type_id IN (" . rtrim($options, ',') . "))
                         GROUP BY request.id");
@@ -840,7 +840,7 @@ function civihr_employee_portal_views_default_views() {
 }
 
 /**
- * Function for caching date periods returned from CiviCRM (avoiding expensive 
+ * Function for caching date periods returned from CiviCRM (avoiding expensive
  * DB calls for each dashboard page hit)
  */
 function get_civihr_date_periods() {
@@ -851,7 +851,7 @@ function get_civihr_date_periods() {
     if ($cache = cache_get('civihr_date_periods')) {
       $periods_data = $cache->data;
       watchdog(
-        'CiviHR Period Cache', 
+        'CiviHR Period Cache',
         'Periods found in cache: <br/><pre>' . print_r($periods_data, true) . '</pre>'
       );
     }
@@ -867,7 +867,7 @@ function get_civihr_date_periods() {
       catch (CiviCRM_API3_Exception $e) {
           $error = $e->getMessage();
           watchdog(
-            'CiviHR Period Cache', 
+            'CiviHR Period Cache',
             "Error obtaining periods from DB: $error ",
             array(),
             WATCHDOG_ALERT
@@ -876,7 +876,7 @@ function get_civihr_date_periods() {
 
       cache_set('civihr_date_periods', $periods_data, 'cache', strtotime('+6 minutes'));
       watchdog(
-        'CiviHR Period Cache', 
+        'CiviHR Period Cache',
         'Periods obtained from DB and stored in cache: <br/><pre>' . print_r($periods_data, true) . '</pre>'
       );
     }
@@ -6961,7 +6961,7 @@ function civihr_employee_portal_is_sick_absence($absenceName) {
 
 /**
  * Return an ID of 'sick' Absence Type or NULL if 'sick' type is not found.
- * 
+ *
  * @return int|NULL
  */
 function civihr_employee_portal_get_absence_sick_type_id() {

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -349,7 +349,7 @@ function _rebuild_absence_list_view() {
                         ON request.activity_type_id = absence_type_debit.debit_activity_type_id
                         LEFT JOIN " . $civi_db_name . ".civicrm_hrabsence_type absence_type_credit
                         ON request.activity_type_id = absence_type_credit.credit_activity_type_id
-                        INNER JOIN " . $civi_db_name . ".civicrm_uf_match drupal_contact
+                        LEFT JOIN " . $civi_db_name . ".civicrm_uf_match drupal_contact
                         ON tgt.contact_id = drupal_contact.contact_id
                         WHERE (request.activity_type_id IN (" . rtrim($options, ',') . "))
                         GROUP BY request.id");


### PR DESCRIPTION
## Problem

When a user whose manager does not have a CiviHR account creates a leave request it does not appear in the absence_approval_list database view. This view is used by the manager-absence-approval page.

## Solution

Change the join on the view to use LEFT JOIN which will return the absences regardless of whether the manager at the time has a CiviHR account

## Notes

- A similar view, `absence_list` exists and is defined in the same file. I would suggest changing the same condition on this too but I'm not sure where (or if) this is used.