### PR TITLE
PCHR-2097: Allow overlapping absence when absence rejected

### DIFF
--- a/civihr_employee_portal/src/Forms/AbsenceRequestForm.php
+++ b/civihr_employee_portal/src/Forms/AbsenceRequestForm.php
@@ -9,7 +9,7 @@ class AbsenceRequestForm {
     protected $form_state;
 
     const CANCELLED_LEAVE_TYPE_ID = 3;
-    const DENIED_LEAVE_TYPE_ID = 9;
+    const REJECTED_LEAVE_TYPE_ID = 9;
 
     /**
      * Constructor
@@ -419,7 +419,7 @@ class AbsenceRequestForm {
         $absencesDataQuery = db_select('absence_list', 'al')
             ->condition('contact_id', $_SESSION['CiviCRM']['userID'])
             ->condition('absence_status', self::CANCELLED_LEAVE_TYPE_ID, '<>')
-            ->condition('absence_status', self::DENIED_LEAVE_TYPE_ID, '<>')
+            ->condition('absence_status', self::REJECTED_LEAVE_TYPE_ID, '<>')
             ->fields('al', array('absence_start_date_timestamp', 'absence_end_date_timestamp'));
 
         $absencesData = $absencesDataQuery->execute()->fetchAll();

--- a/civihr_employee_portal/src/Forms/AbsenceRequestForm.php
+++ b/civihr_employee_portal/src/Forms/AbsenceRequestForm.php
@@ -9,6 +9,7 @@ class AbsenceRequestForm {
     protected $form_state;
 
     const CANCELLED_LEAVE_TYPE_ID = 3;
+    const DENIED_LEAVE_TYPE_ID = 9;
 
     /**
      * Constructor
@@ -418,7 +419,7 @@ class AbsenceRequestForm {
         $absencesDataQuery = db_select('absence_list', 'al')
             ->condition('contact_id', $_SESSION['CiviCRM']['userID'])
             ->condition('absence_status', self::CANCELLED_LEAVE_TYPE_ID, '<>')
-            //->condition('absence_end_date_timestamp', strtotime('today'), '>')
+            ->condition('absence_status', self::DENIED_LEAVE_TYPE_ID, '<>')
             ->fields('al', array('absence_start_date_timestamp', 'absence_end_date_timestamp'));
 
         $absencesData = $absencesDataQuery->execute()->fetchAll();
@@ -546,7 +547,7 @@ class AbsenceRequestForm {
 
         if ($period_id == null) {
           watchdog(
-            'CiviHR Period Cache', 
+            'CiviHR Period Cache',
             'Period for ' . implode('-', $start_date) . ' not found in period cache.  Cache data: <br/><pre>' . print_r(get_civihr_date_periods(), true) . '</pre>',
             array(),
             WATCHDOG_ALERT


### PR DESCRIPTION
## Problem

When you create a leave request and it is rejected you cannot create another leave request for the same period.

This is because the query to check for duplicates only ignores cancelled requests.

```
 $absencesDataQuery = db_select('absence_list', 'al')
  ->condition('contact_id', $_SESSION['CiviCRM']['userID'])
  ->condition('absence_status', self::CANCELLED_LEAVE_TYPE_ID, '<>')
  ->fields('al', array('absence_start_date_timestamp', 'absence_end_date_timestamp'));
```

## Solution

Add a condition so absences with the rejected status will also be ignored in the validation