### PR TITLE
PCHR-2039: Add link to people page in employee access request email

### DIFF
--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.rules_defaults.inc
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.rules_defaults.inc
@@ -79,8 +79,8 @@ function civihr_employee_portal_features_default_rules_configuration() {
             "active" : "1",
             "from_mail" : "[site:mail]",
             "subject" : "Employee Access Request",
-            "body" : "User [current-user:contact_display_name] with username: [current-user:name] ([current-user:mail]) has requested access to your CiviHR Self Service Portal.\\r\\nPlease login to activate this account and assign appropriate access level.",
-            "plaintext" : "User [current-user:contact_display_name] with username: [current-user:name] ([current-user:mail]) has requested access to your CiviHR Self Service Portal.\\r\\nPlease login to activate this account and assign appropriate access level.",
+            "body" : "User [current-user:contact_display_name] with username: [current-user:name] ([current-user:mail]) has requested access to your CiviHR Self Service Portal.\\r\\n<a href = \'[site:url]admin/people\'>Please login to activate this account and assign appropriate access level</a>.",
+            "plaintext" : "User [current-user:contact_display_name] with username: [current-user:name] ([current-user:mail]) has requested access to your CiviHR Self Service Portal.\\r\\n<a href = \'[site:url]admin/people\'>Please login to activate this account and assign appropriate access level</a>.",
             "language_user" : "1",
             "language" : [ "current-user:language" ]
           }
@@ -138,5 +138,6 @@ function civihr_employee_portal_features_default_rules_configuration() {
       ]
     }
   }');
+
   return $items;
 }


### PR DESCRIPTION
## Problem

The 'request access' e-mail that is sent to site admins does not contain a link to the site

## Solution

Add a link to the `admin/people` page inside the email

## Notes

`drush fr -y --force civihr_employee_portal_features.rules_config` must be run to update rules