### PR TITLE
PCHR-1953: Removed loading of reqangular.js file twice.

### DIFF
--- a/civihr_employee_portal/civihr_leave_absences/civihr_leave_absences.module
+++ b/civihr_employee_portal/civihr_leave_absences/civihr_leave_absences.module
@@ -74,8 +74,11 @@ function civihr_leave_absences_init() {
  *    Custom markup from template file.
  */
 function civihr_leave_absences_get_markup($resource = '') {
-
-  civicrm_resources_load('org.civicrm.reqangular', ['reqangular.min.js']);
+  $scripts = drupal_get_js('footer');
+  // Adding js file only if its not loaded already.
+  if (!strpos($scripts, 'reqangular.min.js')) {
+    civicrm_resources_load('org.civicrm.reqangular', ['reqangular.min.js']);
+  }
   civicrm_resources_load('uk.co.compucorp.civicrm.hrleaveandabsences', ["$resource.min.js"]);
 
   return civihr_leave_absences_load_file(str_replace('-', '_', $resource));


### PR DESCRIPTION
**Problem:** 
Reqangular js file was getting loaded twice from my-leave and manager_leave pages that was getting called from generic function because of this it was throwing below console errors.
![manager_leave___hr17](https://cloud.githubusercontent.com/assets/2689257/24348231/9dabf82e-12f8-11e7-9037-6c3bad5526cd.png)

**Solution:**
Removed loading of Reqangular js file twice from civihr_leave_absences_get_markup function.
