### PR TITLE
PCHR-2105 Restrict to Work Emails in Staff Directory

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.info
+++ b/civihr_employee_portal/civihr_employee_portal.info
@@ -40,6 +40,7 @@ dependencies[] = conditional_styles
 ; Views Handlers
 files[] = views/includes/civihr_employee_portal_argument_date_range.inc
 files[] = views/includes/civihr_employee_portal_argument_contact_id.inc
+files[] = views/includes/civihr_employee_portal_handler_email.inc
 files[] = views/includes/civihr_employee_portal_handler_age_group.inc
 files[] = views/includes/civihr_employee_portal_argument_age_group.inc
 files[] = views/includes/civihr_employee_portal_handler_absence_duration.inc

--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -1000,6 +1000,9 @@ function civihr_employee_portal_views_data_alter(&$data) {
   $data['absence_approval_list']['absence_end_date_timestamp']['filter']['handler'] = 'views_handler_filter_date';
   $data['absence_approval_list']['absence_end_date_timestamp']['argument']['handler'] = 'views_handler_argument_date';
 
+  // custom handler to add links to emails
+  $data['hrjc_contact_details']['work_email']['field']['handler'] = 'civihr_employee_portal_handler_email';
+
   return $data;
 }
 

--- a/civihr_employee_portal/views/includes/civihr_employee_portal_handler_email.inc
+++ b/civihr_employee_portal/views/includes/civihr_employee_portal_handler_email.inc
@@ -1,0 +1,42 @@
+
+<?php
+
+/**
+ * Custom field handler for emails, including multiple emails since
+ * @see civicrm_handler_field_email only works with single mails
+ */
+class civihr_employee_portal_handler_email extends views_handler_field {
+  /**
+   * @param array $values
+   *  All the values to be rendered by the view
+   *
+   * @return string
+   *  The rendered emails separated by spaces
+   */
+  public function render($values) {
+    $emails = $this->get_value($values);
+
+    if (!$emails) {
+      return '';
+    }
+
+    $this->sanitize_value($emails);
+    $emails = array_filter(explode(' ', $emails));
+    array_walk($emails, function (&$email) {
+      $email = $this->linkify($email);
+    });
+
+    return implode(' ', $emails);
+  }
+
+  /**
+   * @param string $email
+   *  The email to be put in a link
+   *
+   * @return string
+   *  The linked email
+   */
+  private function linkify($email) {
+    return sprintf('<a href="mailto:%s">%s</a>', $email, $email);
+  }
+}

--- a/civihr_employee_portal/views/views_export/views_hr_staff_directory.inc
+++ b/civihr_employee_portal/views/views_export/views_hr_staff_directory.inc
@@ -116,7 +116,7 @@ $handler->display->display_options['style_options']['info'] = array(
     'separator' => '',
     'empty_column' => 0,
   ),
-  'email_1' => array(
+  'work_email' => array(
     'sortable' => 1,
     'default_sort_order' => 'asc',
     'align' => '',
@@ -310,14 +310,14 @@ $handler->display->display_options['fields']['title']['table'] = 'hrjc_role';
 $handler->display->display_options['fields']['title']['field'] = 'role_title';
 $handler->display->display_options['fields']['title']['relationship'] = 'role_jobcontract_id';
 $handler->display->display_options['fields']['title']['label'] = 'Job Title';
-/* Field: CiviCRM Email: Email Address */
-$handler->display->display_options['fields']['email_1']['id'] = 'email_1';
-$handler->display->display_options['fields']['email_1']['table'] = 'civicrm_email';
-$handler->display->display_options['fields']['email_1']['field'] = 'email';
-$handler->display->display_options['fields']['email_1']['relationship'] = 'id';
-$handler->display->display_options['fields']['email_1']['location_type'] = '0';
-$handler->display->display_options['fields']['email_1']['location_op'] = '0';
-$handler->display->display_options['fields']['email_1']['is_primary'] = 0;
+/* Field: HRJobContract Contact Work/Home Phone and E-mail Entity: Work_email */
+$handler->display->display_options['fields']['work_email']['id'] = 'work_email';
+$handler->display->display_options['fields']['work_email']['table'] = 'hrjc_contact_details';
+$handler->display->display_options['fields']['work_email']['field'] = 'work_email';
+$handler->display->display_options['fields']['work_email']['relationship'] = 'hrjc_contact_details';
+$handler->display->display_options['fields']['work_email']['label'] = 'Email';
+// $handler->display->display_options['fields']['work_email']['alter']['make_link'] = TRUE;
+// $handler->display->display_options['fields']['work_email']['alter']['path'] = 'mailto:[work_email]';
 /* Field: HRJobContract Role entity: Role_location */
 $handler->display->display_options['fields']['role_location']['id'] = 'role_location';
 $handler->display->display_options['fields']['role_location']['table'] = 'hrjc_role';
@@ -458,6 +458,33 @@ $handler->display->display_options['filters']['role_title']['expose']['autocompl
 $handler->display->display_options['filters']['role_title']['expose']['autocomplete_raw_suggestion'] = 1;
 $handler->display->display_options['filters']['role_title']['expose']['autocomplete_raw_dropdown'] = 1;
 $handler->display->display_options['filters']['role_title']['expose']['autocomplete_dependent'] = 0;
+/* Filter criterion: HRJobContract Contact Work/Home Phone and E-mail Entity: Work_email */
+$handler->display->display_options['filters']['work_email']['id'] = 'work_email';
+$handler->display->display_options['filters']['work_email']['table'] = 'hrjc_contact_details';
+$handler->display->display_options['filters']['work_email']['field'] = 'work_email';
+$handler->display->display_options['filters']['work_email']['relationship'] = 'hrjc_contact_details';
+$handler->display->display_options['filters']['work_email']['operator'] = 'contains';
+$handler->display->display_options['filters']['work_email']['group'] = 1;
+$handler->display->display_options['filters']['work_email']['exposed'] = TRUE;
+$handler->display->display_options['filters']['work_email']['expose']['operator_id'] = 'work_email_op';
+$handler->display->display_options['filters']['work_email']['expose']['label'] = 'Email';
+$handler->display->display_options['filters']['work_email']['expose']['operator'] = 'work_email_op';
+$handler->display->display_options['filters']['work_email']['expose']['identifier'] = 'work_email';
+$handler->display->display_options['filters']['work_email']['expose']['remember_roles'] = array(
+  2 => '2',
+  1 => 0,
+  3 => 0,
+  55120974 => 0,
+  17087012 => 0,
+  57573969 => 0,
+);
+$handler->display->display_options['filters']['work_email']['expose']['autocomplete_filter'] = 1;
+$handler->display->display_options['filters']['work_email']['expose']['autocomplete_items'] = '10';
+$handler->display->display_options['filters']['work_email']['expose']['autocomplete_min_chars'] = '0';
+$handler->display->display_options['filters']['work_email']['expose']['autocomplete_field'] = 'work_email';
+$handler->display->display_options['filters']['work_email']['expose']['autocomplete_raw_suggestion'] = 1;
+$handler->display->display_options['filters']['work_email']['expose']['autocomplete_raw_dropdown'] = 1;
+$handler->display->display_options['filters']['work_email']['expose']['autocomplete_dependent'] = 0;
 /* Filter criterion: HRJobContract Contact Work/Home Phone and E-mail Entity: Work_phone */
 $handler->display->display_options['filters']['work_phone']['id'] = 'work_phone';
 $handler->display->display_options['filters']['work_phone']['table'] = 'hrjc_contact_details';
@@ -484,33 +511,6 @@ $handler->display->display_options['filters']['work_phone']['expose']['autocompl
 $handler->display->display_options['filters']['work_phone']['expose']['autocomplete_raw_suggestion'] = 1;
 $handler->display->display_options['filters']['work_phone']['expose']['autocomplete_raw_dropdown'] = 1;
 $handler->display->display_options['filters']['work_phone']['expose']['autocomplete_dependent'] = 0;
-/* Filter criterion: CiviCRM Email: Email Address */
-$handler->display->display_options['filters']['email']['id'] = 'email';
-$handler->display->display_options['filters']['email']['table'] = 'civicrm_email';
-$handler->display->display_options['filters']['email']['field'] = 'email';
-$handler->display->display_options['filters']['email']['relationship'] = 'id';
-$handler->display->display_options['filters']['email']['operator'] = 'contains';
-$handler->display->display_options['filters']['email']['group'] = 1;
-$handler->display->display_options['filters']['email']['exposed'] = TRUE;
-$handler->display->display_options['filters']['email']['expose']['operator_id'] = 'email_op';
-$handler->display->display_options['filters']['email']['expose']['label'] = 'Email';
-$handler->display->display_options['filters']['email']['expose']['operator'] = 'email_op';
-$handler->display->display_options['filters']['email']['expose']['identifier'] = 'email';
-$handler->display->display_options['filters']['email']['expose']['remember_roles'] = array(
-  2 => '2',
-  1 => 0,
-  3 => 0,
-  55120974 => 0,
-  17087012 => 0,
-  57573969 => 0,
-);
-$handler->display->display_options['filters']['email']['expose']['autocomplete_filter'] = 1;
-$handler->display->display_options['filters']['email']['expose']['autocomplete_items'] = '10';
-$handler->display->display_options['filters']['email']['expose']['autocomplete_min_chars'] = '0';
-$handler->display->display_options['filters']['email']['expose']['autocomplete_field'] = 'email_1';
-$handler->display->display_options['filters']['email']['expose']['autocomplete_raw_suggestion'] = 1;
-$handler->display->display_options['filters']['email']['expose']['autocomplete_raw_dropdown'] = 1;
-$handler->display->display_options['filters']['email']['expose']['autocomplete_dependent'] = 0;
 /* Filter criterion: HRJobContract Role entity: Role_department */
 $handler->display->display_options['filters']['department']['id'] = 'department';
 $handler->display->display_options['filters']['department']['table'] = 'hrjc_role';

--- a/civihr_employee_portal/views/views_export/views_hr_staff_directory.inc
+++ b/civihr_employee_portal/views/views_export/views_hr_staff_directory.inc
@@ -316,8 +316,6 @@ $handler->display->display_options['fields']['work_email']['table'] = 'hrjc_cont
 $handler->display->display_options['fields']['work_email']['field'] = 'work_email';
 $handler->display->display_options['fields']['work_email']['relationship'] = 'hrjc_contact_details';
 $handler->display->display_options['fields']['work_email']['label'] = 'Email';
-// $handler->display->display_options['fields']['work_email']['alter']['make_link'] = TRUE;
-// $handler->display->display_options['fields']['work_email']['alter']['path'] = 'mailto:[work_email]';
 /* Field: HRJobContract Role entity: Role_location */
 $handler->display->display_options['fields']['role_location']['id'] = 'role_location';
 $handler->display->display_options['fields']['role_location']['table'] = 'hrjc_role';


### PR DESCRIPTION
## Problem

The staff-directory view currently uses the primary email, regardless of whether it is personal or not. It should use only the work e-mail(s) and be blank if there are none.

In addition, rendering a list of emails will show them as plain text unless the `civicrm_handler_field_email` is used. However, this handler does not support multiple e-mails - for example 'a@gmail.com b@gmail.com' will result in `<a href="a@gmail.com b@gmail.com">a@gmail.com b@gmail.com</a>`

## Solution

Change the view to use an existing field, the 'work_email' field defined on the `hrjc_contact_details` table. This field will be empty if there are no work emails, or a list of them (space separated) if there are some.

In order to render them properly with the links I added a new custom field handler that will make links from each of the e-mails.