### PR TITLE
PCHR-2120: Rewrite the Query to build Absence Activity View to pick data from L&A related tables

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -315,50 +315,32 @@ function _rebuild_absence_activity_view() {
   $civi_settings = parse_url(CIVICRM_DSN);
   $civi_db_name = trim($civi_settings['path'], '/');
 
-  $activityTypesIds = _get_absence_activity_types_ids();
-  if (!empty($activityTypesIds)) {
-    db_query('DROP VIEW IF EXISTS absence_activity');
-    db_query("CREATE VIEW absence_activity AS
-              SELECT ac.contact_id AS absence_contact_id,
-                absence_activity.id AS absence_activity_id,
-                ov.label AS absence_type,
-                DATE(a2.activity_date_time) AS absence_date,
-                DATE_FORMAT(DATE(a2.activity_date_time), '%Y-%m') AS absence_month,
-                (SELECT MIN(DATE(activity_date_time)) FROM {$civi_db_name}.civicrm_activity WHERE source_record_id = a2.source_record_id) AS absence_start_date,
-                DATE_FORMAT((SELECT MIN(DATE(activity_date_time)) FROM {$civi_db_name}.civicrm_activity WHERE source_record_id = a2.source_record_id), '%Y-%m') AS absence_start_date_month,
-                (SELECT MAX(DATE(activity_date_time)) FROM {$civi_db_name}.civicrm_activity WHERE source_record_id = a2.source_record_id) AS absence_end_date,
-                DATE_FORMAT((SELECT MAX(DATE(activity_date_time)) FROM {$civi_db_name}.civicrm_activity WHERE source_record_id = a2.source_record_id), '%Y-%m') AS absence_end_date_month,
-                CONCAT(IF (DATE_FORMAT(a2.activity_date_time, '%w') = 0, 7, DATE_FORMAT(a2.activity_date_time, '%w')), '. ', DATE_FORMAT(a2.activity_date_time, '%W')) AS absence_day_of_week,
-                a2.duration AS absence_duration,
-                IF (ov.label <> 'TOIL (Credit)', a2.duration, NULL) AS absence_amount_taken,
-                IF (ov.label = 'TOIL (Credit)', a2.duration, NULL) AS absence_amount_accrued,
-                IF (ov.label = 'TOIL (Credit)', -a2.duration, a2.duration) AS absence_absolute_amount,
-                a.status_id AS absence_status,
-                IF (ov.label = 'TOIL (Credit)', 1, 0) AS absence_is_credit
-              FROM {$civi_db_name}.civicrm_activity absence_activity
-              LEFT JOIN {$civi_db_name}.civicrm_activity a ON a.id = absence_activity.id
-              LEFT JOIN {$civi_db_name}.civicrm_activity a2 ON a2.source_record_id = absence_activity.id
-              LEFT JOIN {$civi_db_name}.civicrm_option_group og ON og.name = 'activity_type'
-              LEFT JOIN {$civi_db_name}.civicrm_option_value ov ON ov.value = a.activity_type_id AND ov.option_group_id = og.id
-              LEFT JOIN {$civi_db_name}.civicrm_activity_contact ac ON ac.activity_id = absence_activity.id AND ac.record_type_id = 3
-              WHERE (a2.duration IS NOT NULL AND a2.duration > 0)
-              AND
-              absence_activity.activity_type_id IN (" . implode(',', $activityTypesIds) . ")");
+  db_query('DROP VIEW IF EXISTS absence_activity');
+  db_query("CREATE VIEW absence_activity AS
+            SELECT lr.contact_id AS absence_contact_id,
+              lr.id AS absence_activity_id,
+              at.title as absence_type,
+              lrd.date AS absence_date,
+              DATE_FORMAT(DATE(lrd.date), '%Y-%m') AS absence_month,
+              (SELECT MIN(DATE(date)) FROM {$civi_db_name}.civicrm_hrleaveandabsences_leave_request_date WHERE leave_request_id = lr.id) AS absence_start_date,
+              DATE_FORMAT((SELECT MIN(DATE(date)) FROM {$civi_db_name}.civicrm_hrleaveandabsences_leave_request_date WHERE leave_request_id = lr.id), '%Y-%m') AS absence_start_date_month,
+              (SELECT MAX(DATE(date)) FROM {$civi_db_name}.civicrm_hrleaveandabsences_leave_request_date WHERE leave_request_id = lr.id) AS absence_end_date,
+              DATE_FORMAT((SELECT MAX(DATE(date)) FROM {$civi_db_name}.civicrm_hrleaveandabsences_leave_request_date WHERE leave_request_id = lr.id), '%Y-%m') AS absence_end_date_month,
+              CONCAT(IF (DATE_FORMAT(lrd.date, '%w') = 0, 7, DATE_FORMAT(lrd.date, '%w')), '. ', DATE_FORMAT(lrd.date, '%W')) AS absence_day_of_week,
+              ABS(bc.amount) as absence_duration,
+              IF(lr.request_type != 'toil', ABS(bc.amount), NULL) AS absence_amount_taken,
+              IF(lr.request_type = 'toil', bc.amount, NULL) AS absence_amount_accrued,
+              IF(lr.request_type = 'toil', -bc.amount, -bc.amount) AS absence_absolute_amount,
+              lr.status_id AS absence_status,
+              IF(lr.request_type = 'toil', 1, 0) AS absence_is_credit
+            FROM {$civi_db_name}.civicrm_hrleaveandabsences_leave_request lr
+            LEFT JOIN {$civi_db_name}.civicrm_hrleaveandabsences_leave_request_date lrd ON lr.id = lrd.leave_request_id
+            LEFT JOIN {$civi_db_name}.civicrm_hrleaveandabsences_absence_type at ON at.id = lr.type_id
+            LEFT JOIN {$civi_db_name}.civicrm_hrleaveandabsences_leave_balance_change bc ON bc.source_id = lrd.id and bc.source_type = 'leave_request_day'");
 
-    // Set to false so it will not rebuild until not asked to rebuild
-    variable_set('rebuild_absence_activity', 'FALSE');
-  }
-}
+  // Set to false so it will not rebuild until not asked to rebuild
+  variable_set('rebuild_absence_activity', 'FALSE');
 
-/**
- * Return an array of absence activity types IDs.
- *
- * @return array
- */
-function _get_absence_activity_types_ids() {
-  $activityTypesIds = [];
-
-  return $activityTypesIds;
 }
 
 /**

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -322,10 +322,10 @@ function _rebuild_absence_activity_view() {
               at.title as absence_type,
               lrd.date AS absence_date,
               DATE_FORMAT(DATE(lrd.date), '%Y-%m') AS absence_month,
-              (SELECT MIN(DATE(date)) FROM {$civi_db_name}.civicrm_hrleaveandabsences_leave_request_date WHERE leave_request_id = lr.id) AS absence_start_date,
-              DATE_FORMAT((SELECT MIN(DATE(date)) FROM {$civi_db_name}.civicrm_hrleaveandabsences_leave_request_date WHERE leave_request_id = lr.id), '%Y-%m') AS absence_start_date_month,
-              (SELECT MAX(DATE(date)) FROM {$civi_db_name}.civicrm_hrleaveandabsences_leave_request_date WHERE leave_request_id = lr.id) AS absence_end_date,
-              DATE_FORMAT((SELECT MAX(DATE(date)) FROM {$civi_db_name}.civicrm_hrleaveandabsences_leave_request_date WHERE leave_request_id = lr.id), '%Y-%m') AS absence_end_date_month,
+              lr.from_date AS absence_start_date,
+              DATE_FORMAT(DATE(lr.from_date), '%Y-%m') AS absence_start_date_month,
+              lr.to_date AS absence_end_date,
+              DATE_FORMAT(DATE(lr.to_date), '%Y-%m') AS absence_end_date_month,
               CONCAT(IF (DATE_FORMAT(lrd.date, '%w') = 0, 7, DATE_FORMAT(lrd.date, '%w')), '. ', DATE_FORMAT(lrd.date, '%W')) AS absence_day_of_week,
               ABS(bc.amount) as absence_duration,
               IF(lr.request_type != 'toil', ABS(bc.amount), NULL) AS absence_amount_taken,
@@ -334,9 +334,9 @@ function _rebuild_absence_activity_view() {
               lr.status_id AS absence_status,
               IF(lr.request_type = 'toil', 1, 0) AS absence_is_credit
             FROM {$civi_db_name}.civicrm_hrleaveandabsences_leave_request lr
-            LEFT JOIN {$civi_db_name}.civicrm_hrleaveandabsences_leave_request_date lrd ON lr.id = lrd.leave_request_id
-            LEFT JOIN {$civi_db_name}.civicrm_hrleaveandabsences_absence_type at ON at.id = lr.type_id
-            LEFT JOIN {$civi_db_name}.civicrm_hrleaveandabsences_leave_balance_change bc ON bc.source_id = lrd.id and bc.source_type = 'leave_request_day'");
+            INNER JOIN {$civi_db_name}.civicrm_hrleaveandabsences_leave_request_date lrd ON lr.id = lrd.leave_request_id
+            INNER JOIN {$civi_db_name}.civicrm_hrleaveandabsences_absence_type at ON at.id = lr.type_id
+            INNER JOIN {$civi_db_name}.civicrm_hrleaveandabsences_leave_balance_change bc ON bc.source_id = lrd.id and bc.source_type = 'leave_request_day'");
 
   // Set to false so it will not rebuild until not asked to rebuild
   variable_set('rebuild_absence_activity', 'FALSE');

--- a/civihr_hrjobcontract_entities/civihr_hrjobcontract_entities.module
+++ b/civihr_hrjobcontract_entities/civihr_hrjobcontract_entities.module
@@ -1178,6 +1178,7 @@ function civihr_hrjobcontract_entities_entity_property_info_alter(&$info) {
 
     // Add relationship to CiviCRM contact for the Absence Entity
     $info['civihr_length_of_service']['properties']['entity_id']['type'] = 'civicrm_contact';
+    $info['civihr_absence_activity']['properties']['absence_contact_id']['type'] = 'civicrm_contact';
 
     // Properties for phone
     $info['hrjobcontract_contact_info']['properties']['contact_id']['type'] = 'civicrm_contact';


### PR DESCRIPTION
The Absence Activity view was picking data from the HRabsence extension related tables but since the extension will soon be deprecated in favour of the Leave and Absence extension, 
This PR makes the change by modifying the query to build the Absence activity view to pick data from L&A related tables.

The Leave and Absence report view now has its data populated from L&A tables although some view handlers need to be updated as some of the columns are showing incorrect values the columns are Absence status (Picking statues from HRabsence leave request statuses), Absence Duration In Days, Absence Amount Taken, Absence Amount Accrued, Absence Absolute Amount . This will be fixed in subsequent PR's.

Here is a sample cross-section of the Leave and Absence Reports Page.

![civihr custom report - civihr 1 6 demo 2017-04-05 18-47-18](https://cloud.githubusercontent.com/assets/6951813/24719123/7e949ed4-1a30-11e7-9879-9f03db800fcd.png)
