### PR TITLE
PCHR-2122:  Update The Absence Status Views Handler to fetch statuses from Leave Request Status Option Group

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -720,7 +720,7 @@ function get_civihr_absence_statuses($status_id = NULL) {
                 civicrm_initialize();
 
                 // Activity absence statuses array
-                $absenceStatuses = CRM_Core_OptionGroup::values('activity_status', FALSE, FALSE, FALSE, NULL, 'name');
+                $absenceStatuses = CRM_Core_OptionGroup::values('hrleaveandabsences_leave_request_status', FALSE, FALSE, FALSE, NULL, 'label');
 
                 watchdog('DB hit absence statuses', 'DB');
 

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -740,16 +740,7 @@ function get_civihr_absence_statuses($status_id = NULL) {
     // Get the status values based on the status_id
     $status_id_value = CRM_Utils_Array::value($status_id, $absenceStatuses);
 
-    // How we want to display the approved absences?
-    if ($status_id_value == 'Completed') {
-        $status_id_value = 'Approved';
-    }
-    if ($status_id_value == 'Scheduled') {
-        $status_id_value = 'Awaiting approval';
-    }
-
     return $status_id_value;
-
 }
 
 function get_document_statuses($status_id = NULL) {


### PR DESCRIPTION
Previously, the Absence status views handler for the L&A reports view fetches statuses from an option group related to the HRabsence extension. 
This PR modifies the function that fetches the statuses to fetch from the hrleaveandabsences_leave_request_status option group.

![civihr custom report - civihr 1 6 demo 2017-04-07 12-05-19](https://cloud.githubusercontent.com/assets/6951813/24797782/bc2d98d0-1b8a-11e7-9d4c-213e73d492b1.png)
 