### PR TITLE
PCHR-1728: Add SMTP Module to Dependencies

### DIFF
--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.info
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.info
@@ -15,6 +15,7 @@ dependencies[] = menu
 dependencies[] = mimemail
 dependencies[] = mimemail_action
 dependencies[] = mimemail_compress
+dependencies[] = smtp
 dependencies[] = node
 dependencies[] = options
 dependencies[] = page_manager


### PR DESCRIPTION
## Problem
SMTP module had to be installed manually on every CiviHR installation.

## Solution
Added installation of SMTP module to drush makefile for CiviHR in https://github.com/civicrm/civicrm-buildkit/pull/310. Added SMTP module to dependencies of employee portal, so it gets enabled on installation of SSP.