### PR TITLE
PCHR-2159: Fix link to contributing.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 ## Overview
-_A brief description of the pull request. Try to keep it non-technical. Please mark your pull request with the appropriate [label(s)](../CONTRIBUTING.md#label-types)_
+_A brief description of the pull request. Try to keep it non-technical. Please mark your pull request with the appropriate [label(s)](https://github.com/compucorp/civihr-employee-portal/blob/staging/CONTRIBUTING.md#label-types)_
 
 ## Before
 _The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._


### PR DESCRIPTION
## Overview
Relative links don't work in pull requests so this fixes the link to contributing.md

## Before
Link to contributing.md is broken

## After
Link to contributing.md works

---

- [ ] Tests Pass
