### PR TITLE
PCHR-2143: Always Show Documents Widgets

### DIFF
--- a/civihr_employee_portal/views/includes/civihr_employee_portal_handler_absence_table_header_block_area.inc
+++ b/civihr_employee_portal/views/includes/civihr_employee_portal_handler_absence_table_header_block_area.inc
@@ -28,7 +28,7 @@ class civihr_employee_portal_handler_absence_table_header_block_area extends vie
 
   /**
    * Return an array containing header row.
-   * 
+   *
    * @return array
    */
   private function getHeaderRow() {
@@ -122,7 +122,7 @@ class civihr_employee_portal_handler_absence_table_header_block_area extends vie
       '',
     );
     foreach ($activityAbsenceTypeIds as $activityId => $typeId) {
-      $row['type_' . $typeId] = $balance[$typeId];
+      $row['type_' . $typeId] = CRM_Utils_Array::value($typeId, $balance);
     }
 
     return $row;

--- a/civihr_employee_portal/views/templates/views-view-table--Documents--block-1.tpl.php
+++ b/civihr_employee_portal/views/templates/views-view-table--Documents--block-1.tpl.php
@@ -45,8 +45,12 @@ $statuses = array(
     </thead>
     <?php endif; ?>
   <tbody>
-    <?php foreach ($rows as $row_count => $row): ?>
-        <?php $class = 'document-row status-id-' . strip_tags($row['status_id']); ?>
+    <?php foreach ($rows as $row_count => $row):
+      if (!isset($row['id'])) {
+        printf('<tr class = "document-row no-results"><td colspan="4">%s</td></tr>', $row[0]);
+        continue;
+      }
+      $class = 'document-row status-id-' . strip_tags($row['status_id']); ?>
       <tr <?php if ($row_classes[$row_count] || $class) {
           print 'class="' . implode(' ', $row_classes[$row_count]) . ' ' . $class . '"';
         } ?>>

--- a/civihr_employee_portal/views/templates/views-view-table--Documents--block.tpl.php
+++ b/civihr_employee_portal/views/templates/views-view-table--Documents--block.tpl.php
@@ -27,6 +27,9 @@ $statuses = array(
 $statusesCount = array_combine(array_keys($statuses), array_fill(0, count($statuses), 0));
 
 foreach ($rows as $row):
+  if (!isset($row['status_id'])) {
+    continue;
+  }
   $statusesCount[strtolower(str_replace(' ', '-', $row['status_id']))] ++;
   $statusesCount[0] ++;
 endforeach;
@@ -73,8 +76,12 @@ endforeach;
           </thead>
           <?php endif; ?>
         <tbody>
-          <?php foreach ($rows as $row_count => $row): ?>
-              <?php $class = 'document-row status-id-' . strtolower(str_replace(' ', '-', $row['status_id'])); ?>
+          <?php foreach ($rows as $row_count => $row):
+              if (!isset($row['id'])) {
+                printf('<tr class = "document-row no-results"><td colspan="4">%s</td></tr>', $row[0]);
+                continue;
+              }
+              $class = 'document-row status-id-' . strtolower(str_replace(' ', '-', $row['status_id'])); ?>
             <tr <?php if ($row_classes[$row_count] || $class) {
                 print 'class="' . implode(' ', $row_classes[$row_count]) . ' ' . $class . '"';
               } ?>>

--- a/civihr_employee_portal/views/views_export/views_documents.inc
+++ b/civihr_employee_portal/views/views_export/views_documents.inc
@@ -118,6 +118,14 @@ $handler->display->display_options['style_options']['info'] = array(
     'empty_column' => 0,
   ),
 );
+$handler->display->display_options['style_options']['empty_table'] = TRUE;
+/* No results behavior: Global: Unfiltered text */
+$handler->display->display_options['empty']['area_text_custom']['id'] = 'area_text_custom';
+$handler->display->display_options['empty']['area_text_custom']['table'] = 'views';
+$handler->display->display_options['empty']['area_text_custom']['field'] = 'area_text_custom';
+$handler->display->display_options['empty']['area_text_custom']['label'] = 'No Document Results';
+$handler->display->display_options['empty']['area_text_custom']['empty'] = TRUE;
+$handler->display->display_options['empty']['area_text_custom']['content'] = 'There are no documents to display.';
 /* Field: Document entity: Document entity ID */
 $handler->display->display_options['fields']['id']['id'] = 'id';
 $handler->display->display_options['fields']['id']['table'] = 'documents';


### PR DESCRIPTION
## Overview
The document and document manager widget s are hidden on the SSP dashboard if you don't have documents assigned to you. They should always be shown, with a message saying there are no documents.

## Before

If you didn't have documents assigned you wouldn't see the "Documents" or "Document Manager" widgets.

![](https://s3-eu-west-1.amazonaws.com/uploads-eu.hipchat.com/124355/4781222/p02DeGjef3Fh5C6/upload.png)


## After
You will always see the "Documents" and "Document Manager" widgets, regardless of whether you have anything assigned to you.

![screenshot from 2017-04-27 15-38-02](https://cloud.githubusercontent.com/assets/6374064/25488684/8e914bf8-2b5f-11e7-9fe3-51bab313fce4.png)


## Technical Details
This PR makes changes to a view so reverting the view will be necessary.

## Comments
Changing the view was a small issue, but the template does not expect empty results so I needed to fix the warnings from PHP.

---

- [ ] Tests Pass

It looks like the tests haven't been run for a while and are broken.
