### PR TITLE
PCHR-2144: Updates to SSP documents widget

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.info
+++ b/civihr_employee_portal/civihr_employee_portal.info
@@ -36,6 +36,7 @@ dependencies[] = views_json
 dependencies[] = views_bulk_operations
 dependencies[] = browserclass
 dependencies[] = conditional_styles
+dependencies[] = civicrm_resources
 
 ; Views Handlers
 files[] = views/includes/civihr_employee_portal_argument_date_range.inc

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -549,7 +549,6 @@ function civihr_employee_portal_init() {
     drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/lib/sweetalert/sweetalert.css");
     drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/lib/tablesaw/tablesaw.css");
 
-
     _add_script_to_page('/js/tasks.js', 'dashboard');
 
     _add_script_to_page([
@@ -563,6 +562,9 @@ function civihr_employee_portal_init() {
       '/lib/sweetalert/sweetalert.min.js'
     ]);
 
+    civicrm_resources_load('org.civicrm.reqangular', ['reqangular.min.js']);
+    _add_script_to_page('/js/ta-documents-app.js', 'dashboard');
+
     _rebuild_view('absence_list');
     _rebuild_view('length_of_service');
     _rebuild_view('absence_activity');
@@ -572,13 +574,12 @@ function civihr_employee_portal_init() {
     _rebuild_view('documents');
 
     _load_ta_settings();
-
-    // Page load scripts
-    civicrm_resources_load('org.civicrm.reqangular', ['reqangular.min.js']);
-    _add_script_to_page('/js/ta-documents-app.js', 'dashboard');
   }
 }
 
+/**
+ * Pass tasksAssignments data to Global Drupal.settings object
+ */
 function _load_ta_settings() {
   $taSettings = civicrm_api3('TASettings', 'get')['values'];
 
@@ -587,15 +588,15 @@ function _load_ta_settings() {
   }
 
   drupal_add_js([
-    'Tasksassignments' => array(
+    'tasksAssignments' => [
       'extensionPath' => CRM_Core_Resources::singleton()->getUrl('uk.co.compucorp.civicrm.tasksassignments'),
       'case_extension' => !empty(CRM_Core_Component::get('CiviCase')),
       'settings' => $taSettings,
-      'permissions' => array(
+      'permissions' => [
         'delete_tasks_and_documents' => CRM_Core_Permission::check('delete Tasks and Documents'),
-      ),
+      ],
       'debug' => $config->debug
-    ),
+    ],
     'adminId' => CRM_Core_Session::getLoggedInContactID(),
     'contactId' => CRM_Utils_Request::retrieve('cid', 'Integer')
   ], 'setting');

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -581,6 +581,7 @@ function civihr_employee_portal_init() {
  * Pass tasksAssignments data to Global Drupal.settings object
  */
 function _load_ta_settings() {
+  $config = CRM_Core_Config::singleton();
   $taSettings = civicrm_api3('TASettings', 'get')['values'];
 
   if (!empty($taSettings['days_to_create_a_document_clone'])) {

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -569,6 +569,32 @@ function civihr_employee_portal_init() {
     _rebuild_view('appraisal');
     _rebuild_view('tasks');
     _rebuild_view('documents');
+
+    $extensionPath = CRM_Extension_System::singleton()->getMapper()->keyToUrl('uk.co.compucorp.civicrm.tasksassignments');
+
+    $allSettings = array();
+    $taSettings = civicrm_api3('TASettings', 'get');
+    foreach ($taSettings['values'] as $key => $value) {
+      $allSettings[$key] = $value['value'];
+    }
+    if (!empty($allSettings['days_to_create_a_document_clone'])) {
+      $allSettings['days_to_create_a_document_clone'] = (int)$allSettings['days_to_create_a_document_clone'];
+    }
+
+    $settings = [
+      'Tasksassignments' => array(
+        'extensionPath' => CRM_Core_Resources::singleton()->getUrl('uk.co.compucorp.civicrm.tasksassignments'),
+        'case_extension' => !empty(CRM_Core_Component::get('CiviCase')),
+        'settings' => $allSettings,
+        'permissions' => array(
+          'delete_tasks_and_documents' => CRM_Core_Permission::check('delete Tasks and Documents'),
+        ),
+      ),
+      'adminId' => CRM_Core_Session::getLoggedInContactID(),
+      'contactId' => _get_civicrm_contact_id_by_drupal_uid($user->uid),
+      'debug' => $config->debug
+    ];
+    drupal_add_js($settings, 'setting');
   }
 }
 

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -130,43 +130,30 @@ function _setup_modals() {
 }
 
 /**
- * Adds a script to a specific page form other extensions
- *
- * @param array $resources (key as Module and value as array of scripts)
- * @param string $page
- */
-function _add_module_script_to_page($resources, $page = NULL) {
-
-  if (!is_null($page) && arg(0) != $page) {
-    return;
-  }
-
-  if (is_array($resources)) {
-    foreach ($resources as $key => $value) {
-      civicrm_resources_load($key, $value);
-    }
-  }
-}
-
-/**
  * Adds a script to a specific page.
  *
- * @param string $scriptFile the name of the script file (extension included)
+ * @param string $resources the name of the script file (extension included)
+ * @param string $extension
  * @param string $page
  */
-function _add_script_to_page($scriptFile, $page = NULL) {
+function _add_script_to_page($resources, $extension = NULL, $page = NULL) {
 
   if (!is_null($page) && arg(0) != $page) {
     return;
   }
 
-  if (is_array($scriptFile)) {
-    foreach ($scriptFile as $value) {
-      drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . $value, 'file');
-    }
+  if ($extension) {
+    civicrm_resources_load($extension, $resources);
   }
   else {
-    drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . $scriptFile, 'file');
+    if (is_array($resources)) {
+      foreach ($resources as $value) {
+        drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . $value, 'file');
+      }
+    }
+    else {
+      drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . $resources, 'file');
+    }
   }
 }
 
@@ -569,8 +556,6 @@ function civihr_employee_portal_init() {
     drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/lib/sweetalert/sweetalert.css");
     drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/lib/tablesaw/tablesaw.css");
 
-    _add_script_to_page('/js/tasks.js', 'dashboard');
-
     _add_script_to_page([
       '/js/scripts.js',
       '/js/filters.js',
@@ -582,13 +567,8 @@ function civihr_employee_portal_init() {
       '/lib/sweetalert/sweetalert.min.js'
     ]);
 
-    _add_module_script_to_page([
-      'org.civicrm.reqangular' => [
-        'reqangular.min.js'
-        ]
-      ], 'dashboard');
-
-    _add_script_to_page('/js/ta-documents-app.js', 'dashboard');
+    _add_script_to_page(['reqangular.min.js'], 'org.civicrm.reqangular', 'dashboard');
+    _add_script_to_page(['/js/tasks.js', '/js/ta-documents-app.js'], NULL, 'dashboard');
 
     _rebuild_view('absence_list');
     _rebuild_view('length_of_service');

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -130,6 +130,25 @@ function _setup_modals() {
 }
 
 /**
+ * Adds a script to a specific page form other extensions
+ *
+ * @param array $resources (key as Module and value as array of scripts)
+ * @param string $page
+ */
+function _add_module_script_to_page($resources, $page = NULL) {
+
+  if (!is_null($page) && arg(0) != $page) {
+    return;
+  }
+
+  if (is_array($resources)) {
+    foreach ($resources as $key => $value) {
+      civicrm_resources_load($key, $value);
+    }
+  }
+}
+
+/**
  * Adds a script to a specific page.
  *
  * @param string $scriptFile the name of the script file (extension included)
@@ -140,6 +159,7 @@ function _add_script_to_page($scriptFile, $page = NULL) {
   if (!is_null($page) && arg(0) != $page) {
     return;
   }
+
   if (is_array($scriptFile)) {
     foreach ($scriptFile as $value) {
       drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . $value, 'file');
@@ -562,7 +582,12 @@ function civihr_employee_portal_init() {
       '/lib/sweetalert/sweetalert.min.js'
     ]);
 
-    civicrm_resources_load('org.civicrm.reqangular', ['reqangular.min.js']);
+    _add_module_script_to_page([
+      'org.civicrm.reqangular' => [
+        'reqangular.min.js'
+        ]
+      ], 'dashboard');
+
     _add_script_to_page('/js/ta-documents-app.js', 'dashboard');
 
     _rebuild_view('absence_list');
@@ -598,8 +623,7 @@ function _load_ta_settings() {
       ],
       'debug' => $config->debug
     ],
-    'adminId' => CRM_Core_Session::getLoggedInContactID(),
-    'contactId' => CRM_Utils_Request::retrieve('cid', 'Integer')
+    'adminId' => CRM_Core_Session::getLoggedInContactID()
   ], 'setting');
 }
 

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -549,6 +549,7 @@ function civihr_employee_portal_init() {
     drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/lib/sweetalert/sweetalert.css");
     drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/lib/tablesaw/tablesaw.css");
 
+
     _add_script_to_page('/js/tasks.js', 'dashboard');
 
     _add_script_to_page([
@@ -570,32 +571,34 @@ function civihr_employee_portal_init() {
     _rebuild_view('tasks');
     _rebuild_view('documents');
 
-    $extensionPath = CRM_Extension_System::singleton()->getMapper()->keyToUrl('uk.co.compucorp.civicrm.tasksassignments');
+    _load_ta_settings();
 
-    $allSettings = array();
-    $taSettings = civicrm_api3('TASettings', 'get');
-    foreach ($taSettings['values'] as $key => $value) {
-      $allSettings[$key] = $value['value'];
-    }
-    if (!empty($allSettings['days_to_create_a_document_clone'])) {
-      $allSettings['days_to_create_a_document_clone'] = (int)$allSettings['days_to_create_a_document_clone'];
-    }
-
-    $settings = [
-      'Tasksassignments' => array(
-        'extensionPath' => CRM_Core_Resources::singleton()->getUrl('uk.co.compucorp.civicrm.tasksassignments'),
-        'case_extension' => !empty(CRM_Core_Component::get('CiviCase')),
-        'settings' => $allSettings,
-        'permissions' => array(
-          'delete_tasks_and_documents' => CRM_Core_Permission::check('delete Tasks and Documents'),
-        ),
-      ),
-      'adminId' => CRM_Core_Session::getLoggedInContactID(),
-      'contactId' => _get_civicrm_contact_id_by_drupal_uid($user->uid),
-      'debug' => $config->debug
-    ];
-    drupal_add_js($settings, 'setting');
+    // Page load scripts
+    civicrm_resources_load('org.civicrm.reqangular', ['reqangular.min.js']);
+    _add_script_to_page('/js/ta-documents-app.js', 'dashboard');
   }
+}
+
+function _load_ta_settings() {
+  $taSettings = civicrm_api3('TASettings', 'get')['values'];
+
+  if (!empty($taSettings['days_to_create_a_document_clone'])) {
+    $taSettings['days_to_create_a_document_clone'] = (int)$taSettings['days_to_create_a_document_clone'];
+  }
+
+  drupal_add_js([
+    'Tasksassignments' => array(
+      'extensionPath' => CRM_Core_Resources::singleton()->getUrl('uk.co.compucorp.civicrm.tasksassignments'),
+      'case_extension' => !empty(CRM_Core_Component::get('CiviCase')),
+      'settings' => $taSettings,
+      'permissions' => array(
+        'delete_tasks_and_documents' => CRM_Core_Permission::check('delete Tasks and Documents'),
+      ),
+      'debug' => $config->debug
+    ),
+    'adminId' => CRM_Core_Session::getLoggedInContactID(),
+    'contactId' => CRM_Utils_Request::retrieve('cid', 'Integer')
+  ], 'setting');
 }
 
 function _rebuild_reports_views() {

--- a/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
+++ b/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
@@ -27,6 +27,7 @@ function civihr_default_permissions_user_default_permissions() {
       'civihr_admin' => 'civihr_admin',
       'civihr_admin_local' => 'civihr_admin_local',
       'civihr_manager' => 'civihr_manager',
+      'civihr_staff' => 'civihr_staff',
     ),
     'module' => 'civicrm',
   );
@@ -2099,6 +2100,7 @@ function civihr_default_permissions_user_default_permissions() {
       'civihr_admin' => 'civihr_admin',
       'civihr_admin_local' => 'civihr_admin_local',
       'civihr_manager' => 'civihr_manager',
+      'civihr_staff' => 'civihr_staff',
     ),
     'module' => 'civicrm',
   );

--- a/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
+++ b/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
@@ -99,6 +99,17 @@ function civihr_default_permissions_user_default_permissions() {
     'module' => 'civicrm',
   );
 
+  // Exported permission: 'access Tasks and Assignments Files'.
+  $permissions['access Tasks and Assignments Files'] = array(
+    'name' => 'access Tasks and Assignments Files',
+    'roles' => array(
+      'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
+      'civihr_staff' => 'civihr_staff',
+    ),
+    'module' => 'civicrm',
+  );
+
   // Exported permission: 'access Vacancy'.
   $permissions['access Vacancy'] = array(
     'name' => 'access Vacancy',
@@ -380,6 +391,7 @@ function civihr_default_permissions_user_default_permissions() {
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
       'civihr_admin_local' => 'civihr_admin_local',
+      'civihr_staff' => 'civihr_staff',
     ),
     'module' => 'civicrm',
   );
@@ -2226,17 +2238,17 @@ function civihr_default_permissions_user_default_permissions() {
   );
 
   // Exported permission: 'view my tasks and documents blocks'.
-  $permissions['view my tasks and documents blocks'] = [
+  $permissions['view my tasks and documents blocks'] = array(
     'name' => 'view my tasks and documents blocks',
-    'roles' => [
+    'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
       'civihr_admin_local' => 'civihr_admin_local',
       'civihr_manager' => 'civihr_manager',
       'civihr_staff' => 'civihr_staff',
-    ],
+    ),
     'module' => 'civihr_employee_portal',
-  ];
+  );
 
   // Exported permission: 'view own manual batches'.
   $permissions['view own manual batches'] = array(

--- a/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.info
+++ b/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.info
@@ -51,6 +51,7 @@ features[user_permission][] = access HRJobs
 features[user_permission][] = access HRReport
 features[user_permission][] = access Report Criteria
 features[user_permission][] = access Tasks and Assignments
+features[user_permission][] = access Tasks and Assignments Files
 features[user_permission][] = access Vacancy
 features[user_permission][] = access administration pages
 features[user_permission][] = access all cases and activities

--- a/civihr_employee_portal/js/ta-documents-app.js
+++ b/civihr_employee_portal/js/ta-documents-app.js
@@ -24,14 +24,14 @@
           .catch(function (reason) {
             CRM.alert(reason, 'Error', 'error');
           });
-      }
+      };
 
-      (function init ($window) {
+      (function init () {
         // Reloads page on 'document-saved' event
         $rootScope.$on('document-saved', function () {
           $window.location.reload();
         });
-      })($window);
+      })();
 
       /**
        * Opens Document Modal

--- a/civihr_employee_portal/js/ta-documents-app.js
+++ b/civihr_employee_portal/js/ta-documents-app.js
@@ -1,8 +1,8 @@
 /* globals angular */
 
 (function (angular) {
-  angular.module('taDocuments', ['civitasks.appDocuments']).controller('ModalController', ['$scope', '$rootScope', '$rootElement', '$log', '$uibModal', 'DocumentService', 'FileService', 'config',
-    function ($scope, $rootScope, $rootElement, $log, $modal, DocumentService, FileService, config) {
+  angular.module('taDocuments', ['civitasks.appDocuments']).controller('ModalController', ['$scope', '$rootScope', '$window', '$rootElement', '$log', '$uibModal', 'DocumentService', 'FileService', 'config',
+    function ($scope, $rootScope, $window, $rootElement, $log, $modal, DocumentService, FileService, config) {
       var vm = {};
 
       /**
@@ -25,6 +25,11 @@
             CRM.alert(reason, 'Error', 'error');
           });
       }
+
+      // Reloads page on 'document-saved' event
+      $rootScope.$on('document-saved', function () {
+        $window.location.reload();
+      });
 
       /**
        * Opens Document Modal

--- a/civihr_employee_portal/js/ta-documents-app.js
+++ b/civihr_employee_portal/js/ta-documents-app.js
@@ -1,13 +1,11 @@
-angular.module('taDocuments', ['civitasks.appDocuments']).controller('myController', ['$scope', '$rootScope', '$rootElement', '$log', '$uibModal', 'DocumentService', 'FileService', 'config',
+angular.module('taDocuments', ['civitasks.appDocuments']).controller('ModalController', ['$scope', '$rootScope', '$rootElement', '$log', '$uibModal', 'DocumentService', 'FileService', 'config',
   function($scope, $rootScope, $rootElement, $log, $modal, DocumentService, FileService, config) {
     $scope.modalDocument = function(data, e) {
       e && e.preventDefault();
-      var DocumentData = DocumentService.get({
+      DocumentService.get({
         'id': data.id
-      });
-
-      DocumentData.then(function(data) {
-        // Function to display the modal
+      }).then(function(data) {
+        // Display the modal
         openModalDocument(data[0]);
       });
     }

--- a/civihr_employee_portal/js/ta-documents-app.js
+++ b/civihr_employee_portal/js/ta-documents-app.js
@@ -1,12 +1,13 @@
 angular.module('taDocuments', ['civitasks.appDocuments']).controller('ModalController', ['$scope', '$rootScope', '$rootElement', '$log', '$uibModal', 'DocumentService', 'FileService', 'config',
-  function($scope, $rootScope, $rootElement, $log, $modal, DocumentService, FileService, config) {
-    $scope.modalDocument = function(data, e) {
-      e && e.preventDefault();
-      DocumentService.get({
-        'id': data.id
-      }).then(function(data) {
+  function ($scope, $rootScope, $rootElement, $log, $modal, DocumentService, FileService, config) {
+    this.modalDocument = function (id, role) {
+
+      DocumentService.get({'id': id})
+      .then(function (data) {
         // Display the modal
-        openModalDocument(data[0]);
+        !!data && openModalDocument(data[0], role);
+      }, function (reason) {
+        CRM.alert(reason, 'Error', 'error');
       });
     }
 
@@ -15,16 +16,19 @@ angular.module('taDocuments', ['civitasks.appDocuments']).controller('ModalContr
      *
      * @param {object} data
      */
-    function openModalDocument(data) {
+    function openModalDocument (data, role) {
       var modalInstance = $modal.open({
         appendTo: $rootElement.find('div').eq(0),
         templateUrl: config.path.TPL + 'modal/document.html?v=3',
         controller: 'ModalDocumentCtrl',
         resolve: {
-          data: function() {
+          role: function () {
+            return [role];
+          },
+          data: function () {
             return data;
           },
-          files: function() {
+          files: function () {
             if (!data.id || !+data.file_count) {
               return [];
             }
@@ -34,13 +38,13 @@ angular.module('taDocuments', ['civitasks.appDocuments']).controller('ModalContr
         }
       });
 
-      modalInstance.result.then(function(results) {
+      modalInstance.result.then(function (results) {
         $scope.$broadcast('documentFormSuccess', results, data);
 
         if (results.open) {
           $rootScope.modalDocument(data);
         }
-      }, function() {
+      }, function () {
         $log.info('Modal dismissed');
       });
     }

--- a/civihr_employee_portal/js/ta-documents-app.js
+++ b/civihr_employee_portal/js/ta-documents-app.js
@@ -1,0 +1,50 @@
+angular.module('taDocuments', ['civitasks.appDocuments']).controller('myController', ['$scope', '$rootScope', '$rootElement', '$log', '$uibModal', 'DocumentService', 'FileService', 'config',
+  function($scope, $rootScope, $rootElement, $log, $modal, DocumentService, FileService, config) {
+    $scope.modalDocument = function(data, e) {
+      e && e.preventDefault();
+      var DocumentData = DocumentService.get({
+        'id': data.id
+      });
+
+      DocumentData.then(function(data) {
+        // Function to display the modal
+        openModalDocument(data[0]);
+      });
+    }
+
+    /**
+     * Opens Document Modal with or without document data
+     *
+     * @param {object} data
+     */
+    function openModalDocument(data) {
+      var modalInstance = $modal.open({
+        appendTo: $rootElement.find('div').eq(0),
+        templateUrl: config.path.TPL + 'modal/document.html?v=3',
+        controller: 'ModalDocumentCtrl',
+        resolve: {
+          data: function() {
+            return data;
+          },
+          files: function() {
+            if (!data.id || !+data.file_count) {
+              return [];
+            }
+
+            return FileService.get(data.id, 'civicrm_activity');
+          }
+        }
+      });
+
+      modalInstance.result.then(function(results) {
+        $scope.$broadcast('documentFormSuccess', results, data);
+
+        if (results.open) {
+          $rootScope.modalDocument(data);
+        }
+      }, function() {
+        $log.info('Modal dismissed');
+      });
+    }
+  }
+]);

--- a/civihr_employee_portal/js/ta-documents-app.js
+++ b/civihr_employee_portal/js/ta-documents-app.js
@@ -26,10 +26,12 @@
           });
       }
 
-      // Reloads page on 'document-saved' event
-      $rootScope.$on('document-saved', function () {
-        $window.location.reload();
-      });
+      (function init ($window) {
+        // Reloads page on 'document-saved' event
+        $rootScope.$on('document-saved', function () {
+          $window.location.reload();
+        });
+      })($window);
 
       /**
        * Opens Document Modal

--- a/civihr_employee_portal/views/templates/views-view-table--Documents--block.tpl.php
+++ b/civihr_employee_portal/views/templates/views-view-table--Documents--block.tpl.php
@@ -34,7 +34,7 @@ foreach ($rows as $row):
   $statusesCount[0] ++;
 endforeach;
 ?>
-<div data-ta-documents ng-controller="myController" class="chr_table-w-filters chr_table-w-filters--documents row">
+<div data-ta-documents ng-controller="ModalController" class="chr_table-w-filters chr_table-w-filters--documents row">
   <div class="chr_table-w-filters__filters col-md-3">
     <div class="chr_table-w-filters__filters__dropdown-wrapper">
       <div class="chr_custom-select chr_custom-select--full">
@@ -107,9 +107,7 @@ endforeach;
                   </button>
                 <?php else: ?>
                   <button
-                    ng-click="modalDocument({
-                      id: <?php print strip_tags($row['id']); ?>
-                    })"
+                    ng-click="modalDocument({ id: <?php print strip_tags($row['id']); ?> })"
                     class="btn btn-sm btn-default">
                     <i class="fa fa-upload"></i> Open
                   </button>
@@ -129,8 +127,8 @@ endforeach;
 
     CRM.contactId = Drupal.settings.contactId;
     CRM.adminId = Drupal.settings.adminId;
-    CRM.Tasksassignments = Drupal.settings.Tasksassignments;
-    CRM.debug = Drupal.settings.Tasksassignments.debug;
+    CRM.tasksAssignments = Drupal.settings.tasksAssignments;
+    CRM.debug = Drupal.settings.tasksAssignments.debug;
 
     function filterTable(statusId) {
       if (parseInt(statusId, 10) === 0) {

--- a/civihr_employee_portal/views/templates/views-view-table--Documents--block.tpl.php
+++ b/civihr_employee_portal/views/templates/views-view-table--Documents--block.tpl.php
@@ -17,6 +17,9 @@
  *   field id, then row number. This matches the index in $rows.
  * @ingroup views_templates
  */
+// loading required resources
+civicrm_resources_load('org.civicrm.reqangular', ['reqangular.min.js']);
+
 $statuses = array(
   0 => t('All'),
   'awaiting-upload' => t('Awaiting upload'),
@@ -155,5 +158,29 @@ endforeach;
     $filtersDropdown.on('change', function (e) {
       filterTable($(this).val());
     });
+
+    // Trigger event to trigger appDocuments forom T&A
+    function taInit() {
+      var detail = {
+        'app': 'appDocuments',
+        'module': 'tnadocuments'
+      };
+
+      document.dispatchEvent(typeof window.CustomEvent == "function" ? new CustomEvent('taInit', {
+        'detail': detail
+      }) : (function(){
+        var e = document.createEvent('CustomEvent');
+        e.initCustomEvent('taInit', true, true, detail);
+        return e;
+      })());
+    };
+
+    taInit();
+
+    document.addEventListener('taReady', function(){
+      taInit();
+    });
   }(CRM.$));
 </script>
+
+<script src="<?php echo getModuleUrl('uk.co.compucorp.civicrm.tasksassignments').'js/dist/tasks-assignments.min.js';?>"></script>

--- a/civihr_employee_portal/views/templates/views-view-table--Documents--block.tpl.php
+++ b/civihr_employee_portal/views/templates/views-view-table--Documents--block.tpl.php
@@ -130,6 +130,15 @@ endforeach;
   (function ($) {
     'use strict';
 
+    CRM.contactId = Drupal.settings.contactId;
+    CRM.adminId = Drupal.settings.adminId;
+    CRM.Tasksassignments = {
+      extensionPath: Drupal.settings.Tasksassignments.extensionPath,
+      case_extension: Drupal.settings.Tasksassignments.case_extension,
+      settings: Drupal.settings.Tasksassignments.settings,
+      permissions: Drupal.settings.Tasksassignments.permissions
+    };
+
     function filterTable(statusId) {
       if (parseInt(statusId, 10) === 0) {
         $tableDocStaffRows.show();

--- a/civihr_employee_portal/views/templates/views-view-table--Documents--block.tpl.php
+++ b/civihr_employee_portal/views/templates/views-view-table--Documents--block.tpl.php
@@ -17,9 +17,6 @@
  *   field id, then row number. This matches the index in $rows.
  * @ingroup views_templates
  */
-// loading required resources
-civicrm_resources_load('org.civicrm.reqangular', ['reqangular.min.js']);
-
 $statuses = array(
   0 => t('All'),
   'awaiting-upload' => t('Awaiting upload'),
@@ -37,7 +34,7 @@ foreach ($rows as $row):
   $statusesCount[0] ++;
 endforeach;
 ?>
-<div id="tnadocuments" ng-controller="MainCtrl" class="chr_table-w-filters chr_table-w-filters--documents row">
+<div data-ta-documents ng-controller="myController" class="chr_table-w-filters chr_table-w-filters--documents row">
   <div class="chr_table-w-filters__filters col-md-3">
     <div class="chr_table-w-filters__filters__dropdown-wrapper">
       <div class="chr_custom-select chr_custom-select--full">
@@ -132,12 +129,8 @@ endforeach;
 
     CRM.contactId = Drupal.settings.contactId;
     CRM.adminId = Drupal.settings.adminId;
-    CRM.Tasksassignments = {
-      extensionPath: Drupal.settings.Tasksassignments.extensionPath,
-      case_extension: Drupal.settings.Tasksassignments.case_extension,
-      settings: Drupal.settings.Tasksassignments.settings,
-      permissions: Drupal.settings.Tasksassignments.permissions
-    };
+    CRM.Tasksassignments = Drupal.settings.Tasksassignments;
+    CRM.debug = Drupal.settings.Tasksassignments.debug;
 
     function filterTable(statusId) {
       if (parseInt(statusId, 10) === 0) {
@@ -149,11 +142,11 @@ endforeach;
       $tableDocStaff.find('.status-id-' + statusId).show();
     }
 
-    var $tableFilters = $('.chr_table-w-filters--documents'),
-      $filtersDropdown = $tableFilters.find('.chr_table-w-filters__filters__dropdown'),
-      $filtersNav = $tableFilters.find('.chr_table-w-filters__filters__nav'),
-      $tableDocStaff = $tableFilters.find('.chr_table-w-filters__table'),
-      $tableDocStaffRows = $tableDocStaff.find('.document-row');
+    var $tableFilters = $('.chr_table-w-filters--documents');
+    var $filtersDropdown = $tableFilters.find('.chr_table-w-filters__filters__dropdown');
+    var $filtersNav = $tableFilters.find('.chr_table-w-filters__filters__nav');
+    var $tableDocStaff = $tableFilters.find('.chr_table-w-filters__table');
+    var $tableDocStaffRows = $tableDocStaff.find('.document-row');
 
     $filtersNav.find('a').bind('click', function (e) {
       e.preventDefault();
@@ -170,27 +163,11 @@ endforeach;
       filterTable($(this).val());
     });
 
-    // Trigger event to trigger appDocuments forom T&A
-    function taInit() {
-      var detail = {
-        'app': 'appDocuments',
-        'module': 'tnadocuments'
-      };
-
-      document.dispatchEvent(typeof window.CustomEvent == "function" ? new CustomEvent('taInit', {
-        'detail': detail
-      }) : (function(){
-        var e = document.createEvent('CustomEvent');
-        e.initCustomEvent('taInit', true, true, detail);
-        return e;
-      })());
-    };
-
-    taInit();
-
-    document.addEventListener('taReady', function(){
-      taInit();
+    // Listen for ready event when T&A finishes loading all modules
+    document.addEventListener('taReady', function (e) {
+      angular.bootstrap(angular.element("[data-ta-documents]"), ['taDocuments']);
     });
+
   }(CRM.$));
 </script>
 

--- a/civihr_employee_portal/views/templates/views-view-table--Documents--block.tpl.php
+++ b/civihr_employee_portal/views/templates/views-view-table--Documents--block.tpl.php
@@ -37,20 +37,20 @@ foreach ($rows as $row):
   $statusesCount[0] ++;
 endforeach;
 ?>
-<div class="chr_table-w-filters chr_table-w-filters--documents row">
+<div id="tnadocuments" ng-controller="MainCtrl" class="chr_table-w-filters chr_table-w-filters--documents row">
   <div class="chr_table-w-filters__filters col-md-3">
     <div class="chr_table-w-filters__filters__dropdown-wrapper">
       <div class="chr_custom-select chr_custom-select--full">
         <select class="chr_table-w-filters__filters__dropdown skip-js-custom-select">
-<?php foreach ($statuses as $key => $value): ?>
+          <?php foreach ($statuses as $key => $value): ?>
             <option value="<?php print $key; ?>"><?php print $value; ?> (<?php print $statusesCount[$key]; ?>)</option>
           <?php endforeach; ?>
         </select>
       </div>
     </div>
     <ul class="chr_table-w-filters__filters__nav">
-<?php $classActive = ' class="active"'; ?>
-<?php foreach ($statuses as $key => $value): ?>
+      <?php $classActive = ' class="active"'; ?>
+      <?php foreach ($statuses as $key => $value): ?>
         <li<?php print $classActive; ?>><a href data-document-status="<?php print $key; ?>"><?php print $value; ?> <span class="badge badge-primary pull-right"><?php print $statusesCount[$key]; ?></span></a></li>
         <?php $classActive = ''; ?>
       <?php endforeach; ?>
@@ -73,7 +73,7 @@ endforeach;
                 } ?>>
                 <?php print $label; ?>
                 </th>
-  <?php endforeach; ?>
+                <?php endforeach; ?>
               <th></th>
             </tr>
           </thead>
@@ -98,26 +98,28 @@ endforeach;
                   continue;
                 endif;
                 ?>
-    <?php print $content; ?>
+                <?php print $content; ?>
                 </td>
                 <?php endforeach; ?>
               <td>
-  <?php if (strip_tags($row['status_id']) == 3): ?>
+                <?php if (strip_tags($row['status_id']) == 3): ?>
                   <button
                     class="btn btn-sm btn-default ctools-use-modal ctools-modal-civihr-default-style ctools-use-modal-processed"
                     disabled="disabled">
-                    <i class="fa fa-upload"></i> Upload
+                    <i class="fa fa-upload"></i> Open
                   </button>
-  <?php else: ?>
-                  <a
-                    href="/civi_documents/nojs/edit/<?php print strip_tags($row['id']); ?>"
-                    class="btn btn-sm btn-default ctools-use-modal ctools-modal-civihr-default-style ctools-use-modal-processed">
-                    <i class="fa fa-upload"></i> Upload
-                  </a>
-  <?php endif; ?>
+                <?php else: ?>
+                  <button
+                    ng-click="modalDocument({
+                      id: <?php print strip_tags($row['id']); ?>
+                    })"
+                    class="btn btn-sm btn-default">
+                    <i class="fa fa-upload"></i> Open
+                  </button>
+                <?php endif; ?>
               </td>
             </tr>
-<?php endforeach; ?>
+          <?php endforeach; ?>
         </tbody>
       </table>
     </div>
@@ -139,10 +141,10 @@ endforeach;
     }
 
     var $tableFilters = $('.chr_table-w-filters--documents'),
-            $filtersDropdown = $tableFilters.find('.chr_table-w-filters__filters__dropdown'),
-            $filtersNav = $tableFilters.find('.chr_table-w-filters__filters__nav'),
-            $tableDocStaff = $tableFilters.find('.chr_table-w-filters__table'),
-            $tableDocStaffRows = $tableDocStaff.find('.document-row');
+      $filtersDropdown = $tableFilters.find('.chr_table-w-filters__filters__dropdown'),
+      $filtersNav = $tableFilters.find('.chr_table-w-filters__filters__nav'),
+      $tableDocStaff = $tableFilters.find('.chr_table-w-filters__table'),
+      $tableDocStaffRows = $tableDocStaff.find('.document-row');
 
     $filtersNav.find('a').bind('click', function (e) {
       e.preventDefault();

--- a/civihr_employee_portal/views/templates/views-view-table--Documents--block.tpl.php
+++ b/civihr_employee_portal/views/templates/views-view-table--Documents--block.tpl.php
@@ -34,7 +34,7 @@ foreach ($rows as $row):
   $statusesCount[0] ++;
 endforeach;
 ?>
-<div data-ta-documents ng-controller="ModalController" class="chr_table-w-filters chr_table-w-filters--documents row">
+<div data-ta-documents ng-controller="ModalController as document" class="chr_table-w-filters chr_table-w-filters--documents row">
   <div class="chr_table-w-filters__filters col-md-3">
     <div class="chr_table-w-filters__filters__dropdown-wrapper">
       <div class="chr_custom-select chr_custom-select--full">
@@ -107,7 +107,7 @@ endforeach;
                   </button>
                 <?php else: ?>
                   <button
-                    ng-click="modalDocument({ id: <?php print strip_tags($row['id']); ?> })"
+                    ng-click="document.modalDocument(<?php print strip_tags($row['id']); ?> , 'staff')"
                     class="btn btn-sm btn-default">
                     <i class="fa fa-upload"></i> Open
                   </button>


### PR DESCRIPTION
## Overview
Currently in the view of Documents Widget in SSP, modal is displayed using `ctools`. And this needs to address latest requirements to New Document Modal as in T&A. for this an angular app needs to be injected to the view. Also with reusing the modal form T&A, respective fields are to be hidden for the 'staff' role.

## Before
<img width="1043" alt="screen shot 2017-05-26 at 2 24 13 pm" src="https://cloud.githubusercontent.com/assets/6307362/26487385/068a43be-421f-11e7-9bc4-8ea429b04d75.png">

## After
<img width="612" alt="screen shot 2017-05-31 at 11 06 22 pm" src="https://cloud.githubusercontent.com/assets/6307362/26644897/061cc268-4656-11e7-869d-9af9b255da01.png">

## Technical Details
1. Pass 'staff' as role to second argument to 'modalDocument(id, role)' in  `views/templates/views-view-table--Documents--block.tpl.php` which will be passed to Modal Document Controller in T&A through `modalDocument()` in `js/ta-documents-app.js` and using the role to hide the respective fields in the document modal in file `uk.co.compucorp.civicrm.tasksassignments/views/modal/document.html`

2. The angular app injected in the SSP was created originally to work only on the admin, meaning it assumed the user would always have admin permissions. Now that users with the `civihr_staff` role also have access, some permission changes were required: 
- The `view all activities` was added because the Activity API is used internally by the Document API
- The `access AJAX API` was added because it's the very minimum necessary for the frontend to use any API
- The `access Tasks and Assignments Files ` permission was created so users can have access to and upload files attached to a Document
- The `access uploaded files` permission was added so users can download files attached to a Document
3. In order to inject the angular app inside a Drupal page, we need the `CiviCRM Resources` module. This was added as a dependecy of the CiviHR Employee portal module
4. Some settings data required to bootstrap angular app is required, which is collected and passed to view in file `civihr_employee_portal/civihr_employee_portal.module`
5. Also in file `civihr_employee_portal/views/templates/views-view-table--Documents--block.tpl.php`
-> For angular app to be injected to the view, additional `data-ta-documents`  and `ng-controller="ModalController"` are attached to the rot markup.
-> Settings data are made available by passing data form `Drupal` to global `CRM` js object
-> Added minimal angular code in file`js/ta-documents-app.js`
-> Finally, bootstrapped angular app when T&A modules are loaded completely
```js
// Listen for ready event when T&A finishes loading all modules
    document.addEventListener('taReady', function (e) {
      angular.bootstrap(angular.element("[data-ta-documents]"), ['taDocuments']);
    });
```
6. The following code is removed:
```js
modalInstance.result.then(function (results) {
          $scope.$broadcast('documentFormSuccess', results, data);

          if (results.open) {
            $rootScope.modalDocument(data);
          }
        }, function () {
          $log.info('Modal dismissed');
        });
```
Because, the above function is needed to broadcast the `documentFormSucess` event, on which the listener will be checking the status of the updated document and will remove it if it is approved or rejected form the list of documents otherwise keeps them in the list. But, there is nothing to be processed in document list case of SSP. So, removing it.

Also open a document, if $scope.document.open was set true. But, Since we have removed "Save and New" button as per the wireframe, $scope.document.open won't be set true. So, we wont be needing to open new modal once the document is saved. So, we won't be needing it any more. It is kept intact in T&A as it is appropriate.