### PR TITLE
PCHR-2196: Remove permissions for accessing my leave and leave manager page on SSP

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -517,14 +517,6 @@ function civihr_employee_portal_permission() {
       'title' => t('Create and edit Tasks'),
       'description' => t('Availability to create and edit Tasks.'),
     ),
-    'access leave and absences in ssp' => array(
-      'title' => t('Access CiviHR Leave and Absences'),
-      'description' => t('Availability for the Staff to access leave block and calendar')
-    ),
-    'manage leave and absences in ssp' => array(
-      'title' => t('Manage CiviHR Leave and Absences'),
-      'description' => t('Availability for the Manager to access leave block and calendar and manage leave requests')
-    ),
     'view my details' => array(
       'title' => t('View My Details'),
       'description' => t('Availability for the user to view my details block and page')


### PR DESCRIPTION
## Overview
When the Leave and Absence civiHR extension is disabled/uninstalled, the Leave manager can still see Manager Leave and My Leave page on the SSP. The reason is that it is the Employee portal module that creates the permissions that is needed to see this pages. This PR removes these permissions from the Employee portal module so that L&A extension can create these permissions itself.
The permissions are added to be created from L&A extension [here](https://github.com/civicrm/civihr/pull/1892).
## Before
The Employee portal module creates the permissions for accessing Manager Leave and My Leave page on the SSP.

## After
The Employee portal module no longer creates the permissions for accessing Manager Leave and My Leave page on the SSP.

- [ ] Tests Pass
Not sure how to run the tests on the module, besides didn't change anything that should affect the tests.