### PR TITLE
PCHR-2266: Add 'Change Own Username' Permission to CiviHR Roles

### DIFF
--- a/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
+++ b/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
@@ -1069,7 +1069,10 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'change own username',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin' => 'civihr_admin',
       'civihr_admin_local' => 'civihr_admin_local',
+      'civihr_manager' => 'civihr_manager',
+      'civihr_staff' => 'civihr_staff',
     ),
     'module' => 'user',
   );


### PR DESCRIPTION
## Overview
All users in CiviHR should have the 'Change own username' permission enabled by default.

## Before
Only roles that had the permission enabled by default were administrator and civihr_admin_local.

## After
Roles with 'Change own username' permission are administrator, civihr_admin, civihr_admin_local, civihr_manager and civihr_staff.