### PR TITLE
PCHR-2317: Attatch document modal to the root of angular app

### DIFF
--- a/civihr_employee_portal/js/ta-documents-app.js
+++ b/civihr_employee_portal/js/ta-documents-app.js
@@ -40,11 +40,7 @@
             $window.location.reload();
           });
           // Get list of documents
-          DocumentService.get({
-            'status_id': {
-              'NOT IN': config.status.resolve.DOCUMENT
-            }
-          }).then(function (documents) {
+          DocumentService.get().then(function (documents) {
             isContactsCached = DocumentService.cacheContactsAndAssignments(documents, 'contacts');
           });
         })();

--- a/civihr_employee_portal/js/ta-documents-app.js
+++ b/civihr_employee_portal/js/ta-documents-app.js
@@ -8,7 +8,7 @@
         var vm = {};
         var isContactsCached = {};
 
-        vm.showOpenBtn = true;
+        vm.loadingModalData = false;
 
         /**
          * Gets Document for the given document id and
@@ -25,7 +25,7 @@
               }
 
               $rootScope.$broadcast('ct-spinner-show');
-              vm.showOpenBtn = false;
+              vm.loadingModalData = true;
 
               openModalDocument(data[0], role);
             })
@@ -70,7 +70,7 @@
               data: function () {
                 return data;
               },
-              isCachedContacts: isContactsCached,
+              isContactsCached: isContactsCached,
               files: function () {
                 if (!data.id || !+data.file_count) {
                   return [];
@@ -83,7 +83,7 @@
 
           modalInstance.opened.then(function () {
             $rootScope.$broadcast('ct-spinner-hide');
-            vm.showOpenBtn = true;
+            vm.loadingModalData = false;
           });
         };
 

--- a/civihr_employee_portal/js/ta-documents-app.js
+++ b/civihr_employee_portal/js/ta-documents-app.js
@@ -53,7 +53,7 @@
          */
         function openModalDocument(data, role) {
           var modalInstance = $modal.open({
-            appendTo: $rootElement.find('div').eq(0),
+            appendTo: $rootElement,
             templateUrl: config.path.TPL + 'modal/document.html?v=3',
             controller: 'ModalDocumentCtrl',
             resolve: {

--- a/civihr_employee_portal/views/templates/views-view-table--Documents--block-1.tpl.php
+++ b/civihr_employee_portal/views/templates/views-view-table--Documents--block-1.tpl.php
@@ -94,8 +94,9 @@ $statuses = array(
                 <?php print strip_tags(html_entity_decode($content)); ?>
               </td>
             <?php endforeach; ?>
-            <td>
+            <td ct-spinner>
               <button
+              ng-show='document.showOpenBtn'
               ng-click="document.modalDocument(<?php print strip_tags($row['id']); ?>, 'manager')"
               class="btn btn-sm btn-default">
                 <i class="fa fa-upload"></i> Open

--- a/civihr_employee_portal/views/templates/views-view-table--Documents--block-1.tpl.php
+++ b/civihr_employee_portal/views/templates/views-view-table--Documents--block-1.tpl.php
@@ -96,7 +96,7 @@ $statuses = array(
             <?php endforeach; ?>
             <td ct-spinner>
               <button
-              ng-show='document.showOpenBtn'
+              ng-show='!document.loadingModalData'
               ng-click="document.modalDocument(<?php print strip_tags($row['id']); ?>, 'manager')"
               class="btn btn-sm btn-default">
                 <i class="fa fa-upload"></i> Open

--- a/civihr_employee_portal/views/templates/views-view-table--Documents--block.tpl.php
+++ b/civihr_employee_portal/views/templates/views-view-table--Documents--block.tpl.php
@@ -95,18 +95,21 @@ endforeach;
                   continue;
                 endif;
                 ?>
+
                 <?php print $content; ?>
                 </td>
                 <?php endforeach; ?>
-              <td>
+              <td ct-spinner>
                 <?php if (strip_tags($row['status_id']) == 3): ?>
                   <button
+                    ng-show='document.showOpenBtn'
                     class="btn btn-sm btn-default ctools-use-modal ctools-modal-civihr-default-style ctools-use-modal-processed"
                     disabled="disabled">
                     <i class="fa fa-upload"></i> Open
                   </button>
                 <?php else: ?>
                   <button
+                    ng-show='document.showOpenBtn'
                     ng-click="document.modalDocument(<?php print strip_tags($row['id']); ?> , 'staff')"
                     class="btn btn-sm btn-default">
                     <i class="fa fa-upload"></i> Open

--- a/civihr_employee_portal/views/templates/views-view-table--Documents--block.tpl.php
+++ b/civihr_employee_portal/views/templates/views-view-table--Documents--block.tpl.php
@@ -102,14 +102,14 @@ endforeach;
               <td ct-spinner>
                 <?php if (strip_tags($row['status_id']) == 3): ?>
                   <button
-                    ng-show='document.showOpenBtn'
+                    ng-show='!document.loadingModalData'
                     class="btn btn-sm btn-default ctools-use-modal ctools-modal-civihr-default-style ctools-use-modal-processed"
                     disabled="disabled">
                     <i class="fa fa-upload"></i> Open
                   </button>
                 <?php else: ?>
                   <button
-                    ng-show='document.showOpenBtn'
+                    ng-show='!document.loadingModalData'
                     ng-click="document.modalDocument(<?php print strip_tags($row['id']); ?> , 'staff')"
                     class="btn btn-sm btn-default">
                     <i class="fa fa-upload"></i> Open


### PR DESCRIPTION
## Overview
This PR is for the hot fix to add name space to temporary styles for the document modal in ssp for staff and manager document sections.

## Before
Previously, modal in request leave was broken ad follows:
<img width="491" alt="screen shot 2017-06-14 at 12 52 49 pm" src="https://user-images.githubusercontent.com/6307362/27129083-d2706548-5120-11e7-852e-23e60a927929.png">

## After
After name-spacing the temporary styles, the leave request modal looks ok
<img width="487" alt="screen shot 2017-06-14 at 12 48 23 pm" src="https://user-images.githubusercontent.com/6307362/27129091-d850cf8e-5120-11e7-8b49-3b28fb4d21d8.png">

## Technical Details
1. In file `civihr-custom/civihr_employee_portal/js/ta-documents-app.js` change the modal option to attach the modal in the root element as follows:
```js
function openModalDocument(data, role) {
   var modalInstance = $modal.open({
       **appendTo: $rootElement,**
       ...
   });
}
```
2. Name-spacing the temporary styles for document modal in ssp in file `civihr_employee_portal_theme/civihr_default_theme/scss/base/_task-assignments-modal-temp.scss` 
```css
[data-ta-documents],
[data-ta-documents-manager] {
   // All temporary styles for documents modal
}
```
### Updates:
1. When tested in test site 1, sometimes the contacts gets fetched earlier and sometimes take longer. Due to which the target contact in Document modal is available and sometimes not. So to mitigate this issue, function to cache contacts in `Document Service` is passed to modal resolve object, so the modal will be displayed when the contacts gets fetched and cached in SPP.

Update `openModalDocument` function to fetch and cache all contacts before displaying the modal in file `civihr-custom/civihr_employee_portal/js/ta-documents-app.js`.

```js
isContactsCached = DocumentService.cacheContactsAndAssignments(documents, 'contacts');
```

```js
function openModalDocument(data, role) {
  var modalInstance = $modal.open({
    ...
    resolve: {
      ...
      isContactsCached: isContactsCached,
      ...
    }
  });
};
```
Added spinner before loading the Modal.
![finalwithspinner](https://user-images.githubusercontent.com/6307362/27226928-ed828b94-52c0-11e7-8488-75f7cad37d55.gif)

2. In SSP currently documents with approved and rejected status are not fetched as in T&A. But in SSP, including others both approved and rejected documents' contacts needs to be cached. So, removing restriction to fetch documents other than approved(3) and rejected(4) status. Where 3 and 4 are status id respectively.
Change form:
```js
DocumentService.get({
   'status_id': {
       'NOT IN': config.status.resolve.DOCUMENT
   }
}).then(function (documents) {
   ...
});
```
 to
```js
DocumentService.get().then(function (documents) {
   ...
});

- [ ] Tests Pass
No tests added for js changes in ssp.