### PR TITLE
PCHR-2319: Pass modalMode to Document Modal resolve option

### DIFF
--- a/civihr_employee_portal/js/ta-documents-app.js
+++ b/civihr_employee_portal/js/ta-documents-app.js
@@ -57,6 +57,9 @@
             templateUrl: config.path.TPL + 'modal/document.html?v=3',
             controller: 'ModalDocumentCtrl',
             resolve: {
+              modalMode: function () {
+                return '';
+              },
               role: function () {
                 return role;
               },


### PR DESCRIPTION
## Overview
As the document modal is reused form T&A, the document modal now requires `modalMode` to initialize modal title in T&A. So, the modal mode needs to be passed while opening document modal.

## Technical Details
1. `modalMode` is passed to modal options as `''`(empty) because in SSP, the modal title is not dependent on `modalMode` as we are displaying the modal title as document type. We need to  pass the `modalMode` just to make `modalMode` be available in Document Modal Controller in T&A in file `uk.co.compucorp.civicrm.tasksassignments/js/src/tasks-assignments/controllers/modal/modal-document.js`.

```js
       function openModalDocument(data, role) {
          var modalInstance = $modal.open({
            ...
            resolve: {
              modalMode: function () {
                return '';
              },
              ...
            }
          });
        };
```
- [ ] Tests Pass
No tests written for ssp.
