### PR TITLE
PCHR-2318: Buttons change and console error when modal is open on ssp

### DIFF
--- a/civihr_employee_portal/js/ta-documents-app.js
+++ b/civihr_employee_portal/js/ta-documents-app.js
@@ -2,6 +2,10 @@
 
 (function(angular) {
   angular.module('taDocuments', ['civitasks.appDocuments', 'civitasks.directives'])
+    .config(function ($urlRouterProvider, $locationProvider) {
+      $locationProvider.html5Mode(true); // This is required to remove # for the URL
+      $urlRouterProvider.otherwise('/dashboard');
+    })
     .controller('ModalController', ['$scope', '$rootScope', '$window', '$rootElement', '$log', '$uibModal',
       'DocumentService', 'FileService', 'config', 'settings',
       function($scope, $rootScope, $window, $rootElement, $log, $modal, DocumentService, FileService, config, settings) {

--- a/civihr_employee_portal/views/templates/views-view-table--Documents--block.tpl.php
+++ b/civihr_employee_portal/views/templates/views-view-table--Documents--block.tpl.php
@@ -34,6 +34,7 @@ foreach ($rows as $row):
   $statusesCount[0] ++;
 endforeach;
 ?>
+<base href="/"> <!-- This is required to remove # for the URL-->
 <div data-ta-documents ng-controller="ModalController as document" class="chr_table-w-filters chr_table-w-filters--documents row">
   <div class="chr_table-w-filters__filters col-md-3">
     <div class="chr_table-w-filters__filters__dropdown-wrapper">


### PR DESCRIPTION
## Overview
During the Document Updates in SSP, angular app was created and injected in SSP which added additional `#/` in the url causing the following error on opening modals.

#### Error:
![screen shot 2017-06-21 at 7 33 48 pm](https://user-images.githubusercontent.com/6307362/27387512-a66c56bc-56b8-11e7-9cdb-e5a7802a6a72.png)

## Before
![2318-before-min](https://user-images.githubusercontent.com/6307362/27389501-4793108a-56be-11e7-9b62-9a3ea54b09a8.gif)

## After
![2318_after-min](https://user-images.githubusercontent.com/6307362/27389097-2907e84e-56bd-11e7-997f-7a4098aa46a4.gif)

## Technical Details
1. Added following code in `civihr_employee_portal/js/ta-documents-app.js`:
```js
(function(angular) {
  angular.module('taDocuments', ['civitasks.appDocuments', 'civitasks.directives'])
    .config(function ($urlRouterProvider, $locationProvider) {
      $locationProvider.html5Mode(true); // This is required to remove # for the URL
      $urlRouterProvider.otherwise('/dashboard');
    })
    ...
})(angular);
```
This code will be removing the `#/` form the url and add a fallback url to be `/dashboard`.

2. Add `<base href="/"> <!-- This is required to remove # for the URL-->` in file `civihr_employee_portal/views/templates/views-view-table--Documents--block.tpl.php` which applies the base path to be `/`.

## Comments:
1. Previously the **only the first day of the request is shown in case multiple days are selected in a future** 
Check issue here: https://compucorp.atlassian.net/secure/attachment/41625/41625_2317+dates+selected.mp4
This  issue is resolved as of this PR.Now one can select multiple days in Request leave modal. To see it in action please see gif in **After** section.
