### PR TITLE
PCHR-2329: Format expiry date if it only exists

### DIFF
--- a/civihr_employee_portal/views/includes/civihr_employee_portal_handler_documents_date.inc
+++ b/civihr_employee_portal/views/includes/civihr_employee_portal_handler_documents_date.inc
@@ -5,8 +5,10 @@
  * Custom views handler to display Task / Document date in specific format.
  */
 class civihr_employee_portal_handler_documents_date extends views_handler_field {
-    function render($values) {
-        $value = $this->get_value($values);
-        return date('M d Y', strtotime(strip_tags($value)));
+  function render($values) {
+    $value = $this->get_value($values);
+    if($value) {
+      return date('M d Y', strtotime(strip_tags($value)));
     }
+  }
 }


### PR DESCRIPTION
## Overview
The issue is  the value for (Expiry date) " $value" will be "null" when a document is created without expiry date. And the while formatting the expiry date  for  such documents , "null" becomes "1 Jan 1970".

## Before
![screen shot 2017-06-26 at 6 15 07 pm](https://user-images.githubusercontent.com/6307362/27539603-db92e576-5a9c-11e7-95de-a8795ea97e9a.png)

## After
![screen shot 2017-06-26 at 6 15 42 pm](https://user-images.githubusercontent.com/6307362/27539610-e21a24b8-5a9c-11e7-93d5-99810ba111af.png)

## Technical Details
1. Change following code in file `civihr-employee-portal/civihr_employee_portal/views/includes/civihr_employee_portal_handler_documents_date.inc`
```php
class civihr_employee_portal_handler_documents_date extends views_handler_field {
    function render($values) {
        $value = $this->get_value($values);
        return date('M d Y', strtotime(strip_tags($value)));
    }
}
```
To

```php
class civihr_employee_portal_handler_documents_date extends views_handler_field {
    function render($values) {
        $value = $this->get_value($values);
        if($value) {
           return date('M d Y', strtotime(strip_tags($value)));
        }
    }
}
```
## Comments
- Formatting of the date is only done when there exists value for expiry date for a document.

- [ ] Tests Pass
No tests added