### PR TITLE
PCHR-2243: Compare status value with content instead of status id

### DIFF
--- a/civihr_employee_portal/views/templates/views-view-table--Documents--block-1.tpl.php
+++ b/civihr_employee_portal/views/templates/views-view-table--Documents--block-1.tpl.php
@@ -69,7 +69,7 @@ $statuses = array(
                           $selected = ' selected="selected"';
                         endif;
                         ?>
-                      <option value="<?php print $statusKey; ?>"<?php print $selected; ?>><?php print ucwords($statusValue);?></option>
+                      <?php printf('<option value="%s" %s>%s</option>', $statusKey, $selected, ucwords($statusValue)); ?>
                     <?php endforeach; ?>
                   </select>
                   <?php continue; ?>

--- a/civihr_employee_portal/views/templates/views-view-table--Documents--block-1.tpl.php
+++ b/civihr_employee_portal/views/templates/views-view-table--Documents--block-1.tpl.php
@@ -65,11 +65,11 @@ $statuses = array(
                     <?php foreach ($statuses as $statusKey => $statusValue): ?>
                       <?php
                         $selected = '';
-                        if ($statusKey == (int) strip_tags($content)):
+                        if (strtolower($statusValue) == strip_tags($content)):
                           $selected = ' selected="selected"';
                         endif;
                         ?>
-                      <option value="<?php print $statusKey; ?>"<?php print $selected; ?>><?php print $statusValue; ?></option>
+                      <option value="<?php print $statusKey; ?>"<?php print $selected; ?>><?php print ucwords($statusValue);?></option>
                     <?php endforeach; ?>
                   </select>
                   <?php continue; ?>


### PR DESCRIPTION
## Overview
Currently, while displaying the selected  status on Document manager in ssp, whether  to display  a status as selected is determined by comparing status id and status value, which is never true. so the status never gets selected.

## Before
![2243_before-min](https://user-images.githubusercontent.com/6307362/27542933-718add6c-5aa8-11e7-8923-56e48677fb6d.gif)

## After
![2244_after-min](https://user-images.githubusercontent.com/6307362/27542643-9c39829e-5aa7-11e7-80fa-7e67202f7fbb.gif)

## Technical Details
1. Since the value of `$content` is string value like `awaiting-approval`. So, modifying to compare status value to the status content, rather than status_id with status content. 
From:
```php
if ($statusKey == (int) strip_tags($content)):
   $selected = ' selected="selected"';
endif;
```
To:
```php
if (strtolower($statusValue) == strip_tags($content)):
    $selected = ' selected="selected"';
endif;
```
2. Display the status in Sentence format rather than all lowercase:
```html
<option value="...><?php print ucwords($statusValue);?></option>
```

- [ ] Tests Pass
No added tests