### PR TITLE
PCHR-2333: Show Documents to All Assignees on Document Manager

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -287,7 +287,13 @@ function _get_activity_type_ids_by_component($component) {
 function _get_tasks_documents_sql_query(array $activityTypes) {
   $civi_settings = parse_url(CIVICRM_DSN);
   $civi_db_name = trim($civi_settings['path'], '/');
-  return "SELECT a.id, a.activity_type_id, a.subject, a.activity_date_time, acustom.expire_date, a.details, a.status_id, a.is_deleted, ca.case_id, COUNT(ef.id) AS file_count, acs.contact_id AS source_contact_id, contact_source.sort_name AS source_contact_name, act.contact_id AS target_contact_id, contact_target.sort_name AS target_contact_name, aca.contact_id AS assignee_contact_id, contact_assignee.sort_name AS assignee_contact_name
+
+  return "SELECT a.id, a.activity_type_id, a.subject, a.activity_date_time,
+            acustom.expire_date, a.details, a.status_id, a.is_deleted, ca.case_id,
+            COUNT(ef.id) AS file_count, acs.contact_id AS source_contact_id,
+            contact_source.sort_name AS source_contact_name, act.contact_id AS target_contact_id,
+            contact_target.sort_name AS target_contact_name, aca.contact_id AS assignee_contact_id,
+            contact_assignee.sort_name AS assignee_contact_name
             FROM {$civi_db_name}.civicrm_activity a
             LEFT JOIN {$civi_db_name}.civicrm_value_activity_custom_fields_11 acustom ON acustom.entity_id = a.id
             LEFT JOIN {$civi_db_name}.civicrm_case_activity ca ON ca.activity_id = a.id
@@ -299,7 +305,7 @@ function _get_tasks_documents_sql_query(array $activityTypes) {
             LEFT JOIN {$civi_db_name}.civicrm_activity_contact aca ON aca.activity_id = a.id AND aca.record_type_id = 1
             LEFT JOIN {$civi_db_name}.civicrm_contact contact_assignee ON contact_assignee.id = aca.contact_id
             WHERE a.is_deleted = 0 AND a.is_current_revision = 1 AND a.activity_type_id IN (" . implode(',', $activityTypes) . ")
-            GROUP BY a.id";
+            GROUP BY a.id, aca.contact_id";
 }
 
 /**

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -1100,49 +1100,47 @@ function get_task_statuses($status_id = NULL) {
  */
 function get_activity_type_value($type_id = NULL) {
 
-    $activityTypes = &drupal_static(__FUNCTION__);
+  $activityTypes = &drupal_static(__FUNCTION__);
 
-    if (!isset($activityTypes)) {
+  if (!isset($activityTypes)) {
 
-        if ($cache = cache_get('civihr_activity_types')) {
-            $activityTypes = $cache->data;
-        }
-        else {
-            try {
-                // Civi init
-                civicrm_initialize();
-
-                // Task types array
-                $activityTypes = civicrm_api3('Activity', 'getoptions', array(
-                  'field' => "activity_type_id",
-                ));
-
-                // Document types array
-                $documentTypes = civicrm_api3('Document', 'getoptions', array(
-                    'field' => "activity_type_id",
-                ));
-
-                $activityTypes['values'] += $documentTypes['values'];
-                $activityTypes['count'] = count($activityTypes['values']);
-            }
-
-            catch (CiviCRM_API3_Exception $e) {
-                $error = $e->getMessage();
-            }
-
-            // Cache the task types for 5 minutes
-            cache_set('civihr_activity_types', $activityTypes, 'cache', time() + 360);
-        }
+    if ($cache = cache_get('civihr_activity_types')) {
+      $activityTypes = $cache->data;
     }
+    else {
+      try {
+        // Civi init
+        civicrm_initialize();
 
-    if ($type_id === null) {
-        return $activityTypes['values'];
+        // Task types array
+        $activityTypes = civicrm_api3('Activity', 'getoptions', [
+          'field' => "activity_type_id",
+        ]);
+
+        // Document types array
+        $documentTypes = civicrm_api3('Document', 'getoptions', [
+          'field' => "activity_type_id",
+        ]);
+
+        $activityTypes['values'] += $documentTypes['values'];
+        $activityTypes['count'] = count($activityTypes['values']);
+      } catch (CiviCRM_API3_Exception $e) {
+        $error = $e->getMessage();
+      }
+
+      // Cache the task types for 5 minutes
+      cache_set('civihr_activity_types', $activityTypes, 'cache', time() + 360);
     }
+  }
 
-    // Get the type values based on the type_id
-    $type_id_value = CRM_Utils_Array::value($type_id, $activityTypes['values']);
+  if ($type_id === NULL) {
+    return $activityTypes['values'];
+  }
 
-    return $type_id_value;
+  // Get the type values based on the type_id
+  $type_id_value = CRM_Utils_Array::value($type_id, $activityTypes['values']);
+
+  return $type_id_value;
 }
 
 function get_appraisal_cycle_type($type_id = NULL) {

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -1114,8 +1114,16 @@ function get_activity_type_value($type_id = NULL) {
 
                 // Task types array
                 $activityTypes = civicrm_api3('Activity', 'getoptions', array(
+                  'field' => "activity_type_id",
+                ));
+
+                // Document types array
+                $documentTypes = civicrm_api3('Document', 'getoptions', array(
                     'field' => "activity_type_id",
                 ));
+
+                $activityTypes['values'] += $documentTypes['values'];
+                $activityTypes['count'] = count($activityTypes['values']);
             }
 
             catch (CiviCRM_API3_Exception $e) {

--- a/civihr_employee_portal/views/views_export/views_documents.inc
+++ b/civihr_employee_portal/views/views_export/views_documents.inc
@@ -346,6 +346,61 @@ $handler->display->display_options['arguments']['target_contact_id']['default_ar
 $handler->display->display_options['arguments']['target_contact_id']['summary']['number_of_records'] = '0';
 $handler->display->display_options['arguments']['target_contact_id']['summary']['format'] = 'default_summary';
 $handler->display->display_options['arguments']['target_contact_id']['summary_options']['items_per_page'] = '25';
+$handler->display->display_options['merge_rows'] = TRUE;
+$handler->display->display_options['field_config'] = array(
+  'id' => array(
+    'merge_option' => 'merge_unique',
+    'separator' => ', ',
+  ),
+  'activity_type_id' => array(
+    'merge_option' => 'merge_unique',
+    'separator' => ', ',
+  ),
+  'case_id' => array(
+    'merge_option' => 'merge_unique',
+    'separator' => ', ',
+  ),
+  'subject' => array(
+    'merge_option' => 'merge_unique',
+    'separator' => ', ',
+  ),
+  'activity_date_time' => array(
+    'merge_option' => 'merge_unique',
+    'separator' => ', ',
+  ),
+  'expire_date' => array(
+    'merge_option' => 'merge_unique',
+    'separator' => ', ',
+  ),
+  'details' => array(
+    'merge_option' => 'merge_unique',
+    'separator' => ', ',
+  ),
+  'file_count' => array(
+    'merge_option' => 'merge_unique',
+    'separator' => ', ',
+  ),
+  'status_id' => array(
+    'merge_option' => 'merge_unique',
+    'separator' => ', ',
+  ),
+  'target_contact_id' => array(
+    'merge_option' => 'merge_unique',
+    'separator' => ', ',
+  ),
+  'assignee_contact_id' => array(
+    'merge_option' => 'merge_unique',
+    'separator' => ', ',
+  ),
+  'target_contact_name' => array(
+    'merge_option' => 'merge_unique',
+    'separator' => ', ',
+  ),
+  'assignee_contact_name' => array(
+    'merge_option' => 'merge_unique',
+    'separator' => ', ',
+  ),
+);
 
 /* Display: Documents Dashboard Manager block */
 $handler = $view->new_display('block', 'Documents Dashboard Manager block', 'block_1');


### PR DESCRIPTION
## Overview
Document Manager block on SSP Dashbord is used to show the list of documents they have assigned. A document can be assigned to several managers, however, only the first manager assigned was able to see the document on Document Manager block.

## Before
The problem arose because the DB view being used to build the manager block was grouping results by document ID, thus only one manager was shown in result set.

## After
Fixed by altering the SQL being used to build the DB view, adding assignee id to GROUP BY fields. Also had to fix the Documents Dashboard Block, since the new structure of the DB view caused each document to be shown several times (one time per each assigned manager). Did this by merging multiple results within the Drupal view.

List of documents in SSP dashboard showed an empty type for every document. I thought this was a side-effect of the change made in the view, but as it turned out, this happened because the option values for document types, which in fact are a special case of activity types, were not being loaded to resolve activity type id's for their corresponding labels.

Fixed by calling 'getoptions' on Document entity, and merging the result with original activity types array.

## Comments
Reformatted all the code for the get_activity_type_value function, to follow current formatting standards, but did it in the final commit, so changes made can be easily identified on previous ones.