### PR TITLE
PCHR-2355: Configure DATE_FORMAT in HR_settings for SSP

### DIFF
--- a/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
+++ b/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
@@ -1032,6 +1032,7 @@ function civihr_default_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'civihr_admin_local' => 'civihr_admin_local',
+      'civihr_manager' => 'civihr_manager',
     ),
     'module' => 'civihr_employee_portal',
   );

--- a/civihr_employee_portal/js/ta-documents-app.js
+++ b/civihr_employee_portal/js/ta-documents-app.js
@@ -7,13 +7,12 @@
       $urlRouterProvider.otherwise('/dashboard');
     })
     .controller('ModalController', ['$scope', '$rootScope', '$window', '$rootElement', '$log', '$uibModal',
-      'DocumentService', 'FileService', 'config', 'settings', 'HR_settings',
+      'DocumentService', 'FileService', 'config', 'settings', 'DateFormat',
       function($scope, $rootScope, $window, $rootElement, $log, $modal, DocumentService, FileService, config,
-        settings, HR_settings) {
+        settings, DateFormat) {
         var vm = {};
         var isContactsCached = {};
 
-        HR_settings.DATE_FORMAT = "dd/MM/yyyy";
         vm.loadingModalData = false;
 
         /**
@@ -41,12 +40,15 @@
         };
 
         (function init() {
+
           // Reloads page on 'document-saved' event
           $rootScope.$on('document-saved', function () {
             $window.location.reload();
           });
           // Get list of documents
           DocumentService.get().then(function (documents) {
+            //sets the date format for HR_settings.DATE_FORMAT
+            DateFormat.getDateFormat();
             isContactsCached = DocumentService.cacheContactsAndAssignments(documents, 'contacts');
           });
         })();

--- a/civihr_employee_portal/js/ta-documents-app.js
+++ b/civihr_employee_portal/js/ta-documents-app.js
@@ -11,7 +11,7 @@
       function($scope, $rootScope, $window, $rootElement, $log, $modal, DocumentService, FileService, config,
         settings, DateFormat) {
         var vm = {};
-        var isContactsCached = {};
+        var availableContacts = false;
 
         vm.loadingModalData = false;
 
@@ -49,7 +49,7 @@
           DocumentService.get().then(function (documents) {
             //sets the date format for HR_settings.DATE_FORMAT
             DateFormat.getDateFormat();
-            isContactsCached = DocumentService.cacheContactsAndAssignments(documents, 'contacts');
+            DocumentService.cacheContactsAndAssignments(documents, 'contacts');
           });
         })();
 
@@ -74,7 +74,6 @@
               data: function () {
                 return data;
               },
-              isContactsCached: isContactsCached,
               files: function () {
                 if (!data.id || !+data.file_count) {
                   return [];
@@ -90,6 +89,25 @@
             vm.loadingModalData = false;
           });
         };
+
+        /**
+         * Watch for the changes in the list of $rootScope.cache.contact.arrSearch
+         * Display spinner and hide "open" button until the arrSearch is filled with contacts
+         *
+         * Note: $rootScope.cache.contact.arrSearch will always contain a
+         * contact data (curently logged in contact). So if there are documents,
+         * there must be more that one contacts conidering at aleast a target contact in a document
+         */
+        $rootScope.$watch('cache.contact', function () {
+          availableContacts = $rootScope.cache.contact.arrSearch.length > 1;
+          if (!availableContacts) {
+            $rootScope.$broadcast('ct-spinner-show');
+            vm.loadingModalData = true;
+          } else {
+            $rootScope.$broadcast('ct-spinner-hide');
+            vm.loadingModalData = false;
+          }
+        });
 
         return vm;
       }

--- a/civihr_employee_portal/js/ta-documents-app.js
+++ b/civihr_employee_portal/js/ta-documents-app.js
@@ -40,11 +40,11 @@
         };
 
         (function init() {
-
           // Reloads page on 'document-saved' event
           $rootScope.$on('document-saved', function () {
             $window.location.reload();
           });
+
           // Get list of documents
           DocumentService.get().then(function (documents) {
             //sets the date format for HR_settings.DATE_FORMAT
@@ -100,13 +100,8 @@
          */
         $rootScope.$watch('cache.contact', function () {
           availableContacts = $rootScope.cache.contact.arrSearch.length > 1;
-          if (!availableContacts) {
-            $rootScope.$broadcast('ct-spinner-show');
-            vm.loadingModalData = true;
-          } else {
-            $rootScope.$broadcast('ct-spinner-hide');
-            vm.loadingModalData = false;
-          }
+          $rootScope.$broadcast('ct-spinner-' + (availableContacts ? 'hide' : 'show'));
+          vm.loadingModalData = !availableContacts;
         });
 
         return vm;

--- a/civihr_employee_portal/js/ta-documents-app.js
+++ b/civihr_employee_portal/js/ta-documents-app.js
@@ -7,11 +7,13 @@
       $urlRouterProvider.otherwise('/dashboard');
     })
     .controller('ModalController', ['$scope', '$rootScope', '$window', '$rootElement', '$log', '$uibModal',
-      'DocumentService', 'FileService', 'config', 'settings',
-      function($scope, $rootScope, $window, $rootElement, $log, $modal, DocumentService, FileService, config, settings) {
+      'DocumentService', 'FileService', 'config', 'settings', 'HR_settings',
+      function($scope, $rootScope, $window, $rootElement, $log, $modal, DocumentService, FileService, config,
+        settings, HR_settings) {
         var vm = {};
         var isContactsCached = {};
 
+        HR_settings.DATE_FORMAT = "dd/MM/yyyy";
         vm.loadingModalData = false;
 
         /**


### PR DESCRIPTION
## Overview
Currently, when trying to save the documents form Documents Widget in SSP. A error  is thrown because date format is not configured for angular app in ssp for documents modal.

When a `civihr_manager` changes the status form the documents widget in ssp, the status does not get updated and displays the access denied 403 error. Which was due to the permission issue.

## Before
1. Cannot save document by the civihr_manager in ssp
![2355_1_before](https://user-images.githubusercontent.com/6307362/27790371-e4c83bf0-600f-11e7-87fc-97af7578707b.gif)

2. Changing status does not get saved in documents manager in ssp
![2355_before](https://user-images.githubusercontent.com/6307362/27790397-fe58f7a8-600f-11e7-836a-bfcfed1bf412.gif)

## After
1. 'civihr_manager` can save edited document form ssp
![2355_1_after](https://user-images.githubusercontent.com/6307362/27790103-d76f3054-600e-11e7-9a93-49a32188199e.gif)

2. `civihr_manager` can changed the document status and it gets saved
![2355_after](https://user-images.githubusercontent.com/6307362/27790098-d45dab20-600e-11e7-9b48-473fd7532532.gif)

## Technical Details
1. Configure date format for SSP in mini angular app for the Document modals.
```js
.controller('ModalController', ['$scope', ..., 'settings', 'DateFormat',
      function($scope, ..., settings, DateFormat) {
        ...
       (function init() {
          ...
          // Get list of documents
          DocumentService.get().then(function (documents) {
            //sets the date format for HR_settings.DATE_FORMAT
            DateFormat.getDateFormat();
          });
        ...
    })();
});
```
2. Give "change document status" permission for "civihr_manager" user in file "features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc"
```php
  // Exported permission: 'change document status'.
  $permissions['change document status'] = array(
    'name' => 'change document status',
    'roles' => array(
      ...
      'civihr_manager' => 'civihr_manager',
    ),
    'module' => 'civihr_employee_portal',
  );
```

## Update:
### Reopened Issue:
When the page in ssp is refreshed and before the page gets scrolled back to top, if clicked the open button in a document on Document Manager in ssp, the modal opens with empty target contact. Fetching and caching of contacts for a document is improved in  PR #312 , and this even needs to be polished to to fix the reopened issue taking following steps

1. Watch for the change in the contacts search array.
```js
$rootScope.$watch('cache.contact', function () {
   ..//other operations
});
```
2. For when there is a change of values in the contacts array, check if the array contains more than one contacts. Because one contact (currently logged in user data) will already be available. So, if there are documents there should be more than one contact including a contacts associated with the document.
```js
$rootScope.$watch('cache.contact', function () {
   contactsLoaded = $rootScope.cache.contact.arrSearch.length > 1;
   if (!contactsLoaded) {
      ... // Display spinner and hide "open" button
   } else {
      ... // Hide spinner and display "open" button
   }
});
```
3. Add a code to display and hide the spinner and "Open " button in documents, in respective place above:
```js
if (!contactsLoaded) {
   $rootScope.$broadcast('ct-spinner-show');
   vm.loadingModalData = true;
} else {
   $rootScope.$broadcast('ct-spinner-hide');
   vm.loadingModalData = false;
}
```
4. We won't be needing to check `isContactsCached` if contact data is resolved as the contacts data will be available when the controller is instantiated in `init()` call.
```js
...
isContactsCached = DocumentService.cacheContactsAndAssignments(documents, 'contacts');
...

...
isContactsCached: isContactsCached,
...
```

### Before:
Displays the open button, before the contacts get fully loaded, and opening the modal displayes modal with empty target contact.
![2355-before-iloveimg-compressed](https://user-images.githubusercontent.com/6307362/27912618-49c9595c-627d-11e7-8235-49d0658042d9.gif)

### After:
Displays the spinner and hides the "open" button  until the data gets loaded.
![fasdfasdf-iloveimg-compressed](https://user-images.githubusercontent.com/6307362/27912139-820e3122-627b-11e7-88e1-11e725bc2caf.gif)
