### PR TITLE
PCHR-2354: Spinner in ssp does not look right

### DIFF
--- a/civihr_employee_portal/js/ta-documents-app.js
+++ b/civihr_employee_portal/js/ta-documents-app.js
@@ -22,14 +22,14 @@
          * @param {string} role
          */
         vm.modalDocument = function (id, role) {
+          $rootScope.$broadcast('ct-spinner-show', 'document-' + id);
+          vm.loadingModalData = true;
+
           DocumentService.get({ id: id })
             .then(function(data) {
               if (!data) {
                 throw new Error('Requested Document is not available');
               }
-
-              $rootScope.$broadcast('ct-spinner-show', 'document-' + id);
-              vm.loadingModalData = true;
 
               openModalDocument(data[0], role);
             })

--- a/civihr_employee_portal/js/ta-documents-app.js
+++ b/civihr_employee_portal/js/ta-documents-app.js
@@ -28,7 +28,7 @@
                 throw new Error('Requested Document is not available');
               }
 
-              $rootScope.$broadcast('ct-spinner-show');
+              $rootScope.$broadcast('ct-spinner-show', 'document-' + id);
               vm.loadingModalData = true;
 
               openModalDocument(data[0], role);

--- a/civihr_employee_portal/views/templates/views-view-table--Documents--block-1.tpl.php
+++ b/civihr_employee_portal/views/templates/views-view-table--Documents--block-1.tpl.php
@@ -94,11 +94,11 @@ $statuses = array(
                 <?php print strip_tags(html_entity_decode($content)); ?>
               </td>
             <?php endforeach; ?>
-            <td ct-spinner>
+            <td ct-spinner ct-spinner-id="document-<?php print strip_tags($row['id']); ?>">
               <button
-              ng-show='!document.loadingModalData'
-              ng-click="document.modalDocument(<?php print strip_tags($row['id']); ?>, 'manager')"
-              class="btn btn-sm btn-default">
+                ng-show='!document.loadingModalData'
+                ng-click="document.modalDocument(<?php print strip_tags($row['id']); ?>, 'manager')"
+                class="btn btn-sm btn-default">
                 <i class="fa fa-upload"></i> Open
               </button>
             </td>

--- a/civihr_employee_portal/views/templates/views-view-table--Documents--block.tpl.php
+++ b/civihr_employee_portal/views/templates/views-view-table--Documents--block.tpl.php
@@ -100,7 +100,7 @@ endforeach;
                 <?php print $content; ?>
                 </td>
                 <?php endforeach; ?>
-              <td ct-spinner>
+              <td ct-spinner ct-spinner-id="document-<?php print strip_tags($row['id']); ?>">
                 <?php if (strip_tags($row['status_id']) == 3): ?>
                   <button
                     ng-show='!document.loadingModalData'


### PR DESCRIPTION
## Overview
After the completion of #312  , there was a issue with spinners in both document and document manager section in ssp. i.e when clicked "open" in any one on the document, the spinner is displayed in all of the documents. This PR fixes the spinner to be displayed to only specific document.

## Before
The spinner is displayed to each document in the list.
![screen shot 2017-07-04 at 9 32 36 pm](https://user-images.githubusercontent.com/6307362/27836705-5bea2126-6100-11e7-875b-f770b7847e32.png)

## After
Displays spinner to the only sepicific document in the list
![untitled](https://user-images.githubusercontent.com/6307362/27836869-0a518092-6101-11e7-8fc5-10c003ecfc12.gif)

## Technical Details
1. Call following in "civihr-custom/civihr_employee_portal/js/ta-documents-app.js"
```js
$rootScope.$broadcast('ct-spinner-show', 'document-' + id);
``` 
to display the spinner in ssp document.
2. Add following 
```html
<td ct-spinner ct-spinner-id="document-<?php print strip_tags($row'id');?>">
``` 
in open button holding table column. in both file "civihr_employee_portal/views/templates/views-view-table-Documentsblock-1.tpl.php" and " civihr_employee_portal/views/templates/views-view-tableDocuments-block.tpl.php"

### Update:
1. Display spinner once clicked open button in a document and hide the button indicating the data is being loaded.
```js
    $rootScope.$broadcast('ct-spinner-show', 'document-' + id);
    vm.loadingModalData = true;
```

## Comments
- No test cases added

- [ ] Tests Pass
