### PR TITLE
PCHR-2333: Fix Document Dashboard Block

### DIFF
--- a/civihr_employee_portal/views/views_export/views_documents.inc
+++ b/civihr_employee_portal/views/views_export/views_documents.inc
@@ -349,7 +349,7 @@ $handler->display->display_options['arguments']['target_contact_id']['summary_op
 $handler->display->display_options['merge_rows'] = TRUE;
 $handler->display->display_options['field_config'] = array(
   'id' => array(
-    'merge_option' => 'merge_unique',
+    'merge_option' => 'filter',
     'separator' => ', ',
   ),
   'activity_type_id' => array(


### PR DESCRIPTION
## Overview
The previous fix for PCHR-2333, merged into staging branch on [this](https://github.com/compucorp/civihr-employee-portal/pull/318) PR, was making all documents to be merged into a single row. 

![image](https://user-images.githubusercontent.com/21999940/27874036-bdcc0486-6173-11e7-8fdf-befac4889a3a.png)

## Before
All fields on the view's display were being merged using 'merge unique values' option.

## After
Fixed by altering merge configuration of the view, assigning the 'filter' option on merge option for Document ID field, so different rows are shown per unique document ID.

![image](https://user-images.githubusercontent.com/21999940/27874200-5bd5dd64-6174-11e7-96b0-44be276d09b2.png)
