### PR TITLE
PCHR-2358: Add user guide link to be used in account menu

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -6768,14 +6768,12 @@ function civihr_employee_portal_preprocess_page(&$vars) {
     $display_name = t('Anonymus');
     $edit_account_link = '';
     $logout_link = '';
-    $user_guide_link = '';
+    $user_guide_link = l('<i class="fa fa-book"></i>' . t('User guide'), 'http://civihr-documentation.readthedocs.io/en/latest/self-service-portal/login-screen/', array('html' => true));
     $image_url = $base_url . '/' . drupal_get_path('module', 'civihr_employee_portal') . '/images/profile-default.png';
 
     if (isset($_SESSION['CiviCRM']) && $user->uid) {
         $edit_account_link = l('<i class="fa fa-edit"></i>' . t('Edit Account'), 'user/' . $user->uid . '/edit', array('html' => true));
         $logout_link = l('<i class="fa fa-sign-out"></i>' . t('Log Out'), 'user/logout', array('html' => true));
-        $user_guide_link = l('<i class="fa fa-book"></i>' . t('User guide'), 'http://civihr-documentation.readthedocs.io/en/latest/self-service-portal/login-screen/', array('html' => true));
-        $user_guide_link = l('<i class="fa fa-book"></i>' . t('User guide'), 'http://civihr-documentation.readthedocs.io/en/latest/self-service-portal/login-screen/', array('html' => true));
 
         // Get the contact data
         $contact_data = get_civihr_contact_data($_SESSION['CiviCRM']['userID']);

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -6768,11 +6768,14 @@ function civihr_employee_portal_preprocess_page(&$vars) {
     $display_name = t('Anonymus');
     $edit_account_link = '';
     $logout_link = '';
+    $user_guide_link = '';
     $image_url = $base_url . '/' . drupal_get_path('module', 'civihr_employee_portal') . '/images/profile-default.png';
 
     if (isset($_SESSION['CiviCRM']) && $user->uid) {
         $edit_account_link = l('<i class="fa fa-edit"></i>' . t('Edit Account'), 'user/' . $user->uid . '/edit', array('html' => true));
         $logout_link = l('<i class="fa fa-sign-out"></i>' . t('Log Out'), 'user/logout', array('html' => true));
+        $user_guide_link = l('<i class="fa fa-book"></i>' . t('User guide'), 'http://civihr-documentation.readthedocs.io/en/latest/self-service-portal/login-screen/', array('html' => true));
+        $user_guide_link = l('<i class="fa fa-book"></i>' . t('User guide'), 'http://civihr-documentation.readthedocs.io/en/latest/self-service-portal/login-screen/', array('html' => true));
 
         // Get the contact data
         $contact_data = get_civihr_contact_data($_SESSION['CiviCRM']['userID']);
@@ -6789,6 +6792,7 @@ function civihr_employee_portal_preprocess_page(&$vars) {
     $vars['image_url'] = $image_url;
     $vars['edit_account'] = $edit_account_link;
     $vars['logout_link'] = $logout_link;
+    $vars['user_guide_link'] = $user_guide_link;
 
 }
 

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -6768,7 +6768,7 @@ function civihr_employee_portal_preprocess_page(&$vars) {
     $display_name = t('Anonymus');
     $edit_account_link = '';
     $logout_link = '';
-    $user_guide_link = l('<i class="fa fa-book"></i>' . t('User guide'), 'http://civihr-documentation.readthedocs.io/en/latest/self-service-portal/login-screen/', array('html' => true));
+    $user_guide_link = l('<i class="fa fa-book"></i>' . t('User guide'), 'http://civihr-documentation.readthedocs.io/en/latest/self-service-portal/login-screen/', array('html' => true, 'attributes' => array('target' => '_blank')));
     $image_url = $base_url . '/' . drupal_get_path('module', 'civihr_employee_portal') . '/images/profile-default.png';
 
     if (isset($_SESSION['CiviCRM']) && $user->uid) {


### PR DESCRIPTION
## Overview
A new menu under account is to be added calling "User Guide" in SSP.

## Before
Not added User guide Menu
![screen shot 2017-07-12 at 7 59 46 pm](https://user-images.githubusercontent.com/6307362/28122065-dca2a7ba-673c-11e7-85b0-6479a3dcebff.png)

## After
Added User guide Menu
![screen shot 2017-07-12 at 7 33 47 pm](https://user-images.githubusercontent.com/6307362/28121221-1a134864-673a-11e7-8ac5-caada8437749.png)

## Technical Details
1. 
```php
/**
 * Implement hook_preprocess_page
 * @param $vars
 */
function civihr_employee_portal_preprocess_page(&$vars) {
    ...
    $user_guide_link = '';
    $image_url = $base_url . '/' . drupal_get_path('module', 'civihr_employee_portal') . '/images/profile-default.png';

    if (isset($_SESSION['CiviCRM']) && $user->uid) {
        ...
        $user_guide_link = l('<i class="fa fa-book"></i>' . t('User guide'), 'http://civihr-documentation.readthedocs.io/en/latest/self-service-portal/login-screen/', array('html' => true));
    ...
    $vars['user_guide_link'] = $user_guide_link;
}
```
