### PR TITLE
PCHR-245: Decode HTML Tags in Vacancy Description

### DIFF
--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -1107,8 +1107,8 @@ function civihr_employee_portal_views_post_render(&$view, &$output, &$cache) {
  * Decodes html entities in description for each vacancy so HTML tags are sent
  * to the browser.
  *
- * @param $view
- * @param $output
+ * @param object $view
+ * @param string $output
  */
 function _civihr_employee_portal_decode_vacancy_description_html(&$view, &$output) {
   $replacements = [];

--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -1097,6 +1097,27 @@ function civihr_employee_portal_views_post_render(&$view, &$output, &$cache) {
       $output = strtr($output, $fieldsToClean);
     }
   }
+
+  if ($view->name == 'hr_vacancies') {
+    _civihr_employee_portal_decode_vacancy_description_html($view, $output);
+  }
+}
+
+/**
+ * Decodes html entities in description for each vacancy so HTML tags are sent
+ * to the browser.
+ *
+ * @param $view
+ * @param $output
+ */
+function _civihr_employee_portal_decode_vacancy_description_html(&$view, &$output) {
+  $replacements = [];
+
+  foreach ($view->style_plugin->rendered_fields as $vacancy) {
+    $replacements[$vacancy['description']] = html_entity_decode($vacancy['description']);
+  }
+
+  $output = strtr($output, $replacements);
 }
 
 function removeAdditionalCommas($view) {


### PR DESCRIPTION
## Overview
Vacancies list on SSP was showing HTML tags on its description, after clicking on "More details".
![hr_vacancies___hrdemo](https://user-images.githubusercontent.com/21999940/28121446-c4ea5f5c-66e0-11e7-8c74-7a50b35fa572.jpg)

## Before
Vacancy list view was showing HTML tags in every vacancy's description. This happened because HTML special characters like '<' and '>' were being changed for HTML entities '&lt;' and '&gt;' respectively, breaking the HTML.

## After
Fixed by implementing the _views_post_render hook, replacing the HTML entities for their corresponding characters.

![image](https://user-images.githubusercontent.com/21999940/28121407-a3380792-66e0-11e7-9e9f-3bfb0887c92a.png)
