### PR TITLE
PCHR-2309: Target contact and notification shown wrong in SSP

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -543,6 +543,33 @@ function getModuleUrl($moduleName) {
 }
 
 /**
+ * Implements hook_coreResourceList
+ *
+ * @param array $list
+ * @param string $region
+ */
+function civihr_employee_portal_civicrm_coreResourceList(&$list, $region) {
+  // To maintain the dependency remove the js files that are dependent on
+  // jquery.notify.js
+  $jsToRemove[] = array_search('js/Common.js', $list);
+  $jsToRemove[] = array_search('js/crm.ajax.js', $list);
+  $jsToRemove[] = array_search('js/wysiwyg/crm.wysiwyg.js', $list);
+  $jsToRemove[] = array_search('js/crm.drupal.js', $list);
+
+  foreach ($jsToRemove as $filepath) {
+    unset($list[$filepath]);
+  }
+
+  // Add the previously unlisted files to the list once the
+  // jquery.notify.js is added
+  $list[] = "packages/jquery/plugins/jquery.notify.js";
+  $list[] = "js/Common.js";
+  $list[] = "js/crm.ajax.js";
+  $list[] = "js/wysiwyg/crm.wysiwyg.js";
+  $list[] = "js/crm.drupal.js";
+}
+
+/**
  * Implements hook_init().
  */
 function civihr_employee_portal_init() {


### PR DESCRIPTION
## Overview
Currently, when the CiviCRM notification is used in SSP, the notification does not appear as in civiCRM pages due to the reason that SSP does not have the template and styles  for the notification. This PR adds  the required `jquery.notify.js` library and fixe x the dependencies between then by re arranging the `js` files to be loaded in SSP.

## Before
- Displays the target contact in disabled dropdown
![screen shot 2017-07-19 at 2 50 21 pm](https://user-images.githubusercontent.com/6307362/28359409-cc950674-6c91-11e7-88cf-046666b3817d.png)

- Displays the notification in default javascript alert
![screen shot 2017-07-19 at 2 51 29 pm](https://user-images.githubusercontent.com/6307362/28359412-cf8b338a-6c91-11e7-954e-f62d6c6bbced.png)

## After
- Displays target contact in plain text:
![screen shot 2017-07-19 at 2 03 24 pm](https://user-images.githubusercontent.com/6307362/28358191-a6dad124-6c8d-11e7-84e0-2818ab374bb3.png)

- Displays the error notification as in CiviCRM pages:
![screen shot 2017-07-19 at 2 19 53 pm](https://user-images.githubusercontent.com/6307362/28358210-c1b99232-6c8d-11e7-95b1-ce1d2a1fff8b.png)

## Technical Details
1: Add `hook_coreResourceList` in file "/civihr_employee_portal/civihr_employee_portal.module"to add the `jquery.notify.js` and rearrange the  `js` files to be loaded in the SSP page.
```php
/**
 * Implements hook_coreResourceList
 *
 * @param array $list
 * @param string $region
 */
 function civihr_employee_portal_civicrm_coreResourceList(&$list, $region) {
   ...
}
```