### PR TITLE
PCHR-2417: Add table class

### DIFF
--- a/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-settings-age-group.tpl.php
+++ b/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-settings-age-group.tpl.php
@@ -6,7 +6,7 @@
         <span class="chr_search-result__total__count"><?php echo count($rows); ?></span>
       </div>
     </div>
-
+    <?php $classes .= ' table '; ?>
     <table <?php if ($classes) { print 'class="'. $classes . '" '; } ?><?php print $attributes; ?>>
       <?php if (!empty($title) || !empty($caption)) : ?>
         <caption><?php print $caption . $title; ?></caption>

--- a/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-settings-age-group.tpl.php
+++ b/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-settings-age-group.tpl.php
@@ -6,6 +6,7 @@
         <span class="chr_search-result__total__count"><?php echo count($rows); ?></span>
       </div>
     </div>
+    <!--Adding "table" class to get the bootstrap styles-->
     <?php $classes .= ' table '; ?>
     <table <?php if ($classes) { print 'class="'. $classes . '" '; } ?><?php print $attributes; ?>>
       <?php if (!empty($title) || !empty($caption)) : ?>


### PR DESCRIPTION
## Overview
As part of this PR `table` class is added to the `age-group` table.

## Technical Details
The `age-group` sections table did not have `table` class and because of that the bootstrap styles were not getting applied. Added the same.

