### PR TITLE
PCHR-2325: Remove HR Documents Block From new Tasks and Documents Page

### DIFF
--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.pages_default.inc
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.pages_default.inc
@@ -606,29 +606,6 @@ function civihr_employee_portal_features_default_page_manager_pages() {
   $display->content['new-0f962e7d-947f-4064-b545-efdf7262a50f'] = $pane;
   $display->panels['header'][0] = 'new-0f962e7d-947f-4064-b545-efdf7262a50f';
   $pane = new stdClass();
-  $pane->pid = 'new-7bc09b07-84d8-44a5-9f7b-1ac1e4cfcd0a';
-  $pane->panel = 'middle';
-  $pane->type = 'block';
-  $pane->subtype = 'views-hr_documents-block';
-  $pane->shown = TRUE;
-  $pane->access = array();
-  $pane->configuration = array(
-    'override_title' => 0,
-    'override_title_text' => '',
-    'override_title_heading' => 'h2',
-  );
-  $pane->cache = array();
-  $pane->style = array(
-    'settings' => NULL,
-  );
-  $pane->css = array();
-  $pane->extras = array();
-  $pane->position = 0;
-  $pane->locks = array();
-  $pane->uuid = '7bc09b07-84d8-44a5-9f7b-1ac1e4cfcd0a';
-  $display->content['new-7bc09b07-84d8-44a5-9f7b-1ac1e4cfcd0a'] = $pane;
-  $display->panels['middle'][0] = 'new-7bc09b07-84d8-44a5-9f7b-1ac1e4cfcd0a';
-  $pane = new stdClass();
   $pane->pid = 'new-691f553c-d36d-474b-b89b-c75974eb3eb4';
   $pane->panel = 'middle';
   $pane->type = 'block';
@@ -648,11 +625,11 @@ function civihr_employee_portal_features_default_page_manager_pages() {
     'css_class' => 'chr_panel chr_panel--no-padding',
   );
   $pane->extras = array();
-  $pane->position = 1;
+  $pane->position = 0;
   $pane->locks = array();
   $pane->uuid = '691f553c-d36d-474b-b89b-c75974eb3eb4';
   $display->content['new-691f553c-d36d-474b-b89b-c75974eb3eb4'] = $pane;
-  $display->panels['middle'][1] = 'new-691f553c-d36d-474b-b89b-c75974eb3eb4';
+  $display->panels['middle'][0] = 'new-691f553c-d36d-474b-b89b-c75974eb3eb4';
   $pane = new stdClass();
   $pane->pid = 'new-691f553c-d36d-474b-b89b-c75974eb3eb5';
   $pane->panel = 'middle';
@@ -673,11 +650,11 @@ function civihr_employee_portal_features_default_page_manager_pages() {
     'css_class' => 'footer-slider-block',
   );
   $pane->extras = array();
-  $pane->position = 2;
+  $pane->position = 1;
   $pane->locks = array();
   $pane->uuid = '691f553c-d36d-474b-b89b-c75974eb3eb5';
   $display->content['new-691f553c-d36d-474b-b89b-c75974eb3eb5'] = $pane;
-  $display->panels['middle'][2] = 'new-691f553c-d36d-474b-b89b-c75974eb3eb5';
+  $display->panels['middle'][1] = 'new-691f553c-d36d-474b-b89b-c75974eb3eb5';
   $display->hide_title = PANELS_TITLE_FIXED;
   $display->title_pane = '0';
   $handler->conf['display'] = $display;


### PR DESCRIPTION
## Overview
The idea was to move "My Tasks", "Documents" and "Documents Manager" blocks from the SSP dashboard to a new page, "Tasks and Documents", accessible via a new item on the main menu. This was done on a previous PR (#323), however, the HR Resources Block was also added to the new Tasks and Documents page. This widget should only appear on dashboard page.

## Before
HR Resources block was appearing on Tasks and Documents page.

![image](https://user-images.githubusercontent.com/21999940/28921680-9007b648-781c-11e7-8783-4be57a876606.png)

## After
The block was removed from Tasks and Documents page.

![image](https://user-images.githubusercontent.com/21999940/27962577-f1abc068-62f7-11e7-8bbf-98606fef0839.png)