### PR TITLE
PCHR-2449: Add Sickness reason to Leave And Absence Report

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.info
+++ b/civihr_employee_portal/civihr_employee_portal.info
@@ -48,6 +48,7 @@ files[] = views/includes/civihr_employee_portal_handler_absence_duration.inc
 files[] = views/includes/civihr_employee_portal_handler_activity_type.inc
 files[] = views/includes/civihr_employee_portal_handler_employee_id.inc
 files[] = views/includes/civihr_employee_portal_handler_absence_status.inc
+files[] = views/includes/civihr_employee_portal_handler_sickness_reason.inc
 files[] = views/includes/civihr_employee_portal_handler_document_status.inc
 files[] = views/includes/civihr_employee_portal_handler_task_status.inc
 files[] = views/includes/civihr_employee_portal_handler_appraisal_cycle_type.inc

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -334,6 +334,7 @@ function _rebuild_absence_activity_view() {
             SELECT lr.contact_id AS absence_contact_id,
               lr.id AS absence_activity_id,
               at.title as absence_type,
+              lr.sickness_reason as sickness_reason,
               lrd.date AS absence_date,
               DATE_FORMAT(DATE(lrd.date), '%Y-%m') AS absence_month,
               lr.from_date AS absence_start_date,
@@ -775,6 +776,45 @@ function get_civihr_absence_statuses($status_id = NULL) {
     $status_id_value = CRM_Utils_Array::value($status_id, $absenceStatuses);
 
     return $status_id_value;
+}
+
+/**
+ * This function returns the sickness reason label for the sickness reason
+ * option value passed to it.
+ * The sickness reason option group is cached to avoid hitting the Db on
+ * every call.
+ *
+ * @param int $sickness_reason_value
+ *
+ * @return string
+ */
+function get_civihr_absence_sickness_reason_label($sickness_reason_value) {
+    $sicknessReasons = &drupal_static(__FUNCTION__);
+
+    if (!isset($sicknessReasons)) {
+        if ($cache = cache_get('civihr_absence_sickness_reasons')) {
+            $sicknessReasons = $cache->data;
+        }
+        else {
+            try {
+                // Civi init
+                civicrm_initialize();
+                $sicknessReasons = CRM_Core_OptionGroup::values('hrleaveandabsences_sickness_reason', FALSE, FALSE, FALSE, NULL, 'label');
+
+                watchdog('DB hit absence sickness reasons', 'DB');
+            }
+
+            catch (CiviCRM_API3_Exception $e) {
+                $error = $e->getMessage();
+            }
+
+            // Cache the absence sickness reasons for 5 minutes
+            cache_set('civihr_absence_sickness_reasons', $sicknessReasons, 'cache', time() + 360);
+        }
+    }
+    $sickness_reason_label = CRM_Utils_Array::value($sickness_reason_value, $sicknessReasons);
+
+    return $sickness_reason_label;
 }
 
 function get_document_statuses($status_id = NULL) {
@@ -3664,6 +3704,12 @@ function civihr_employee_portal_schema_alter(&$schema) {
         'length' => 256,
         'not null' => FALSE,
         'description' => 'Absence Type.',
+    );
+    $schema['absence_activity']['fields']['sickness_reason'] = array(
+        'type' => 'varchar',
+        'length' => 512,
+        'not null' => FALSE,
+        'description' => 'Sickness Reason.',
     );
     $schema['absence_activity']['fields']['absence_date'] = array(
         'type' => 'varchar',

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -779,42 +779,45 @@ function get_civihr_absence_statuses($status_id = NULL) {
 }
 
 /**
- * This function returns the sickness reason label for the sickness reason
+ * Returns the sickness reason label for the sickness reason
  * option value passed to it.
  * The sickness reason option group is cached to avoid hitting the Db on
  * every call.
  *
- * @param int $sickness_reason_value
+ * @param int $sicknessReasonValue
  *
  * @return string
  */
-function get_civihr_absence_sickness_reason_label($sickness_reason_value) {
+
+function get_civihr_absence_sickness_reason_label($sicknessReasonValue) {
     $sicknessReasons = &drupal_static(__FUNCTION__);
+    $SICKNESS_REASONS_CACHE_KEY = 'civihr_absence_sickness_reasons';
 
     if (!isset($sicknessReasons)) {
-        if ($cache = cache_get('civihr_absence_sickness_reasons')) {
-            $sicknessReasons = $cache->data;
+    	  $cachedSicknessReasons = cache_get($SICKNESS_REASONS_CACHE_KEY);
+        if ($cachedSicknessReasons) {
+            $sicknessReasons = $cachedSicknessReasons->data;
         }
         else {
-            try {
-                // Civi init
-                civicrm_initialize();
-                $sicknessReasons = CRM_Core_OptionGroup::values('hrleaveandabsences_sickness_reason', FALSE, FALSE, FALSE, NULL, 'label');
+            civicrm_initialize();
+            $sicknessReasons = [];
+            $result = civicrm_api3('OptionValue', 'get', ['option_group_id' => 'hrleaveandabsences_sickness_reason']);
 
-                watchdog('DB hit absence sickness reasons', 'DB');
+            if ($result['count'] > 0) {
+                $sicknessReasons = array_column($result['values'], 'label', 'value');
             }
-
-            catch (CiviCRM_API3_Exception $e) {
-                $error = $e->getMessage();
-            }
-
             // Cache the absence sickness reasons for 5 minutes
-            cache_set('civihr_absence_sickness_reasons', $sicknessReasons, 'cache', time() + 360);
+            $SECONDS_IN_FIVE_MINUTES = 300;
+            cache_set($SICKNESS_REASONS_CACHE_KEY, $sicknessReasons, 'cache', time() + $SECONDS_IN_FIVE_MINUTES);
         }
     }
-    $sickness_reason_label = CRM_Utils_Array::value($sickness_reason_value, $sicknessReasons);
 
-    return $sickness_reason_label;
+    $sicknessReasonLabel = '';
+    if (!empty($sicknessReasons[$sicknessReasonValue])) {
+        $sicknessReasonLabel = $sicknessReasons[$sicknessReasonValue];
+    }
+
+    return $sicknessReasonLabel;
 }
 
 function get_document_statuses($status_id = NULL) {

--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.views_default.inc
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.views_default.inc
@@ -377,6 +377,12 @@ function civihr_employee_portal_features_views_default_views() {
   $handler->display->display_options['fields']['absence_type']['field'] = 'absence_type';
   $handler->display->display_options['fields']['absence_type']['relationship'] = 'absence_activity';
   $handler->display->display_options['fields']['absence_type']['label'] = 'Absence type';
+  /* Field: Absence Activity entity: Sickness Reason */
+  $handler->display->display_options['fields']['sickness_reason']['id'] = 'absence_type';
+  $handler->display->display_options['fields']['sickness_reason']['table'] = 'absence_activity';
+  $handler->display->display_options['fields']['sickness_reason']['field'] = 'sickness_reason';
+  $handler->display->display_options['fields']['sickness_reason']['relationship'] = 'absence_activity';
+  $handler->display->display_options['fields']['sickness_reason']['label'] = 'Sickness reason';
   /* Field: Absence Activity entity: Absence status */
   $handler->display->display_options['fields']['absence_status']['id'] = 'absence_status';
   $handler->display->display_options['fields']['absence_status']['table'] = 'absence_activity';
@@ -989,6 +995,7 @@ function civihr_employee_portal_features_views_default_views() {
     t('Absence end month'),
     t('Absence duration in days'),
     t('Absence type'),
+    t('Sickness reason'),
     t('Absence status'),
     t('Absence amount taken'),
     t('Absence amount accrued'),

--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -800,6 +800,26 @@ function civihr_employee_portal_views_data_alter(&$data) {
     'sort' => array('handler' => 'views_handler_sort'),
   );
 
+  $data['absence_activity']['sickness_reason'] = array(
+    'title' => t('Sickness reason'),
+    'help' => t('Sickness reason field value'),
+    'real field' => 'sickness_reason',
+    'field' => array(
+      'handler' => 'civihr_employee_portal_handler_sickness_reason',
+      'click sortable' => TRUE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument_string',
+      'name_field' => 'title',
+      'string' => TRUE
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_string',
+      'help' => t('Filter results to a particular result set'),
+    ),
+    'sort' => array('handler' => 'views_handler_sort'),
+  );
+
   $data['civicrm_value_emergency_contacts_21']['id'] = array(
     'title' => t('Emergency Contact ID'),
     'help' => t('Emergency Contact ID field value'),

--- a/civihr_employee_portal/views/includes/civihr_employee_portal_handler_sickness_reason.inc
+++ b/civihr_employee_portal/views/includes/civihr_employee_portal_handler_sickness_reason.inc
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * Custom views handler field to display the sickness reason label
+ * rather than the option value.
+ */
+class civihr_employee_portal_handler_sickness_reason extends views_handler_field {
+
+    function render($values) {
+        $value = $this->get_value($values);
+        $sickness_reason_label = get_civihr_absence_sickness_reason_label($value);
+
+        return $sickness_reason_label;
+    }
+}

--- a/civihr_employee_portal/views/views_export/views_civihr_report_leave_and_absence.inc
+++ b/civihr_employee_portal/views/views_export/views_civihr_report_leave_and_absence.inc
@@ -370,6 +370,12 @@ $handler->display->display_options['fields']['absence_type']['table'] = 'absence
 $handler->display->display_options['fields']['absence_type']['field'] = 'absence_type';
 $handler->display->display_options['fields']['absence_type']['relationship'] = 'absence_activity';
 $handler->display->display_options['fields']['absence_type']['label'] = 'Absence type';
+/* Field: Absence Activity entity: Sickness Reason */
+$handler->display->display_options['fields']['sickness_reason']['id'] = 'absence_type';
+$handler->display->display_options['fields']['sickness_reason']['table'] = 'absence_activity';
+$handler->display->display_options['fields']['sickness_reason']['field'] = 'sickness_reason';
+$handler->display->display_options['fields']['sickness_reason']['relationship'] = 'absence_activity';
+$handler->display->display_options['fields']['sickness_reason']['label'] = 'Sickness reason';
 /* Field: Absence Activity entity: Absence_status */
 $handler->display->display_options['fields']['absence_status']['id'] = 'absence_status';
 $handler->display->display_options['fields']['absence_status']['table'] = 'absence_activity';
@@ -983,6 +989,7 @@ $translatables['civihr_report_leave_and_absence'] = array(
   t('Absence end month'),
   t('Absence duration in days'),
   t('Absence type'),
+  t('Sickness reason'),
   t('Absence status'),
   t('Absence amount taken'),
   t('Absence amount accrued'),


### PR DESCRIPTION
## Overview
Currently the Leave and Absence report on the SSP does not have sickness reason as one of its columns. This PR adds the Sickness reason column and this also makes the sickness reason available in the Pivot table.

## After
![civihr custom report - l_and_a 2017-07-31 11-31-06](https://user-images.githubusercontent.com/6951813/28774063-dacbdbe0-75e3-11e7-9b1f-22e21e225f19.png)



---

- [ ] Tests Pass
Didn't run the tests in employee portal module.