### PR TITLE
PCHR-2326: Fix Pivot table styles

### DIFF
--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -163,18 +163,19 @@
    */
   HRReport.prototype.updateDropdown = function() {
     $('.pvtUi select').each(function () {
-      var selectClass = 'chr_custom-select chr_custom-select--full';
+      var selectClass = 'crm_custom-select crm_custom-select--full';
 
-      if (!$(this).parent().hasClass('chr_custom-select')) {
+      if (!$(this).parent().hasClass('crm_custom-select')) {
         if ($(this).hasClass('pvtAggregator')) {
-          selectClass += ' chr_custom-select--transparent';
+          selectClass += ' crm_custom-select--transparent';
         }
 
         $(this).wrap('<div class="' + selectClass + '"></div>');
+        $(this).parent().append('<span class="crm_custom-select__arrow"></span>');
       }
     });
 
-    $('.pvtVals .chr_custom-select').each(function () {
+    $('.pvtVals .crm_custom-select').each(function () {
       if ($(this).find('select').length === 0) {
         $(this).remove();
       }
@@ -247,7 +248,7 @@
       $(filter_selector).find('span:first').text(that.formatLengthsOfService(employee_length_service));
     }
   }
-  
+
   /**
    * Processes results in people report view to format length of service for each
    * contact in a human readable form using moment lib.


### PR DESCRIPTION
## Overview
As part of this PR, Pivot Table styles has been fixed.

## Before
![civihr_custom_report___hr17-1](https://user-images.githubusercontent.com/5058867/29024559-4174a6a4-7b90-11e7-9bf4-9bdef645dc99.png)

## After
![civihr_custom_report___hr17-1](https://user-images.githubusercontent.com/5058867/29024689-e0d91536-7b90-11e7-9501-59de6b28658b.png)

## Technical Details
As part of https://github.com/compucorp/civihr-employee-portal-theme/pull/168, `chr_custom-select` class was removed because `crm_custom-select` already existed for the same purpose. But the class for Pivot table was not updated. 
1. Class name updated to `crm_custom*`
2. Necessary markup added for the dropdown arrow.
---

- [x] Tests Pass
