### PR TITLE
PCHR-2485: Update yoti callback URL for public access

### DIFF
--- a/civihr_employee_portal/src/Security/PublicFirewall.php
+++ b/civihr_employee_portal/src/Security/PublicFirewall.php
@@ -19,7 +19,8 @@ class PublicFirewall {
     'sites/default/files/logo.jpg', // if logo is missing
     'request_new_account/ajax', // from login page
     '@^user((?!\/register).)*$@', // user* except user/register
-    '@^yoti-connect*@' // yoti login plugin
+    'yoti', // yoti login plugin
+    '@^yoti\/.*@' // anything under yoti
   ];
 
   /**

--- a/civihr_employee_portal/tdd/PublicFirewallTest.php
+++ b/civihr_employee_portal/tdd/PublicFirewallTest.php
@@ -47,8 +47,8 @@ class PublicFirewallTest extends \PHPUnit_Framework_TestCase {
       ['welcome-page/protected'],
       ['request_new_accountajax'],
       ['home/user'],
-      ['yoti_connect'],
-      ['something/yoti-connect'],
+      ['yoti-connect'],
+      ['something/yoti'],
       [''],
     ];
   }
@@ -62,8 +62,8 @@ class PublicFirewallTest extends \PHPUnit_Framework_TestCase {
       ['sites/default/files/logo.jpg'],
       ['request_new_account/ajax'],
       ['user/some/other/path'],
-      ['yoti-connect'],
-      ['yoti-connect/anything'],
+      ['yoti'],
+      ['yoti/anything'],
     ];
   }
 


### PR DESCRIPTION
### Problem
After updating the version of the `yoti` module it's not possible to login using yoti anymore. The version of the module uses a different callback URL, which cannot be accessed by anonymous users.

### Solution
Update the list of URL on the `PublicFirewall` to allow anonymous access to any URL under `/yoti/`