### PR TITLE
PCHR-2485: Allow yoti-connect public access again

### DIFF
--- a/civihr_employee_portal/src/Security/PublicFirewall.php
+++ b/civihr_employee_portal/src/Security/PublicFirewall.php
@@ -20,7 +20,8 @@ class PublicFirewall {
     'request_new_account/ajax', // from login page
     '@^user((?!\/register).)*$@', // user* except user/register
     'yoti', // yoti login plugin
-    '@^yoti\/.*@' // anything under yoti
+    '@^yoti\/.*@', // anything under yoti
+    '@^yoti-connect*@' // also yoti login plugin, where the user is redirected after login
   ];
 
   /**

--- a/civihr_employee_portal/tdd/PublicFirewallTest.php
+++ b/civihr_employee_portal/tdd/PublicFirewallTest.php
@@ -47,8 +47,9 @@ class PublicFirewallTest extends \PHPUnit_Framework_TestCase {
       ['welcome-page/protected'],
       ['request_new_accountajax'],
       ['home/user'],
-      ['yoti-connect'],
+      ['yoti_connect'],
       ['something/yoti'],
+      ['something/yoti_connect'],
       [''],
     ];
   }
@@ -64,6 +65,8 @@ class PublicFirewallTest extends \PHPUnit_Framework_TestCase {
       ['user/some/other/path'],
       ['yoti'],
       ['yoti/anything'],
+      ['yoti-connect'],
+      ['yoti-connect/lorem-ipsum'],
     ];
   }
 


### PR DESCRIPTION
### Problem
After the [update and the change of the callback URL to `yoti`](https://github.com/compucorp/civihr-employee-portal/pull/338), the module still uses the `yoti-connect` URL after the login. Since it's not publicly accessible anymore, the login won't work.

### Solution
The `yoti-connect` URL was added to the `PublicFirewall` again