### PR TITLE
PCHR-2499: Add default report permissions to administrator

### DIFF
--- a/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
+++ b/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
@@ -47,6 +47,7 @@ function civihr_default_permissions_user_default_permissions() {
   $permissions['access CiviReport'] = array(
     'name' => 'access CiviReport',
     'roles' => array(
+      'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
     ),
     'module' => 'civicrm',
@@ -84,7 +85,9 @@ function civihr_default_permissions_user_default_permissions() {
   // Exported permission: 'access Report Criteria'.
   $permissions['access Report Criteria'] = array(
     'name' => 'access Report Criteria',
-    'roles' => array(),
+    'roles' => array(
+      'administrator' => 'administrator',
+    ),
     'module' => 'civicrm',
   );
 
@@ -473,6 +476,7 @@ function civihr_default_permissions_user_default_permissions() {
   $permissions['administer Reports'] = array(
     'name' => 'administer Reports',
     'roles' => array(
+      'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
     ),
     'module' => 'civicrm',

--- a/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
+++ b/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
@@ -87,6 +87,7 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'access Report Criteria',
     'roles' => array(
       'administrator' => 'administrator',
+      'civihr_admin' => 'civihr_admin',
     ),
     'module' => 'civicrm',
   );

--- a/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
+++ b/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
@@ -106,6 +106,7 @@ function civihr_default_permissions_user_default_permissions() {
   $permissions['access Tasks and Assignments Files'] = array(
     'name' => 'access Tasks and Assignments Files',
     'roles' => array(
+      'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
       'civihr_admin_local' => 'civihr_admin_local',
       'civihr_manager' => 'civihr_manager',
@@ -139,6 +140,7 @@ function civihr_default_permissions_user_default_permissions() {
   $permissions['access all cases and activities'] = array(
     'name' => 'access all cases and activities',
     'roles' => array(
+      'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
     ),
     'module' => 'civicrm',
@@ -288,6 +290,7 @@ function civihr_default_permissions_user_default_permissions() {
   $permissions['access my cases and activities'] = array(
     'name' => 'access my cases and activities',
     'roles' => array(
+      'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
     ),
     'module' => 'civicrm',
@@ -426,6 +429,7 @@ function civihr_default_permissions_user_default_permissions() {
   $permissions['add cases'] = array(
     'name' => 'add cases',
     'roles' => array(
+      'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
     ),
     'module' => 'civicrm',
@@ -467,6 +471,7 @@ function civihr_default_permissions_user_default_permissions() {
   $permissions['administer CiviCase'] = array(
     'name' => 'administer CiviCase',
     'roles' => array(
+      'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
     ),
     'module' => 'civicrm',
@@ -1276,6 +1281,7 @@ function civihr_default_permissions_user_default_permissions() {
   $permissions['delete in CiviCase'] = array(
     'name' => 'delete in CiviCase',
     'roles' => array(
+      'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
     ),
     'module' => 'civicrm',


### PR DESCRIPTION
## Overview

Users with the `administrator` role couldn't access any of the reports under Absences -> Absence Report. This happens because the default set of permissions for this role doesn't include those necessary to access the reports.

## Before

The `administrator` roles didn't have the required permissions to access the reports:
- access CiviReport
- access Report Criteria (this one was also added to the `civihr_admin` role)

## After

The `administrator` role has all the required permissions to access the reports.

## Comments

Even though the `administrator` role is one level above the the `civihr_admin` role, it was missing some of the permissions set for the latter. The missing permissions are:

- People Management: delete in People Management
- People Management: administer People Management
- People Management: access my assignments and activities
- People Management: access all assignments and activities
- People Management: add assignments
- CiviTasksassignments: access Tasks and Assignments Files

This PR adds all them to the `administrator` role

---
There are no tests related to this
- [ ] Tests Pass
