### PR TITLE
PCHR-2499: Add L&A default permissions to administrators

### DIFF
--- a/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
+++ b/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
@@ -260,6 +260,7 @@ function civihr_default_permissions_user_default_permissions() {
   $permissions['access leave and absences'] = array(
     'name' => 'access leave and absences',
     'roles' => array(
+      'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
       'civihr_manager' => 'civihr_manager',
       'civihr_staff' => 'civihr_staff',
@@ -277,7 +278,7 @@ function civihr_default_permissions_user_default_permissions() {
       'civihr_manager' => 'civihr_manager',
       'civihr_staff' => 'civihr_staff',
     ),
-    'module' => 'civihr_employee_portal',
+    'module' => 'civicrm',
   );
 
   // Exported permission: 'access my cases and activities'.
@@ -611,6 +612,7 @@ function civihr_default_permissions_user_default_permissions() {
   $permissions['administer leave and absences'] = array(
     'name' => 'administer leave and absences',
     'roles' => array(
+      'administrator' => 'administrator',
       'civihr_admin' => 'civihr_admin',
     ),
     'module' => 'civicrm',
@@ -1766,11 +1768,11 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'manage leave and absences in ssp',
     'roles' => array(
       'administrator' => 'administrator',
-      'civihr_admin_local' => 'civihr_admin_local',
       'civihr_admin' => 'civihr_admin',
+      'civihr_admin_local' => 'civihr_admin_local',
       'civihr_manager' => 'civihr_manager',
     ),
-    'module' => 'civihr_employee_portal',
+    'module' => 'civicrm',
   );
 
   // Exported permission: 'merge duplicate contacts'.

--- a/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.info
+++ b/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.info
@@ -100,6 +100,7 @@ features[user_permission][] = administer fields
 features[user_permission][] = administer filters
 features[user_permission][] = administer image styles
 features[user_permission][] = administer languages
+features[user_permission][] = administer leave and absences
 features[user_permission][] = administer mailsystem
 features[user_permission][] = administer menu
 features[user_permission][] = administer modules


### PR DESCRIPTION
## Overview

Users with the `administrator` role couldn't access any of L&A screens on the CiviHR admin. This happens because the default set of permissions for this role doesn't include those necessary to access the said screens.

## Before

The `administrator` roles didn't have the required permissions the L&A screens on CiviHR admin:
- administer leave and absences
- access leave and absences

## After

The `administrator` role has all the required permissions to access all the L&A screens on CiviHR admin.

## Comments

There was a problem with the civihr_default_permissions feature where it was not keeping track of the `administer leave and absences` permission. It was probably something that was missed during one of the syncs with 1.6, since this is something that was correct on the [PR](https://github.com/compucorp/civihr-employee-portal/pull/288) that originally added this permission to the feature. 

Another thing that was also wrong (another probable miss of the syncs) was the module names on the permissions. The L&A permissions are set by the hrleaveandabsences permission, so the module should say `civicrm` instead of `civihr_employee_portal`. This PR also fixes this.

---
There are no tests related to this
- [ ] Tests Pass
