### PR TITLE
PCHR-2493: Remove filter based on hrvisa custom group table

### DIFF
--- a/civihr_employee_portal/views/views_export/views_hr_staff_directory.inc
+++ b/civihr_employee_portal/views/views_export/views_hr_staff_directory.inc
@@ -583,12 +583,6 @@ $handler->display->display_options['filters']['is_deleted']['table'] = 'civicrm_
 $handler->display->display_options['filters']['is_deleted']['field'] = 'is_deleted';
 $handler->display->display_options['filters']['is_deleted']['value'] = '0';
 $handler->display->display_options['filters']['is_deleted']['group'] = 1;
-/* Filter criterion: CiviCRM Custom: Immigration: Start Date */
-$handler->display->display_options['filters']['start_date_52']['id'] = 'start_date_52';
-$handler->display->display_options['filters']['start_date_52']['table'] = 'civicrm_value_immigration_3';
-$handler->display->display_options['filters']['start_date_52']['field'] = 'start_date_52';
-$handler->display->display_options['filters']['start_date_52']['operator'] = 'empty';
-$handler->display->display_options['filters']['start_date_52']['group'] = 1;
 /* Filter criterion: HRJobContract Role entity: Role end date */
 $handler->display->display_options['filters']['role_end_date']['id'] = 'role_end_date';
 $handler->display->display_options['filters']['role_end_date']['table'] = 'hrjc_role';


### PR DESCRIPTION
## Overview
Since the functionality offered by the hrvisa and hrident extensions is planned to be replaced by the improved documents feature these extensions are not required going forward. However, as they are potentially used by existing clients we will not remove them from the code.

## Before
The staff directory view contains a filter that depends on the hrvisa extension.

## After
The staff directory filter for visa is removed.

---

- [ ] Tests Pass
What's broken is still broken, what was working is still working :unamused: 