### PR TITLE
PCHR-2526: Updated yoti module name for user profile page.

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5867,7 +5867,7 @@ function civihr_employee_portal_form_alter(&$form, &$form_state, $form_id) {
 function civihr_employee_portal_form_user_profile_form_alter(&$form, &$form_state, $form_id) {
 
   // Adding Yoti Login fieldset with button.
-  if (module_exists('yoti_connect')) {
+  if (module_exists('yoti')) {
 
     // Fetching block id from block description.
     $query = db_select('block_custom', 'b')


### PR DESCRIPTION
## Overview
Yoti module name had been updated from yoti_connect to yoti because of which the login link on user profile page was not working. Updated module name to check with new name.

## Technical Details
Changed
```php
module_exists('yoti_connect') to  module_exists('yoti');
```

---