### PR TITLE
PCHR-2457: Document open buttons take very long to load on ssp

### DIFF
--- a/civihr_employee_portal/js/ta-documents-app.js
+++ b/civihr_employee_portal/js/ta-documents-app.js
@@ -72,7 +72,7 @@
           var modalInstance = $modal.open({
             appendTo: $rootElement,
             templateUrl: config.path.TPL + 'modal/document.html?v=3',
-            controller: 'ModalDocumentCtrl',
+            controller: 'ModalDocumentController',
             controllerAs: 'documentModal',
             resolve: {
               modalMode: function () {

--- a/civihr_employee_portal/js/ta-documents-app.js
+++ b/civihr_employee_portal/js/ta-documents-app.js
@@ -31,7 +31,7 @@
         })();
 
         /**
-         * Collect required contact  and cache them for document modal
+         * Collect required contact and cache them for document modal
          */
         function cacheContacts (documents) {
           DocumentService.cacheContactsAndAssignments(documents, 'contacts');
@@ -122,7 +122,7 @@
            * there must be more that one contacts conidering at aleast a target contact in a document
            */
           $rootScope.$watch('cache.contact', function () {
-            availableContacts = $rootScope.cache.contact.arrSearch.length > 1;
+            availableContacts = $rootScope.cache.contact.arrSearch.length >= 1;
             $rootScope.$broadcast('ct-spinner-' + (availableContacts ? 'hide' : 'show'));
             vm.loadingModalData = !availableContacts;
           });

--- a/civihr_employee_portal/js/ta-documents-app.js
+++ b/civihr_employee_portal/js/ta-documents-app.js
@@ -25,7 +25,6 @@
         (function init() {
           // Sets the date format for HR_settings.DATE_FORMAT
           DateFormat.getDateFormat();
-
           subscribeForEvents();
           watchForChanges();
         })();
@@ -122,7 +121,7 @@
            * there must be more that one contacts conidering at aleast a target contact in a document
            */
           $rootScope.$watch('cache.contact', function () {
-            availableContacts = $rootScope.cache.contact.arrSearch.length >= 1;
+            availableContacts = !!$rootScope.cache.contact.arrSearch.length;
             $rootScope.$broadcast('ct-spinner-' + (availableContacts ? 'hide' : 'show'));
             vm.loadingModalData = !availableContacts;
           });

--- a/civihr_employee_portal/js/ta-documents-app.js
+++ b/civihr_employee_portal/js/ta-documents-app.js
@@ -26,7 +26,6 @@
           // Sets the date format for HR_settings.DATE_FORMAT
           DateFormat.getDateFormat();
           subscribeForEvents();
-          watchForChanges();
         })();
 
         /**
@@ -105,25 +104,6 @@
         function subscribeForEvents () {
           $rootScope.$on('document-saved', function () {
             $window.location.reload();
-          });
-        };
-
-        /**
-         * All watchers for changes
-         */
-        function watchForChanges () {
-          /**
-           * Watch for the changes in the list of $rootScope.cache.contact.arrSearch
-           * Display spinner and hide "open" button until the arrSearch is filled with contacts
-           *
-           * Note: $rootScope.cache.contact.arrSearch will always contain a
-           * contact data (curently logged in contact). So if there are documents,
-           * there must be more that one contacts conidering at aleast a target contact in a document
-           */
-          $rootScope.$watch('cache.contact', function () {
-            availableContacts = !!$rootScope.cache.contact.arrSearch.length;
-            $rootScope.$broadcast('ct-spinner-' + (availableContacts ? 'hide' : 'show'));
-            vm.loadingModalData = !availableContacts;
           });
         };
     }

--- a/civihr_employee_portal/js/ta-documents-app.js
+++ b/civihr_employee_portal/js/ta-documents-app.js
@@ -20,24 +20,21 @@
 
         vm.modalDocument = modalDocument;
         vm.openModalDocument = openModalDocument;
+        vm.cacheContacts = cacheContacts;
 
         (function init() {
-          subscribeForEvents();
-          watchForChanges();
-          collectRequiredData();
-        })();
-
-        /**
-         * Collect required data for document modal
-         */
-        function collectRequiredData () {
           // Sets the date format for HR_settings.DATE_FORMAT
           DateFormat.getDateFormat();
 
-          // Fetch and cache contacts and addignments
-          DocumentService.get().then(function (documents) {
-            DocumentService.cacheContactsAndAssignments(documents, 'contacts');
-          });
+          subscribeForEvents();
+          watchForChanges();
+        })();
+
+        /**
+         * Collect required contact  and cache them for document modal
+         */
+        function cacheContacts (documents) {
+          DocumentService.cacheContactsAndAssignments(documents, 'contacts');
         };
 
         /**
@@ -57,6 +54,7 @@
                 throw new Error('Requested Document is not available');
               }
 
+              vm.cacheContacts([data]);
               vm.openModalDocument(data[0], role);
             })
             .catch(function(reason) {


### PR DESCRIPTION
## Overview
In SSP at the Task and Documents page we display a spinner until we get all the documents (target and assignee contact and are cached). That's why the spinner is displayed before "open" button is displayed.

The problem is it takes too long to load the data since we are currently collecting contacts form all documents. This PR fixes it by doing the following things:- 
- Displays the spinner in the button until we have at least one contact.
- The contacts for the document are cached once we click open document modal button.

## Before
1. Takes more time to fetch and cache the contacts in the document displaying spinner longer in place of open button.
![2457-before](https://user-images.githubusercontent.com/6307362/29666255-3f3d7478-88f7-11e7-87cf-5fabf91aa8f9.gif)

## After
1. Displays the spinner in place on button till we have at least one contact in SSP i.e current logged in contact.
![2457-after](https://user-images.githubusercontent.com/6307362/29666301-6cb60424-88f7-11e7-80d8-3b083e147f47.gif)

## Technical Details
1. Remove code to get all the documents on `init` and replace with a code to collect the contact and cache them instead:
```js
/**
 * Collect required contact and cache them for document modal
 */
function cacheContacts (documents) {
   DocumentService.cacheContactsAndAssignments(documents, 'contacts');
};
```
2. Update the contact list when we get a document data, after we click the open button to open modal document.
```js
function modalDocument (id, role, mode) {
   ...
   DocumentService.get({ id: id })
      .then(function(data) {
         ...
         vm.cacheContacts([data]);
         vm.openModalDocument(data[0], role, mode);
      })
      ...
};
```
## Comments
As part of this PR, few extra things have been fixed:
1. Remove the spinner in place of open button on page load. Which is not needed now as are fetching and caching them after clicking the "open" button.
```js
$rootScope.$watch('cache.contact', function () {
    var availableContacts = $rootScope.cache.contact.arrSearch.length >= 1;
    $rootScope.$broadcast('ct-spinner-' + (availableContacts ? 'hide' : 'show'));
    vm.loadingModalData = !availableContacts;
});
```

2. As the controller name of Document Modal Controller has been changed in T&A, as we are reusing it in SSP, the controller name is updated.
```js
controller: 'ModalDocumentController',
```