### PR TITLE
PCHR-2489: Remove JS code form href as its a bad practice

### DIFF
--- a/civihr_employee_portal/views/templates/views-view-table--Documents--block.tpl.php
+++ b/civihr_employee_portal/views/templates/views-view-table--Documents--block.tpl.php
@@ -139,7 +139,7 @@ if (!empty($documentIds)) {
               }
 
               if($field == 'activity_type_id') {
-                printf('<td %s %s><a href="javascript:;" ng-click="document.modalDocument(' . $rowID .', \'staff\',\'' . $mode . '\')">%s</a></td>', $class, $attribute, $content);
+                printf('<td %s %s><a href="" ng-click="document.modalDocument(' . $rowID .', \'staff\',\'' . $mode . '\')">%s</a></td>', $class, $attribute, $content);
               } else {
                 printf('<td %s %s>%s</td>', $class, $attribute, $content);
               }


### PR DESCRIPTION
## Overview
Removes the JS code (`javascript:;`) from `href` as its a bad practice. And it causes the console error on clicking the Document Type in ssp document list (see before section)

## Before
- shows console error
![when_opening_modal_by_clicking_on_document_type](https://user-images.githubusercontent.com/6307362/30068541-d8a7604e-927d-11e7-8a9a-bbbc594a993e.png)

## After
- Does not show the console error
<img width="1411" alt="screen shot 2017-09-05 at 9 07 10 pm" src="https://user-images.githubusercontent.com/6307362/30068681-39d1f474-927e-11e7-834f-eddbdf72afcb.png">
