### PR TITLE
PCHR-2559: Remove "assign all roles" permission from local admin

### DIFF
--- a/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
+++ b/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
@@ -722,7 +722,6 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'administer permissions',
     'roles' => array(
       'administrator' => 'administrator',
-      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'user',
   );

--- a/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
+++ b/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
@@ -906,7 +906,6 @@ function civihr_default_permissions_user_default_permissions() {
     'name' => 'assign all roles',
     'roles' => array(
       'administrator' => 'administrator',
-      'civihr_admin_local' => 'civihr_admin_local',
     ),
     'module' => 'role_delegation',
   );


### PR DESCRIPTION
## Overview
The local admin shouldn't have permission to assign all roles.

## Before
The local admin had permission to assign all roles.

## After
The local admin does not have permission to assign all roles.

---

- [ ] Tests Pass
Same as usual, some working, some not. All tests should be working again when #346 is merged.