### PR TITLE
FAR-198: Allow requesting leave for dates matching the end/beginning of Daylight Saving Time

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -6980,21 +6980,27 @@ function civihr_employee_portal_module_implements_alter(&$implementations, $hook
 
 /**
  * Check if a passed date is weekend day or not
+ *
+ * @param \DateTime $date
+ *
+ * @return bool
  */
-function _isWeekend($date_passed) {
-
-    $date = explode("-", $date_passed);
-
-    $time = mktime(0, 0, 0, $date[1], $date[2], $date[0]);
-    $weekday = date('w', $time);
-    return ($weekday == 0 || $weekday == 6);
+function _isWeekend(\DateTime $date) {
+    $saturday = 6;
+    $sunday = 0;
+    $weekday = $date->format('w');
+    return ($weekday == $saturday || $weekday == $sunday);
 }
 
 /**
  * @param $public_holidays
- * Check if the requested day is holiday or not working day
+ *  Check if the requested day is holiday or not working day
+ * @param \DateTime $date
+ *  The requested day
+ *
+ * @return array
  */
-function _checkRequestedDay($public_holidays, $date) {
+function _checkRequestedDay($public_holidays, \DateTime $date) {
 
     $not_working_day = t('Weekend');
 
@@ -7003,7 +7009,7 @@ function _checkRequestedDay($public_holidays, $date) {
         $public_holiday_date = explode(" ", $public_holiday['activity_date_time']);
 
         // If the public holiday equals with the requested date and the public holiday is enabled
-        if ($public_holiday_date[0] == $date && $public_holiday['status_id'] == 1) {
+        if ($public_holiday_date[0] == $date->format('Y-m-d') && $public_holiday['status_id'] == 1) {
             $exclude_type = " (" . $public_holiday['subject'] . ")";
 
             return array(

--- a/civihr_employee_portal/civihr_employee_portal.rules.inc
+++ b/civihr_employee_portal/civihr_employee_portal.rules.inc
@@ -110,7 +110,7 @@ function civihr_employee_portal_rules_action_info() {
             ),
         ),
     );
-    
+
     return $actions;
 }
 
@@ -136,13 +136,13 @@ function _new_absence_request_action($roles, $absence_type, $absence_details, $f
         // TODO --> status ID should be dynamic??
         'status_id' => '1'
     );
-    
+
     $result = civicrm_api3('Activity', 'create', $activityParam);
-        
+
     // Get the main "absence" activity ID
     $activityTypes = CRM_Core_OptionGroup::values('activity_type', FALSE, FALSE, FALSE, NULL, 'name');
     $activityTypeId = CRM_Utils_Array::key('Absence', $activityTypes);
-    
+
     // Create sub-activities
     $activityLeavesParam = array(
         'sequential' => 1,
@@ -172,41 +172,26 @@ function _new_absence_request_action($roles, $absence_type, $absence_details, $f
 
     // Define Absence Date Durations
     $absentDateDurations = array();
-    $date_counter = 0;
-    
+
+    $fromDate = new \DateTime($form_values->absence_request_date_from);
     foreach ($form_values as $object_property_key => $object_property_value) {
-        
+
         if (strpos($object_property_key, '_requested_day_') !== false) {
-            
-            if ($date_counter > 0) {
-            
-                $new_date = strtotime($form_values->absence_request_date_from);
-                $new_date = $new_date + (60 * 60 * 24 * $date_counter);
-                $new_date = date('Y-m-d', $new_date);
-                
-                $absentDateDurations[$object_property_key] = array('date' => $new_date . " 00:00:00", 'duration' => $object_property_value, 'approval' => '1');
-            
-            }
-            else {
-                
-                $absentDateDurations[$object_property_key] = array('date' => $form_values->absence_request_date_from . " 00:00:00", 'duration' => $object_property_value, 'approval' => '1');
-                
-            }
-            
-            $date_counter++;
+          $absentDateDurations[$object_property_key] = array('date' => $fromDate->format('Y-m-d 00:00:00'), 'duration' => $object_property_value, 'approval' => '1');
+          $fromDate->modify('+1 day');
         }
-        
+
     }
-    
+
     foreach ($absentDateDurations as $object_key => $duration) {
         $activityLeavesParam['activity_date_time'] = $duration['date'];
         $activityLeavesParam['duration'] = $duration['duration'];
         $activityLeavesParam['status_id'] = $duration['approval'];
-        
+
         civicrm_api3('Activity', 'create', $activityLeavesParam);
 
     }
-    
+
     // @TODO -> This should provide success / failure value (email message should be based on this success or failure) -> If failure don't create activity
-        
+
 }


### PR DESCRIPTION
## Overview

It was not possible to request leave if one of the request dates were the start or the end of the Daylight Saving Time in the timezone of the current user, set in Drupal. Whenever someone tried that, the system would return a server error and the list of dates in the Leave Request modal wouldn't be updated.

The reason was that in some places in the SSP code was required to add 1 day to a date. This was implemented with a logic that would convert the date to a unix timestamp and then add 86400 seconds to it (the number of seconds in a day), which works fine for days with 24 hours. However, in countries/timezones with Daylight Saving Time, we can have days with 25 or 23 hours, that will make the code fail.

In 2017, for example, the UK Daylight Saving Time ends on 29th Oct. This day has 25h long. If PHP's timezone is set to `Europe/London`, and we add 86400 to it, the resulting date will still be 2017-10-29, as it can be seen here: https://3v4l.org/i5HEB

## Before

The logic to add 1 day to dates didn't work for days that were not exactly 24h long. This made it impossible to request leave containing either the start or the end date of Daylight Saving Time period.

## After

It's now possible to request leave containing the start or the end date of a Daylight Saving Time period. The logic to add 1 day to dates was improved. Instead of doing the math manually, we now use a `DateTime` object and it's `modify` method to add 1 day to it. The DateTime object is aware of timezones and Daylight Saving Times and can do the proper adjustments automatically. 

## Comments
Whenever you don't use a DateTime object for date calculations, you cause a rupture in space time's fabric. If done continuously, the effects could be catastrophic. 

---

- [ ] Tests Pass
We don't have test coverage for this Part of the system. 