### PR TITLE
PCHR-2327: Divergence with civicrm resources in civi hr v1.6 and civi hr v1.7

### DIFF
--- a/civicrm_resources/civicrm_resources.module
+++ b/civicrm_resources/civicrm_resources.module
@@ -55,7 +55,7 @@ function civicrm_resources_add_resources($extention_path, $req_files = []) {
     drupal_add_css(ltrim(str_replace(DRUPAL_ROOT, '', $css_file), '/'));
   }
   foreach ($js_list as $key => $js_file) {
-    drupal_add_js(ltrim(str_replace(DRUPAL_ROOT, '', $js_file), '/'));
+    drupal_add_js(ltrim(str_replace(DRUPAL_ROOT, '', $js_file), '/'),  array('scope' => 'footer'));
   }
 }
 

--- a/civicrm_resources/civicrm_resources.module
+++ b/civicrm_resources/civicrm_resources.module
@@ -55,7 +55,7 @@ function civicrm_resources_add_resources($extention_path, $req_files = []) {
     drupal_add_css(ltrim(str_replace(DRUPAL_ROOT, '', $css_file), '/'));
   }
   foreach ($js_list as $key => $js_file) {
-    drupal_add_js(ltrim(str_replace(DRUPAL_ROOT, '', $js_file), '/'),  array('scope' => 'footer'));
+    drupal_add_js(ltrim(str_replace(DRUPAL_ROOT, '', $js_file), '/'),  ['scope' => 'footer']);
   }
 }
 

--- a/civicrm_resources/civicrm_resources.module
+++ b/civicrm_resources/civicrm_resources.module
@@ -55,7 +55,7 @@ function civicrm_resources_add_resources($extention_path, $req_files = []) {
     drupal_add_css(ltrim(str_replace(DRUPAL_ROOT, '', $css_file), '/'));
   }
   foreach ($js_list as $key => $js_file) {
-    drupal_add_js(ltrim(str_replace(DRUPAL_ROOT, '', $js_file), '/'),  ['scope' => 'footer']);
+    drupal_add_js(ltrim(str_replace(DRUPAL_ROOT, '', $js_file), '/'),  array('scope' => 'footer'));
   }
 }
 

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -135,9 +135,10 @@ function _setup_modals() {
  * @param string $resources the name of the script file (extension included)
  * @param string $extension
  * @param string $page
- * @param array $jsOptions
+ * @param string $scope
  */
-function _add_script_to_page($resources, $extension = NULL, $page = NULL, $jsOptions = ['scope' => 'footer']) {
+function _add_script_to_page($resources, $extension = NULL, $page = NULL, $scope = 'footer') {
+  $options = ['type' => 'file', 'scope' => $scope];
 
   if (!is_null($page) && arg(0) != $page) {
     return;
@@ -149,11 +150,11 @@ function _add_script_to_page($resources, $extension = NULL, $page = NULL, $jsOpt
   else {
     if (is_array($resources)) {
       foreach ($resources as $value) {
-        drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . $value, $jsOptions);
+        drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . $value, $options);
       }
     }
     else {
-      drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . $resources, $jsOptions);
+      drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . $resources, $options);
     }
   }
 }
@@ -603,8 +604,7 @@ function civihr_employee_portal_init() {
 
     _add_script_to_page(['reqangular.min.js'], 'org.civicrm.reqangular', 'dashboard');
     _add_script_to_page(['reqangular.min.js'], 'org.civicrm.reqangular', 'tasks-and-documents');
-
-    _add_script_to_page(['/js/tasks.js'], NULL, 'tasks-and-documents', ['scope' => 'header']);
+    _add_script_to_page(['/js/tasks.js'], NULL, 'tasks-and-documents', 'header');
     _add_script_to_page(['/js/ta-documents-app.js'], NULL, 'tasks-and-documents');
     _add_script_to_page(['tasks-assignments.min.js'], 'uk.co.compucorp.civicrm.tasksassignments', 'tasks-and-documents');
 

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -135,8 +135,9 @@ function _setup_modals() {
  * @param string $resources the name of the script file (extension included)
  * @param string $extension
  * @param string $page
+ * @param array $jsOptions
  */
-function _add_script_to_page($resources, $extension = NULL, $page = NULL) {
+function _add_script_to_page($resources, $extension = NULL, $page = NULL, $jsOptions = ['scope' => 'footer']) {
 
   if (!is_null($page) && arg(0) != $page) {
     return;
@@ -148,11 +149,11 @@ function _add_script_to_page($resources, $extension = NULL, $page = NULL) {
   else {
     if (is_array($resources)) {
       foreach ($resources as $value) {
-        drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . $value, 'file');
+        drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . $value, $jsOptions);
       }
     }
     else {
-      drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . $resources, 'file');
+      drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . $resources, $jsOptions);
     }
   }
 }
@@ -602,7 +603,10 @@ function civihr_employee_portal_init() {
 
     _add_script_to_page(['reqangular.min.js'], 'org.civicrm.reqangular', 'dashboard');
     _add_script_to_page(['reqangular.min.js'], 'org.civicrm.reqangular', 'tasks-and-documents');
-    _add_script_to_page(['/js/tasks.js', '/js/ta-documents-app.js'], NULL, 'tasks-and-documents');
+
+    _add_script_to_page(['/js/tasks.js'], NULL, 'tasks-and-documents', ['scope' => 'header']);
+    _add_script_to_page(['/js/ta-documents-app.js'], NULL, 'tasks-and-documents');
+    _add_script_to_page(['tasks-assignments.min.js'], 'uk.co.compucorp.civicrm.tasksassignments', 'tasks-and-documents');
 
     _rebuild_view('absence_list');
     _rebuild_view('length_of_service');

--- a/civihr_employee_portal/views/templates/views-view-table--Documents--block.tpl.php
+++ b/civihr_employee_portal/views/templates/views-view-table--Documents--block.tpl.php
@@ -172,5 +172,3 @@ endforeach;
 
   }(CRM.$));
 </script>
-
-<script src="<?php echo getModuleUrl('uk.co.compucorp.civicrm.tasksassignments').'js/dist/tasks-assignments.min.js';?>"></script>


### PR DESCRIPTION
## Overview
This PR adds the fix applied in [this link](https://github.com/compucorp/civihr-employee-portal/commit/c16bbca577c72486c645f60fdff0d0588b38e2e5) by modifying the `civicrm_reource.module` file in 1.6 site. And use it to load the resources as required in appropriate section in in `civihr_employee_portal.module`.

As a result the `angular is not defined error` is also fixed in 1.6 site.

## Before
- The resources were not loaded correctly in right section causing the reqangular.min.js to load after the `ta-documents-app.js` in SSP causing angular is not defined console error as a result yoti login is also not working.
![image-2017-09-28-14-55-54-980](https://user-images.githubusercontent.com/6307362/31074866-682e2e4a-a792-11e7-8382-329ad6c43e35.png)

## After
- `angular is not defined` error is not gone and SSP `/tasks-documents` has not console error.
<img width="1303" alt="screen shot 2017-10-02 at 3 42 27 pm" src="https://user-images.githubusercontent.com/6307362/31074938-b8326a28-a792-11e7-9a11-e11b6c110e92.png">

- Document modal loads correctly in ssp, without error.
![10](https://user-images.githubusercontent.com/6307362/31075697-8fbdc340-a796-11e7-984e-28b0ddb25fc4.gif)

-  `/welcome-page` loads with no error. After yoti login should also work as expected. Following error is because i am truing to access yoti api from my local site.
![11](https://user-images.githubusercontent.com/6307362/31075763-d595a608-a796-11e7-9d27-b54cecabab2d.gif)


## Technical Details
1. Modified `civicrm_resource.module` file for load the reosurces in footer section in file "civicrm_resources/civicrm_resources.module".
```php
drupal_add_js(ltrim(str_replace(DRUPAL_ROOT, '', $js_file), '/'),  ['scope' => 'footer']);
```

2. Modify `_add_script_to_page()` to receive `jsOptions` param which will be used to load the resources in specific sections (`header`, `body` and `footer`)
```php
function _add_script_to_page($resources, $extension = NULL, $page = NULL, $scope = 'footer') {
    $options = ['type' => 'file', 'scope' => $scope];
    ...
    else {
       if (is_array($resources)) {
          foreach ($resources as $value) {
             drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . $value, $options);
          }
       }
       else {
          drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . $resources, $options);
       }
    }
}
```

3. Load the resources in order in SSP in file "civihr_employee_portal/civihr_employee_portal.module"
```php
_add_script_to_page(['/js/tasks.js'], NULL, 'tasks-and-documents', 'header');
 _add_script_to_page(['/js/ta-documents-app.js'], NULL, 'tasks-and-documents');
_add_script_to_page(['tasks-assignments.min.js'], 'uk.co.compucorp.civicrm.tasksassignments', 'tasks-and-documents');
```

## Comments
The same fixes are added in 1.7-wip branch and tested, and it fixes the reported issue for 1.7 site as well.
