### PR TITLE
PCHR-2755: Hide the Appraisals menu

### DIFF
--- a/civihr_employee_portal/views/views_export/views_appraisals.inc
+++ b/civihr_employee_portal/views/views_export/views_appraisals.inc
@@ -8,7 +8,7 @@ $view->base_table = 'appraisal';
 $view->human_name = 'Appraisals';
 $view->core = 7;
 $view->api_version = '3.0';
-$view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
+$view->disabled = TRUE; /* Edit this to true to make a default view disabled initially */
 
 /* Display: Master */
 $handler = $view->new_display('default', 'Master', 'default');


### PR DESCRIPTION
## Overview

When we create a new site, using buildkit, there's an Appraisal item available in the SSP menu. The appraisal extension is not complete and hasn't been released yet, so the menu should be hidden.

## Before

The Appraisals item is visible in the SSP menu:

![captura de tela de 2017-10-10 13-57-05](https://user-images.githubusercontent.com/388373/31399523-fe09e626-adc2-11e7-8d6f-ec46760478be.png)


## After

The Appraisals item isn't visible in the SSP menu anymore:

![captura de tela de 2017-10-10 13-59-32](https://user-images.githubusercontent.com/388373/31399608-469757b6-adc3-11e7-9f4e-6bc37e4e14ef.png)

---

- [ ] Tests Pass
No tests are affected by this