### PR TITLE
PCHR-2783: Keeping Images in Sync

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.install
+++ b/civihr_employee_portal/civihr_employee_portal.install
@@ -196,6 +196,34 @@ function civihr_employee_portal_update_7009() {
 }
 
 /**
+ * Update My Details webform upload size
+ */
+function civihr_employee_portal_update_7009() {
+  $nodes = node_load_multiple(NULL, ["title" => "My details - edit"]);
+
+  if (count($nodes) !== 1) {
+    return;
+  }
+
+  $node = current($nodes);
+
+  if (!isset($node->webform['components'])) {
+    return;
+  }
+
+  $components = $node->webform['components'];
+  $imageFieldName = 'Upload Image';
+
+  foreach ($components as $component) {
+    if ($imageFieldName == $component['name']) {
+      $component['extra']['filtering']['size'] = '10MB';
+      webform_component_update($component);
+      break;
+    }
+  }
+}
+
+/**
  * Function to determine whether menu link exists or not.
  *
  * @param string

--- a/civihr_employee_portal/civihr_employee_portal.install
+++ b/civihr_employee_portal/civihr_employee_portal.install
@@ -205,13 +205,13 @@ function civihr_employee_portal_update_7009() {
     return;
   }
 
-  $node = current($nodes);
+  $myDetailsWebform = current($nodes);
 
-  if (!isset($node->webform['components'])) {
+  if (!isset($myDetailsWebform->webform['components'])) {
     return;
   }
 
-  $components = $node->webform['components'];
+  $components = $myDetailsWebform->webform['components'];
   $imageFieldName = 'Upload Image';
 
   foreach ($components as $component) {

--- a/civihr_employee_portal/civihr_employee_portal.install
+++ b/civihr_employee_portal/civihr_employee_portal.install
@@ -198,7 +198,7 @@ function civihr_employee_portal_update_7009() {
 /**
  * Update My Details webform upload size
  */
-function civihr_employee_portal_update_7009() {
+function civihr_employee_portal_update_7010() {
   $nodes = node_load_multiple(NULL, ["title" => "My details - edit"]);
 
   if (count($nodes) !== 1) {

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -6178,3 +6178,18 @@ function get_civihr_version() {
 
   return $civihrVersion;
 }
+
+/**
+ * Implements hook_civicrm_postProcess().
+ *
+ * @param string $formName
+ * @param CRM_Core_Form $form
+ */
+function civihr_employee_portal_civicrm_postProcess($formName, &$form) {
+  if ($formName === CRM_Contact_Form_Contact::class) {
+    // user data was updated so clear cache
+    $contactID = CRM_Core_Session::getLoggedInContactID();
+    $contact_value = 'civihr_contact_data_' . $contactID;
+    cache_clear_all($contact_value, 'cache');
+  }
+}

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -6180,18 +6180,6 @@ function get_civihr_version() {
 }
 
 /**
- * Implements hook_civicrm_postProcess().
- *
- * @param string $formName
- * @param CRM_Core_Form $form
- */
-function civihr_employee_portal_civicrm_postProcess($formName, &$form) {
-  if ($formName === CRM_Contact_Form_Contact::class) {
-    _civihr_employee_portal_clear_contact_cache($form->getContactID());
-  }
-}
-
-/**
  * Clears the basic cached contact data
  * @see get_civihr_contact_data
  *

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -6187,9 +6187,17 @@ function get_civihr_version() {
  */
 function civihr_employee_portal_civicrm_postProcess($formName, &$form) {
   if ($formName === CRM_Contact_Form_Contact::class) {
-    // user data was updated so clear cache
-    $contactID = CRM_Core_Session::getLoggedInContactID();
-    $contact_value = 'civihr_contact_data_' . $contactID;
-    cache_clear_all($contact_value, 'cache');
+    _civihr_employee_portal_clear_contact_cache($form->getContactID());
   }
+}
+
+/**
+ * Clears the basic cached contact data
+ * @see get_civihr_contact_data
+ *
+ * @param int $contactID
+ */
+function _civihr_employee_portal_clear_contact_cache($contactID) {
+  $cacheKey = 'civihr_contact_data_' . $contactID;
+  cache_clear_all($cacheKey, 'cache');
 }

--- a/civihr_employee_portal/features/node_export_files/my_details.export
+++ b/civihr_employee_portal/features/node_export_files/my_details.export
@@ -243,7 +243,7 @@ array(
                   'png',
                 ),
                 'addextensions' => '',
-                'size' => '2 MB',
+                'size' => '10 MB',
               ),
               'scheme' => 'public',
               'directory' => '',

--- a/civihr_employee_portal/src/Forms/ContactForm.php
+++ b/civihr_employee_portal/src/Forms/ContactForm.php
@@ -13,6 +13,8 @@ class ContactForm {
    */
   public static function postProcess($form) {
     self::resizeImage($form);
+    // If details are updated clear contact cache
+    _civihr_employee_portal_clear_contact_cache($form->getContactID());
   }
 
   /**
@@ -29,7 +31,6 @@ class ContactForm {
     }
 
     $imagePath = ContactImagePathfinder::getPath($contactID);
-
     ImageResizer::resizeForProfile($imagePath);
   }
 }


### PR DESCRIPTION
## Overview

Keeping the Drupal user image in sync with the CiviCRM contact image is a pain. To lessen that pain we will remove the Drupal image from the Drupal user edit page and rely only on the CiviCRM contact image.

## Before

- The Drupal user edit page had an option to upload an image, which would not be reflected in CiviCRM.
- The maximum upload size for the user image in the "Edit My Details" webform was 2MB.
- When you updated a contact image on the CiviCRM profile page it was not reflected in the SSP dashboard

## After

- The Drupal user edit page does not have an option to upload an image (achieved with drush command `drush vset --format=integer user_pictures 0`)
- The maximum upload size for the user image in the "Edit My Details" webform is 10MB.
- When you updated a contact image on the CiviCRM profile page the contact data cache is cleared and the new image is shown on the SSP dashboard.

---

- [x] Tests Pass
