### PR TITLE
PCHR-2621: Remove hook_preprocess_page implementation

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5504,43 +5504,6 @@ function getCalendarButtonMarkup($idxKey) {
 }
 
 /**
- * Implement hook_preprocess_page
- * @param $vars
- */
-function civihr_employee_portal_preprocess_page(&$vars) {
-    global $user;
-    global $base_url;
-
-    $display_name = t('Anonymus');
-    $edit_account_link = '';
-    $logout_link = '';
-    $user_guide_link = l('<i class="fa fa-book"></i>' . t('User guide'), 'http://civihr-documentation.readthedocs.io/en/latest/self-service-portal/login-screen/', array('html' => true, 'attributes' => array('target' => '_blank')));
-    $image_url = $base_url . '/' . drupal_get_path('module', 'civihr_employee_portal') . '/images/profile-default.png';
-
-    if (isset($_SESSION['CiviCRM']) && $user->uid) {
-        $edit_account_link = l('<i class="fa fa-edit"></i>' . t('Edit Account'), 'user/' . $user->uid . '/edit', array('html' => true));
-        $logout_link = l('<i class="fa fa-sign-out"></i>' . t('Log Out'), 'user/logout', array('html' => true));
-
-        // Get the contact data
-        $contact_data = get_civihr_contact_data($_SESSION['CiviCRM']['userID']);
-        if (!empty($contact_data['display_name'])) {
-            $display_name = $contact_data['display_name'];
-        }
-        if (isset($contact_data['image_URL']) && !empty($contact_data['image_URL'])) {
-            $image_url = $contact_data['image_URL'];
-        }
-    }
-
-    // This values will be used in the template by Drupal
-    $vars['user_name'] = $display_name;
-    $vars['image_url'] = $image_url;
-    $vars['edit_account'] = $edit_account_link;
-    $vars['logout_link'] = $logout_link;
-    $vars['user_guide_link'] = $user_guide_link;
-
-}
-
-/**
  * Implements hook_token_info().
  */
 function civihr_employee_portal_token_info() {


### PR DESCRIPTION
All the data and the markup that was used to build the user menu in the top menu of the SSP is now owned by `CRM_HRCore_UserMenuMarkup` (see https://github.com/civicrm/civihr/pull/2236), so we don't need the `civihr_employee_portal_preprocess_page` hook anymore

Related PRs:
* https://github.com/civicrm/civihr/pull/2236
* https://github.com/compucorp/civihr-employee-portal-theme/pull/250