### PR TITLE
PCHR-2628: Assign new permission to root user by default

### DIFF
--- a/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
+++ b/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
@@ -2285,5 +2285,14 @@ function civihr_default_permissions_user_default_permissions() {
     'module' => 'civihr_employee_portal',
   );
 
+  // Exported permission: 'access CiviCRM developer menu and tools'.
+  $permissions['access CiviCRM developer menu and tools'] = array(
+    'name' => 'access CiviCRM developer menu and tools',
+    'roles' => array(
+      'administrator' => 'administrator'
+    ),
+    'module' => 'civicrm',
+  );
+
   return $permissions;
 }

--- a/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.info
+++ b/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.info
@@ -45,6 +45,7 @@ features[features_api][] = api:2
 features[user_permission][] = Administer fancy login
 features[user_permission][] = access AJAX API
 features[user_permission][] = access CiviCRM
+features[user_permission][] = access CiviCRM developer menu and tools
 features[user_permission][] = access CiviReport
 features[user_permission][] = access Contact Dashboard
 features[user_permission][] = access HRJobs


### PR DESCRIPTION
This PR applies the "Access CiviCRM developer menu and tools" permission (see https://github.com/civicrm/civihr/pull/2242) to the administrator role by default, for existing and future sites