### PR TITLE
PCHR-2756: Rename 'Tasks and Documents' to 'Tasks'

### DIFF
--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.pages_default.inc
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.pages_default.inc
@@ -249,7 +249,7 @@ function civihr_employee_portal_features_default_page_manager_pages() {
   $page->api_version = 1;
   $page->name = 'tasks_and_documents';
   $page->task = 'page';
-  $page->admin_title = 'Tasks and Documents';
+  $page->admin_title = 'Tasks';
   $page->admin_description = '';
   $page->path = 'tasks-and-documents';
   $page->access = array(
@@ -269,7 +269,7 @@ function civihr_employee_portal_features_default_page_manager_pages() {
   );
   $page->menu = array(
     'type' => 'normal',
-    'title' => 'Tasks and Documents',
+    'title' => 'Tasks',
     'name' => 'main-menu',
     'weight' => '4',
     'parent' => array(
@@ -329,7 +329,7 @@ function civihr_employee_portal_features_default_page_manager_pages() {
     ),
   );
   $display->cache = array();
-  $display->title = 'Tasks and Documents';
+  $display->title = 'Tasks';
   $display->uuid = '091af8a4-cb6d-45b4-8946-1016cd5fb4d8';
   $display->storage_type = 'page_manager';
   $display->storage_id = 'page_dashboard_panel_context';


### PR DESCRIPTION
## Overview
Simply renames the "Tasks and Documents" page and menu item to "Tasks 

## Before
<img width="500" alt="before" src="https://user-images.githubusercontent.com/6400898/32010599-94ca1694-b9b2-11e7-8b75-041b9b3f7cd2.png">

## After
<img width="800" alt="after" src="https://user-images.githubusercontent.com/6400898/32010614-a09046ce-b9b2-11e7-8583-80f774ad320f.png">
