### PR TITLE
PCHR-2633: Export menu items with fa icons

### DIFF
--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.features.menu_links.inc
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.features.menu_links.inc
@@ -17,9 +17,7 @@ function civihr_employee_portal_features_menu_default_menu_links() {
     'router_path' => 'reports/settings/age_group',
     'link_title' => 'Age groups',
     'options' => array(
-      'attributes' => array(
-        'title' => '',
-      ),
+      'attributes' => array(),
       'identifier' => 'hr-reports-settings_age-groups:reports/settings/age_group/',
     ),
     'module' => 'menu',
@@ -77,9 +75,7 @@ function civihr_employee_portal_features_menu_default_menu_links() {
     'router_path' => 'civicrm',
     'link_title' => 'CiviHR admin',
     'options' => array(
-      'attributes' => array(
-        'title' => '',
-      ),
+      'attributes' => array(),
       'identifier' => 'main-menu_civihr-admin:civicrm',
     ),
     'module' => 'menu',
@@ -97,9 +93,7 @@ function civihr_employee_portal_features_menu_default_menu_links() {
     'router_path' => 'dashboard',
     'link_title' => 'CiviHR SSP',
     'options' => array(
-      'attributes' => array(
-        'title' => '',
-      ),
+      'attributes' => array(),
       'identifier' => 'main-menu_civihr-ssp:dashboard',
     ),
     'module' => 'menu',
@@ -110,6 +104,35 @@ function civihr_employee_portal_features_menu_default_menu_links() {
     'weight' => 0,
     'customized' => 1,
   );
+  // Exported menu link: main-menu_help://civihr-documentation.readthedocs.io/en/latest/self-service-portal/login-screen/.
+  $menu_links['main-menu_help://civihr-documentation.readthedocs.io/en/latest/self-service-portal/login-screen/'] = array(
+    'menu_name' => 'main-menu',
+    'link_path' => '//civihr-documentation.readthedocs.io/en/latest/self-service-portal/login-screen/',
+    'router_path' => '',
+    'link_title' => 'Help',
+    'options' => array(
+      'identifier' => 'main-menu_help://civihr-documentation.readthedocs.io/en/latest/self-service-portal/login-screen/',
+      'attributes' => array(
+        'class' => array(
+          0 => 'fa',
+          1 => 'fa-question-circle',
+        ),
+        'target' => '_blank',
+      ),
+      'item_attributes' => array(
+        'id' => '',
+        'class' => '',
+        'style' => '',
+      ),
+    ),
+    'module' => 'menu',
+    'hidden' => 0,
+    'external' => 1,
+    'has_children' => 0,
+    'expanded' => 0,
+    'weight' => 9,
+    'customized' => 1,
+  );
   // Exported menu link: main-menu_home:dashboard.
   $menu_links['main-menu_home:dashboard'] = array(
     'menu_name' => 'main-menu',
@@ -117,9 +140,7 @@ function civihr_employee_portal_features_menu_default_menu_links() {
     'router_path' => 'dashboard',
     'link_title' => 'Home',
     'options' => array(
-      'attributes' => array(
-        'title' => '',
-      ),
+      'attributes' => array(),
       'identifier' => 'main-menu_home:dashboard',
     ),
     'module' => 'menu',
@@ -130,6 +151,62 @@ function civihr_employee_portal_features_menu_default_menu_links() {
     'weight' => 0,
     'customized' => 1,
   );
+  // Exported menu link: main-menu_hr-resources:hr-resources.
+  $menu_links['main-menu_hr-resources:hr-resources'] = array(
+    'menu_name' => 'main-menu',
+    'link_path' => 'hr-resources',
+    'router_path' => 'hr-resources',
+    'link_title' => 'HR Resources',
+    'options' => array(
+      'attributes' => array(
+        'class' => array(
+          0 => 'fa',
+          1 => 'fa-file-text-o',
+        ),
+      ),
+      'item_attributes' => array(
+        'id' => '',
+        'class' => '',
+        'style' => '',
+      ),
+      'identifier' => 'main-menu_hr-resources:hr-resources',
+    ),
+    'module' => 'system',
+    'hidden' => 0,
+    'external' => 0,
+    'has_children' => 0,
+    'expanded' => 0,
+    'weight' => 8,
+    'customized' => 1,
+  );
+  // Exported menu link: main-menu_manager-leave:manager-leave.
+  $menu_links['main-menu_manager-leave:manager-leave'] = array(
+    'menu_name' => 'main-menu',
+    'link_path' => 'manager-leave',
+    'router_path' => 'manager-leave',
+    'link_title' => 'Manager Leave',
+    'options' => array(
+      'attributes' => array(
+        'class' => array(
+          0 => 'fa',
+          1 => 'fa-suitcase',
+        ),
+      ),
+      'item_attributes' => array(
+        'id' => '',
+        'class' => '',
+        'style' => '',
+      ),
+      'identifier' => 'main-menu_manager-leave:manager-leave',
+    ),
+    'module' => 'system',
+    'hidden' => 0,
+    'external' => 0,
+    'has_children' => 0,
+    'expanded' => 0,
+    'weight' => 6,
+    'customized' => 1,
+  );
   // Exported menu link: main-menu_my-details:hr-details.
   $menu_links['main-menu_my-details:hr-details'] = array(
     'menu_name' => 'main-menu',
@@ -138,6 +215,17 @@ function civihr_employee_portal_features_menu_default_menu_links() {
     'link_title' => 'My Details',
     'options' => array(
       'identifier' => 'main-menu_my-details:hr-details',
+      'attributes' => array(
+        'class' => array(
+          0 => 'fa',
+          1 => 'fa-user',
+        ),
+      ),
+      'item_attributes' => array(
+        'id' => '',
+        'class' => '',
+        'style' => '',
+      ),
     ),
     'module' => 'system',
     'hidden' => 0,
@@ -147,25 +235,32 @@ function civihr_employee_portal_features_menu_default_menu_links() {
     'weight' => 2,
     'customized' => 1,
   );
-  // Exported menu link: main-menu_help://civihr-documentation.readthedocs.io/en/latest/self-service-portal/login-screen/.
-  $menu_links['main-menu_help://civihr-documentation.readthedocs.io/en/latest/self-service-portal/login-screen/'] = array(
+  // Exported menu link: main-menu_my-leave:my-leave.
+  $menu_links['main-menu_my-leave:my-leave'] = array(
     'menu_name' => 'main-menu',
-    'link_path' => '//civihr-documentation.readthedocs.io/en/latest/self-service-portal/login-screen/',
-    'router_path' => '',
-    'link_title' => 'Help',
+    'link_path' => 'my-leave',
+    'router_path' => 'my-leave',
+    'link_title' => 'My Leave',
     'options' => array(
       'attributes' => array(
-        'title' => '',
-        'target' => '_blank',
+        'class' => array(
+          0 => 'fa',
+          1 => 'fa-calendar',
+        ),
       ),
-      'identifier' => 'main-menu_help://civihr-documentation.readthedocs.io/en/latest/self-service-portal/login-screen/',
+      'item_attributes' => array(
+        'id' => '',
+        'class' => '',
+        'style' => '',
+      ),
+      'identifier' => 'main-menu_my-leave:my-leave',
     ),
-    'module' => 'menu',
+    'module' => 'system',
     'hidden' => 0,
-    'external' => 1,
+    'external' => 0,
     'has_children' => 0,
     'expanded' => 0,
-    'weight' => 9,
+    'weight' => 5,
     'customized' => 1,
   );
   // Exported menu link: main-menu_reports:reports.
@@ -175,10 +270,18 @@ function civihr_employee_portal_features_menu_default_menu_links() {
     'router_path' => 'reports',
     'link_title' => 'Reports',
     'options' => array(
-      'attributes' => array(
-        'title' => '',
-      ),
       'identifier' => 'main-menu_reports:reports',
+      'attributes' => array(
+        'class' => array(
+          0 => 'fa',
+          1 => 'fa-table',
+        ),
+      ),
+      'item_attributes' => array(
+        'id' => '',
+        'class' => '',
+        'style' => '',
+      ),
     ),
     'module' => 'system',
     'hidden' => 0,
@@ -188,17 +291,108 @@ function civihr_employee_portal_features_menu_default_menu_links() {
     'weight' => 10,
     'customized' => 1,
   );
+  // Exported menu link: main-menu_staff-directory:staff-directory.
+  $menu_links['main-menu_staff-directory:staff-directory'] = array(
+    'menu_name' => 'main-menu',
+    'link_path' => 'staff-directory',
+    'router_path' => 'staff-directory',
+    'link_title' => 'Staff Directory',
+    'options' => array(
+      'attributes' => array(
+        'class' => array(
+          0 => 'fa',
+          1 => 'fa-search',
+        ),
+      ),
+      'item_attributes' => array(
+        'id' => '',
+        'class' => '',
+        'style' => '',
+      ),
+      'identifier' => 'main-menu_staff-directory:staff-directory',
+    ),
+    'module' => 'system',
+    'hidden' => 0,
+    'external' => 0,
+    'has_children' => 0,
+    'expanded' => 0,
+    'weight' => 3,
+    'customized' => 1,
+  );
+  // Exported menu link: main-menu_tasks:tasks-and-documents.
+  $menu_links['main-menu_tasks:tasks-and-documents'] = array(
+    'menu_name' => 'main-menu',
+    'link_path' => 'tasks-and-documents',
+    'router_path' => 'tasks-and-documents',
+    'link_title' => 'Tasks',
+    'options' => array(
+      'attributes' => array(
+        'class' => array(
+          0 => 'fa',
+          1 => 'fa-list-ul',
+        ),
+      ),
+      'item_attributes' => array(
+        'id' => '',
+        'class' => '',
+        'style' => '',
+      ),
+      'identifier' => 'main-menu_tasks:tasks-and-documents',
+    ),
+    'module' => 'system',
+    'hidden' => 0,
+    'external' => 0,
+    'has_children' => 0,
+    'expanded' => 0,
+    'weight' => 4,
+    'customized' => 1,
+  );
+  // Exported menu link: main-menu_vacancies:hr-vacancies.
+  $menu_links['main-menu_vacancies:hr-vacancies'] = array(
+    'menu_name' => 'main-menu',
+    'link_path' => 'hr-vacancies',
+    'router_path' => 'hr-vacancies',
+    'link_title' => 'Vacancies',
+    'options' => array(
+      'attributes' => array(
+        'class' => array(
+          0 => 'fa',
+          1 => 'fa-user-plus',
+        ),
+      ),
+      'item_attributes' => array(
+        'id' => '',
+        'class' => '',
+        'style' => '',
+      ),
+      'identifier' => 'main-menu_vacancies:hr-vacancies',
+    ),
+    'module' => 'system',
+    'hidden' => 0,
+    'external' => 0,
+    'has_children' => 0,
+    'expanded' => 0,
+    'weight' => 7,
+    'customized' => 1,
+  );
 
   // Translatables
   // Included for use with string extractors like potx.
   t('Age groups');
   t('CiviHR SSP');
   t('CiviHR admin');
+  t('HR Resources');
+  t('Help');
   t('Home');
+  t('Manager Leave');
   t('My Details');
+  t('My Leave');
   t('Report 1: People');
   t('Report 2: Leave and Absence');
   t('Reports');
+  t('Staff Directory');
+  t('Tasks');
+  t('Vacancies');
 
   return $menu_links;
 }


### PR DESCRIPTION
This PR simply exports the menu items of the SSP main menu with the new attributes that define the FowAwesome icons (see [here](https://github.com/compucorp/civihr-employee-portal-theme/pull/256)) that they get assigned by default

I noticed that a lot of menu items were not included in the feature still, so I've added them