### PR TITLE
PCHR-2634: Update CiviHR Admin menu link

### DIFF
--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.features.menu_links.inc
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.features.menu_links.inc
@@ -91,24 +91,6 @@ function civihr_employee_portal_features_menu_default_menu_links() {
     'weight' => -1,
     'customized' => 1,
   );
-  // Exported menu link: main-menu_civihr-ssp:dashboard.
-  $menu_links['main-menu_civihr-ssp:dashboard'] = array(
-    'menu_name' => 'main-menu',
-    'link_path' => 'dashboard',
-    'router_path' => 'dashboard',
-    'link_title' => 'CiviHR SSP',
-    'options' => array(
-      'attributes' => array(),
-      'identifier' => 'main-menu_civihr-ssp:dashboard',
-    ),
-    'module' => 'menu',
-    'hidden' => 0,
-    'external' => 0,
-    'has_children' => 0,
-    'expanded' => 0,
-    'weight' => 0,
-    'customized' => 1,
-  );
   // Exported menu link: main-menu_help://civihr-documentation.readthedocs.io/en/latest/self-service-portal/login-screen/.
   $menu_links['main-menu_help://civihr-documentation.readthedocs.io/en/latest/self-service-portal/login-screen/'] = array(
     'menu_name' => 'main-menu',
@@ -145,7 +127,17 @@ function civihr_employee_portal_features_menu_default_menu_links() {
     'router_path' => 'dashboard',
     'link_title' => 'Home',
     'options' => array(
-      'attributes' => array(),
+      'attributes' => array(
+        'class' => array(
+          0 => 'fa',
+          1 => 'fa-home',
+        ),
+      ),
+      'item_attributes' => array(
+        'id' => '',
+        'class' => '',
+        'style' => '',
+      ),
       'identifier' => 'main-menu_home:dashboard',
     ),
     'module' => 'menu',
@@ -384,7 +376,6 @@ function civihr_employee_portal_features_menu_default_menu_links() {
   // Translatables
   // Included for use with string extractors like potx.
   t('Age groups');
-  t('CiviHR SSP');
   t('HR admin');
   t('HR Resources');
   t('Help');

--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.features.menu_links.inc
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.features.menu_links.inc
@@ -73,9 +73,14 @@ function civihr_employee_portal_features_menu_default_menu_links() {
     'menu_name' => 'main-menu',
     'link_path' => 'civicrm',
     'router_path' => 'civicrm',
-    'link_title' => 'CiviHR admin',
+    'link_title' => 'HR admin',
     'options' => array(
-      'attributes' => array(),
+      'attributes' => array(
+        'class' => array(
+          0 => 'fa',
+          1 => 'fa-tachometer',
+        ),
+      ),
       'identifier' => 'main-menu_civihr-admin:civicrm',
     ),
     'module' => 'menu',
@@ -380,7 +385,7 @@ function civihr_employee_portal_features_menu_default_menu_links() {
   // Included for use with string extractors like potx.
   t('Age groups');
   t('CiviHR SSP');
-  t('CiviHR admin');
+  t('HR admin');
   t('HR Resources');
   t('Help');
   t('Home');


### PR DESCRIPTION
## Overview
This PR amends the "CiviHR admin" menu item by changing the label and assigning an icon to it.
It also adds an icon to the "Home" menu item, and removes the "CiviHR SSP" one as it was just a clone of "Home"

_(Related PR: https://github.com/compucorp/civihr-employee-portal-theme/pull/258)_

## Before
<img width="200" alt="admin-before" src="https://user-images.githubusercontent.com/6400898/32166325-c7dbf974-bd65-11e7-8676-334bdcf31f66.png">
<img width="350" alt="home-before" src="https://user-images.githubusercontent.com/6400898/32166327-c7fa2b92-bd65-11e7-94ee-5e638655e91e.png">


## After
<img width="200" alt="admin-after" src="https://user-images.githubusercontent.com/6400898/32166339-cefc92ea-bd65-11e7-8e5a-fe98c58fd946.png">
<img width="350" alt="home-after" src="https://user-images.githubusercontent.com/6400898/32166340-cf18e95e-bd65-11e7-88d9-40045c636db2.png">