### PR TITLE
PCHR-2848: Updates to "My Details" Block

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.info
+++ b/civihr_employee_portal/civihr_employee_portal.info
@@ -43,6 +43,7 @@ files[] = views/includes/civihr_employee_portal_argument_date_range.inc
 files[] = views/includes/civihr_employee_portal_argument_contact_id.inc
 files[] = views/includes/civihr_employee_portal_handler_email.inc
 files[] = views/includes/civihr_employee_portal_handler_age_group.inc
+files[] = views/includes/civihr_employee_portal_handler_aggregated_address.inc
 files[] = views/includes/civihr_employee_portal_argument_age_group.inc
 files[] = views/includes/civihr_employee_portal_handler_absence_duration.inc
 files[] = views/includes/civihr_employee_portal_handler_activity_type.inc

--- a/civihr_employee_portal/src/Blocks/MyDetailsData.php
+++ b/civihr_employee_portal/src/Blocks/MyDetailsData.php
@@ -14,29 +14,13 @@ class MyDetailsData {
 
         }
 
-        // @TODO -> show different view with all the data available
-        // If we are on the HR details full list page, show different view with all the data
-        if (isset($_GET['q']) && $_GET['q'] == 'hr-details') {
+        // Get the contact details view
+        $contact_details = views_embed_view('my_details_block', 'my_details_block');
 
-            // Get the contact details view
-            $contact_details = views_embed_view('my_details_block', 'my_details_block_full');
+        // Get the address details view
+        $address_data = views_embed_view('my_details_block', 'my_address_block');
+        $address_data_title = t('Contact Information');
 
-            // Get the emergency contacts block (not the address data)
-            $address_data = views_embed_view('my_details_block', 'my_details_emergency_contact');
-            $address_data_title = t('Emergency Contact');
-
-        }
-        else {
-
-            // Get the contact details view
-            $contact_details = views_embed_view('my_details_block', 'my_details_block');
-
-            // Get the address details view
-            $address_data = views_embed_view('my_details_block', 'my_address_block');
-            $address_data_title = t('Contact Information');
-
-        }
-        
         // Output the themed details block
         return theme('civihr_employee_portal_my_details_block', 
             array(

--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -35,6 +35,14 @@ function civihr_employee_portal_views_data_alter(&$data) {
     'sort' => array('handler' => 'views_handler_sort'),
   );
 
+  $data['civicrm_contact']['aggregated_address'] = [
+    'title' => t('Aggregated Contact Address'),
+    'help' => t('Displays aggregated address for the contact'),
+    'field' => [
+      'handler' => 'civihr_employee_portal_handler_aggregated_address',
+    ],
+  ];
+
   /**
    * Custom field handler which will create age group based on the contact birth date
    */

--- a/civihr_employee_portal/views/includes/civihr_employee_portal_handler_aggregated_address.inc
+++ b/civihr_employee_portal/views/includes/civihr_employee_portal_handler_aggregated_address.inc
@@ -60,13 +60,15 @@ class civihr_employee_portal_handler_aggregated_address extends views_handler_fi
   }
 
   /**
+   * Returns the HTML for the address as it will appear in the view.
+   *
    * @param array $address
    *   The address data
    * @return string
    *   The formatted address
    */
   private function formatAddress($address) {
-    $format = '%s<br/>%s<br/>%s %s<br/>%s<br />%s';
+    $format = '%s<br/>%s<br/>%s %s<br/>%s<br/>%s';
 
     return sprintf(
       $format,

--- a/civihr_employee_portal/views/includes/civihr_employee_portal_handler_aggregated_address.inc
+++ b/civihr_employee_portal/views/includes/civihr_employee_portal_handler_aggregated_address.inc
@@ -1,0 +1,81 @@
+<?php
+
+use CRM_Utils_Array as ArrayHelper;
+
+/**
+ * Handles aggregation of a contacts different address fields
+ */
+class civihr_employee_portal_handler_aggregated_address extends views_handler_field {
+
+  /**
+   * @inheritdoc
+   */
+  public function render($values) {
+    $contactID = isset($values->id) ? $values->id : NULL;
+
+    if (!$contactID) {
+      return '';
+    }
+
+    $address = $this->getAddress($contactID);
+
+    if (!$address) {
+      return '';
+    }
+
+    return $this->formatAddress($address);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function query() {
+    // override default behaviour as this handler is not tied to a single field
+  }
+
+  /**
+   * Gets the primary address for a contact ID
+   *
+   * @param int $contactID
+   * @return array|null
+   */
+  private function getAddress($contactID) {
+    $return = [
+      'street_address',
+      'supplemental_address_1',
+      'city',
+      'state_province_id.name',
+      'postal_code',
+      'country_id.name',
+    ];
+
+    $params = ['is_primary' => 1, 'contact_id' => $contactID, 'return' => $return];
+    $address = civicrm_api3('Address', 'get', $params);
+
+    if ($address['count'] != 1) {
+      return NULL;
+    }
+
+    return array_shift($address['values']);
+  }
+
+  /**
+   * @param array $address
+   *   The address data
+   * @return string
+   *   The formatted address
+   */
+  private function formatAddress($address) {
+    $format = '%s<br/>%s<br/>%s %s<br/>%s<br />%s';
+
+    return sprintf(
+      $format,
+      ArrayHelper::value('street_address', $address),
+      ArrayHelper::value('supplemental_address_1', $address),
+      ArrayHelper::value('city', $address),
+      ArrayHelper::value('state_province_id.name', $address),
+      ArrayHelper::value('postal_code', $address),
+      ArrayHelper::value('country_id.name', $address)
+    );
+  }
+}

--- a/civihr_employee_portal/views/views_export/views_my_details_block.inc
+++ b/civihr_employee_portal/views/views_export/views_my_details_block.inc
@@ -135,6 +135,7 @@ $handler->display->display_options['fields']['work_email']['label'] = 'Work E-ma
 $handler->display->display_options['fields']['birth_date']['id'] = 'birth_date';
 $handler->display->display_options['fields']['birth_date']['table'] = 'civicrm_contact';
 $handler->display->display_options['fields']['birth_date']['field'] = 'birth_date';
+$handler->display->display_options['fields']['birth_date']['label'] = 'Date of Birth';
 $handler->display->display_options['fields']['birth_date']['date_format'] = 'custom';
 $handler->display->display_options['fields']['birth_date']['custom_date_format'] = 'd.m.Y';
 $handler->display->display_options['fields']['birth_date']['second_date_format'] = 'long';
@@ -269,7 +270,7 @@ $translatables['my_details_block'] = array(
   t('Work Phone Extension'),
   t('[work_phone] ext. [work_phone_ext]'),
   t('Work E-mail'),
-  t('Birth Date'),
+  t('Date of Birth'),
   t('Location'),
   t('Designation'),
   t('Role title'),

--- a/civihr_employee_portal/views/views_export/views_my_details_block.inc
+++ b/civihr_employee_portal/views/views_export/views_my_details_block.inc
@@ -162,11 +162,6 @@ $handler->display->display_options['fields']['role_department']['table'] = 'hrjc
 $handler->display->display_options['fields']['role_department']['field'] = 'role_department';
 $handler->display->display_options['fields']['role_department']['relationship'] = 'role_jobcontract_id';
 $handler->display->display_options['fields']['role_department']['label'] = 'Role Department';
-/* Field: CiviCRM Contacts: Aggregated Contact Address */
-$handler->display->display_options['fields']['aggregated_address']['id'] = 'aggregated_address';
-$handler->display->display_options['fields']['aggregated_address']['table'] = 'civicrm_contact';
-$handler->display->display_options['fields']['aggregated_address']['field'] = 'aggregated_address';
-$handler->display->display_options['fields']['aggregated_address']['label'] = 'Address';
 $handler->display->display_options['defaults']['arguments'] = FALSE;
 /* Contextual filter: HRJobContract Details entity: Period start date */
 $handler->display->display_options['arguments']['period_start_date']['id'] = 'period_start_date';
@@ -208,10 +203,10 @@ $handler->display->display_options['arguments']['effective_end_date']['summary_o
 $handler->display->display_options['arguments']['effective_end_date']['civihr_range'] = '>=';
 $handler->display->display_options['arguments']['effective_end_date']['civihr_range_empty'] = '1';
 
-/* Display: My address */
-$handler = $view->new_display('block', 'My address', 'my_address_block');
+/* Display: Contact Information */
+$handler = $view->new_display('block', 'Contact Information', 'my_address_block');
 $handler->display->display_options['defaults']['title'] = FALSE;
-$handler->display->display_options['title'] = 'My Address Block';
+$handler->display->display_options['title'] = 'Contact Information Block';
 $handler->display->display_options['defaults']['pager'] = FALSE;
 $handler->display->display_options['pager']['type'] = 'some';
 $handler->display->display_options['pager']['options']['items_per_page'] = '1';
@@ -227,6 +222,11 @@ $handler->display->display_options['relationships']['hrjc_contact_details']['id'
 $handler->display->display_options['relationships']['hrjc_contact_details']['table'] = 'civicrm_contact';
 $handler->display->display_options['relationships']['hrjc_contact_details']['field'] = 'hrjc_contact_details';
 $handler->display->display_options['defaults']['fields'] = FALSE;
+/* Field: CiviCRM Address: Contact ID */
+$handler->display->display_options['fields']['contact_id']['id'] = 'contact_id';
+$handler->display->display_options['fields']['contact_id']['table'] = 'civicrm_address';
+$handler->display->display_options['fields']['contact_id']['field'] = 'contact_id';
+$handler->display->display_options['fields']['contact_id']['exclude'] = TRUE;
 /* Field: HRJobContract Contact Work/Home Phone and E-mail Entity: Home_phone */
 $handler->display->display_options['fields']['home_phone']['id'] = 'home_phone';
 $handler->display->display_options['fields']['home_phone']['table'] = 'hrjc_contact_details';
@@ -239,55 +239,11 @@ $handler->display->display_options['fields']['home_email']['table'] = 'hrjc_cont
 $handler->display->display_options['fields']['home_email']['field'] = 'home_email';
 $handler->display->display_options['fields']['home_email']['relationship'] = 'hrjc_contact_details';
 $handler->display->display_options['fields']['home_email']['label'] = 'Personal E-mail';
-/* Field: CiviCRM Address: Full Street Address */
-$handler->display->display_options['fields']['street_address']['id'] = 'street_address';
-$handler->display->display_options['fields']['street_address']['table'] = 'civicrm_address';
-$handler->display->display_options['fields']['street_address']['field'] = 'street_address';
-$handler->display->display_options['fields']['street_address']['relationship'] = 'drupal_id';
-$handler->display->display_options['fields']['street_address']['label'] = 'Address';
-$handler->display->display_options['fields']['street_address']['location_type'] = '1';
-$handler->display->display_options['fields']['street_address']['location_op'] = '0';
-$handler->display->display_options['fields']['street_address']['is_primary'] = 1;
-/* Field: CiviCRM Address: Supplemental Street Address */
-$handler->display->display_options['fields']['supplemental_address_1']['id'] = 'supplemental_address_1';
-$handler->display->display_options['fields']['supplemental_address_1']['table'] = 'civicrm_address';
-$handler->display->display_options['fields']['supplemental_address_1']['field'] = 'supplemental_address_1';
-$handler->display->display_options['fields']['supplemental_address_1']['relationship'] = 'drupal_id';
-$handler->display->display_options['fields']['supplemental_address_1']['label'] = 'Address Line 2';
-$handler->display->display_options['fields']['supplemental_address_1']['element_label_colon'] = FALSE;
-$handler->display->display_options['fields']['supplemental_address_1']['location_type'] = '1';
-$handler->display->display_options['fields']['supplemental_address_1']['location_op'] = '0';
-$handler->display->display_options['fields']['supplemental_address_1']['is_primary'] = 1;
-/* Field: CiviCRM Address: City / Suburb */
-$handler->display->display_options['fields']['city']['id'] = 'city';
-$handler->display->display_options['fields']['city']['table'] = 'civicrm_address';
-$handler->display->display_options['fields']['city']['field'] = 'city';
-$handler->display->display_options['fields']['city']['relationship'] = 'drupal_id';
-$handler->display->display_options['fields']['city']['location_type'] = '1';
-$handler->display->display_options['fields']['city']['location_op'] = '0';
-$handler->display->display_options['fields']['city']['is_primary'] = 1;
-/* Field: CiviCRM Address: Postal Code */
-$handler->display->display_options['fields']['postal_code']['id'] = 'postal_code';
-$handler->display->display_options['fields']['postal_code']['table'] = 'civicrm_address';
-$handler->display->display_options['fields']['postal_code']['field'] = 'postal_code';
-$handler->display->display_options['fields']['postal_code']['relationship'] = 'drupal_id';
-$handler->display->display_options['fields']['postal_code']['location_type'] = '1';
-$handler->display->display_options['fields']['postal_code']['location_op'] = '0';
-$handler->display->display_options['fields']['postal_code']['is_primary'] = 1;
-/* Field: CiviCRM Address: State/Province */
-$handler->display->display_options['fields']['state_province']['id'] = 'state_province';
-$handler->display->display_options['fields']['state_province']['table'] = 'civicrm_address';
-$handler->display->display_options['fields']['state_province']['field'] = 'state_province';
-$handler->display->display_options['fields']['state_province']['location_type'] = '1';
-$handler->display->display_options['fields']['state_province']['location_op'] = '0';
-$handler->display->display_options['fields']['state_province']['is_primary'] = 1;
-/* Field: CiviCRM Address: Country */
-$handler->display->display_options['fields']['country']['id'] = 'country';
-$handler->display->display_options['fields']['country']['table'] = 'civicrm_address';
-$handler->display->display_options['fields']['country']['field'] = 'country';
-$handler->display->display_options['fields']['country']['location_type'] = '1';
-$handler->display->display_options['fields']['country']['location_op'] = '0';
-$handler->display->display_options['fields']['country']['is_primary'] = 1;
+/* Field: CiviCRM Contacts: Aggregated Contact Address */
+$handler->display->display_options['fields']['aggregated_address']['id'] = 'aggregated_address';
+$handler->display->display_options['fields']['aggregated_address']['table'] = 'civicrm_contact';
+$handler->display->display_options['fields']['aggregated_address']['field'] = 'aggregated_address';
+$handler->display->display_options['fields']['aggregated_address']['label'] = 'Address';
 $translatables['my_details_block'] = array(
   t('Master'),
   t('My Details Block'),
@@ -318,15 +274,10 @@ $translatables['my_details_block'] = array(
   t('Designation'),
   t('Role title'),
   t('Role Department'),
-  t('Address'),
   t('All'),
-  t('My address'),
-  t('My Address Block'),
+  t('Contact Information'),
+  t('Contact Information Block'),
   t('Personal Phone'),
   t('Personal E-mail'),
-  t('Address Line 2'),
-  t('City / Suburb'),
-  t('Postal Code'),
-  t('State/Province'),
-  t('Country'),
+  t('Address'),
 );

--- a/civihr_employee_portal/views/views_export/views_my_details_block.inc
+++ b/civihr_employee_portal/views/views_export/views_my_details_block.inc
@@ -98,7 +98,6 @@ $handler->display->display_options['defaults']['fields'] = FALSE;
 $handler->display->display_options['fields']['id']['id'] = 'id';
 $handler->display->display_options['fields']['id']['table'] = 'civicrm_contact';
 $handler->display->display_options['fields']['id']['field'] = 'id';
-$handler->display->display_options['fields']['id']['exclude'] = TRUE;
 $handler->display->display_options['fields']['id']['separator'] = '';
 /* Field: CiviCRM Contacts: Display Name */
 $handler->display->display_options['fields']['display_name']['id'] = 'display_name';
@@ -132,6 +131,13 @@ $handler->display->display_options['fields']['work_email']['table'] = 'hrjc_cont
 $handler->display->display_options['fields']['work_email']['field'] = 'work_email';
 $handler->display->display_options['fields']['work_email']['relationship'] = 'hrjc_contact_details';
 $handler->display->display_options['fields']['work_email']['label'] = 'Work E-mail';
+/* Field: CiviCRM Contacts: Birth Date */
+$handler->display->display_options['fields']['birth_date']['id'] = 'birth_date';
+$handler->display->display_options['fields']['birth_date']['table'] = 'civicrm_contact';
+$handler->display->display_options['fields']['birth_date']['field'] = 'birth_date';
+$handler->display->display_options['fields']['birth_date']['date_format'] = 'custom';
+$handler->display->display_options['fields']['birth_date']['custom_date_format'] = 'd.m.Y';
+$handler->display->display_options['fields']['birth_date']['second_date_format'] = 'long';
 /* Field: HRJobContract Details entity: Location_label */
 $handler->display->display_options['fields']['location_label']['id'] = 'location_label';
 $handler->display->display_options['fields']['location_label']['table'] = 'hrjc_details';
@@ -156,12 +162,11 @@ $handler->display->display_options['fields']['role_department']['table'] = 'hrjc
 $handler->display->display_options['fields']['role_department']['field'] = 'role_department';
 $handler->display->display_options['fields']['role_department']['relationship'] = 'role_jobcontract_id';
 $handler->display->display_options['fields']['role_department']['label'] = 'Role Department';
-/* Field: CiviCRM Custom: Emergency Contacts: Name */
-$handler->display->display_options['fields']['name_80']['id'] = 'name_80';
-$handler->display->display_options['fields']['name_80']['table'] = 'civicrm_value_emergency_contacts_21';
-$handler->display->display_options['fields']['name_80']['field'] = 'name_80';
-$handler->display->display_options['fields']['name_80']['label'] = 'Emergency Contact';
-$handler->display->display_options['fields']['name_80']['alter']['strip_tags'] = TRUE;
+/* Field: CiviCRM Contacts: Aggregated Contact Address */
+$handler->display->display_options['fields']['aggregated_address']['id'] = 'aggregated_address';
+$handler->display->display_options['fields']['aggregated_address']['table'] = 'civicrm_contact';
+$handler->display->display_options['fields']['aggregated_address']['field'] = 'aggregated_address';
+$handler->display->display_options['fields']['aggregated_address']['label'] = 'Address';
 $handler->display->display_options['defaults']['arguments'] = FALSE;
 /* Contextual filter: HRJobContract Details entity: Period start date */
 $handler->display->display_options['arguments']['period_start_date']['id'] = 'period_start_date';
@@ -243,7 +248,6 @@ $handler->display->display_options['fields']['street_address']['label'] = 'Addre
 $handler->display->display_options['fields']['street_address']['location_type'] = '1';
 $handler->display->display_options['fields']['street_address']['location_op'] = '0';
 $handler->display->display_options['fields']['street_address']['is_primary'] = 1;
-$handler->display->display_options['fields']['street_address']['is_billing'] = 0;
 /* Field: CiviCRM Address: Supplemental Street Address */
 $handler->display->display_options['fields']['supplemental_address_1']['id'] = 'supplemental_address_1';
 $handler->display->display_options['fields']['supplemental_address_1']['table'] = 'civicrm_address';
@@ -254,7 +258,6 @@ $handler->display->display_options['fields']['supplemental_address_1']['element_
 $handler->display->display_options['fields']['supplemental_address_1']['location_type'] = '1';
 $handler->display->display_options['fields']['supplemental_address_1']['location_op'] = '0';
 $handler->display->display_options['fields']['supplemental_address_1']['is_primary'] = 1;
-$handler->display->display_options['fields']['supplemental_address_1']['is_billing'] = 0;
 /* Field: CiviCRM Address: City / Suburb */
 $handler->display->display_options['fields']['city']['id'] = 'city';
 $handler->display->display_options['fields']['city']['table'] = 'civicrm_address';
@@ -263,7 +266,6 @@ $handler->display->display_options['fields']['city']['relationship'] = 'drupal_i
 $handler->display->display_options['fields']['city']['location_type'] = '1';
 $handler->display->display_options['fields']['city']['location_op'] = '0';
 $handler->display->display_options['fields']['city']['is_primary'] = 1;
-$handler->display->display_options['fields']['city']['is_billing'] = 0;
 /* Field: CiviCRM Address: Postal Code */
 $handler->display->display_options['fields']['postal_code']['id'] = 'postal_code';
 $handler->display->display_options['fields']['postal_code']['table'] = 'civicrm_address';
@@ -272,7 +274,6 @@ $handler->display->display_options['fields']['postal_code']['relationship'] = 'd
 $handler->display->display_options['fields']['postal_code']['location_type'] = '1';
 $handler->display->display_options['fields']['postal_code']['location_op'] = '0';
 $handler->display->display_options['fields']['postal_code']['is_primary'] = 1;
-$handler->display->display_options['fields']['postal_code']['is_billing'] = 0;
 /* Field: CiviCRM Address: State/Province */
 $handler->display->display_options['fields']['state_province']['id'] = 'state_province';
 $handler->display->display_options['fields']['state_province']['table'] = 'civicrm_address';
@@ -280,7 +281,6 @@ $handler->display->display_options['fields']['state_province']['field'] = 'state
 $handler->display->display_options['fields']['state_province']['location_type'] = '1';
 $handler->display->display_options['fields']['state_province']['location_op'] = '0';
 $handler->display->display_options['fields']['state_province']['is_primary'] = 1;
-$handler->display->display_options['fields']['state_province']['is_billing'] = 0;
 /* Field: CiviCRM Address: Country */
 $handler->display->display_options['fields']['country']['id'] = 'country';
 $handler->display->display_options['fields']['country']['table'] = 'civicrm_address';
@@ -288,230 +288,6 @@ $handler->display->display_options['fields']['country']['field'] = 'country';
 $handler->display->display_options['fields']['country']['location_type'] = '1';
 $handler->display->display_options['fields']['country']['location_op'] = '0';
 $handler->display->display_options['fields']['country']['is_primary'] = 1;
-$handler->display->display_options['fields']['country']['is_billing'] = 0;
-
-/* Display: My details (full) */
-$handler = $view->new_display('block', 'My details (full)', 'my_details_block_full');
-$handler->display->display_options['defaults']['title'] = FALSE;
-$handler->display->display_options['title'] = 'My Details';
-$handler->display->display_options['defaults']['relationships'] = FALSE;
-/* Relationship: CiviCRM Contacts: Drupal ID */
-$handler->display->display_options['relationships']['drupal_id']['id'] = 'drupal_id';
-$handler->display->display_options['relationships']['drupal_id']['table'] = 'civicrm_contact';
-$handler->display->display_options['relationships']['drupal_id']['field'] = 'drupal_id';
-/* Relationship: CiviCRM Contacts: HRJobContract Revision entity */
-$handler->display->display_options['relationships']['hrjc_revision']['id'] = 'hrjc_revision';
-$handler->display->display_options['relationships']['hrjc_revision']['table'] = 'civicrm_contact';
-$handler->display->display_options['relationships']['hrjc_revision']['field'] = 'hrjc_revision';
-/* Relationship: HRJobContract Revision entity: Details_revision_id */
-$handler->display->display_options['relationships']['details_revision_id']['id'] = 'details_revision_id';
-$handler->display->display_options['relationships']['details_revision_id']['table'] = 'hrjc_revision';
-$handler->display->display_options['relationships']['details_revision_id']['field'] = 'details_revision_id';
-$handler->display->display_options['relationships']['details_revision_id']['relationship'] = 'hrjc_revision';
-/* Relationship: HRJobContract Revision entity: Role_jobcontract_id */
-$handler->display->display_options['relationships']['role_jobcontract_id']['id'] = 'role_jobcontract_id';
-$handler->display->display_options['relationships']['role_jobcontract_id']['table'] = 'hrjc_revision';
-$handler->display->display_options['relationships']['role_jobcontract_id']['field'] = 'role_jobcontract_id';
-$handler->display->display_options['relationships']['role_jobcontract_id']['relationship'] = 'hrjc_revision';
-/* Relationship: CiviCRM Contacts: HRJobContract Contact Work/Home Phone and E-mail Entity */
-$handler->display->display_options['relationships']['hrjc_contact_details']['id'] = 'hrjc_contact_details';
-$handler->display->display_options['relationships']['hrjc_contact_details']['table'] = 'civicrm_contact';
-$handler->display->display_options['relationships']['hrjc_contact_details']['field'] = 'hrjc_contact_details';
-$handler->display->display_options['defaults']['fields'] = FALSE;
-/* Field: CiviCRM Contacts: Contact ID */
-$handler->display->display_options['fields']['id']['id'] = 'id';
-$handler->display->display_options['fields']['id']['table'] = 'civicrm_contact';
-$handler->display->display_options['fields']['id']['field'] = 'id';
-/* Field: CiviCRM Contacts: Display Name */
-$handler->display->display_options['fields']['display_name']['id'] = 'display_name';
-$handler->display->display_options['fields']['display_name']['table'] = 'civicrm_contact';
-$handler->display->display_options['fields']['display_name']['field'] = 'display_name';
-$handler->display->display_options['fields']['display_name']['label'] = 'Display name';
-$handler->display->display_options['fields']['display_name']['link_to_civicrm_contact'] = 0;
-/* Field: HRJobContract Contact Work/Home Phone and E-mail Entity: Work_phone */
-$handler->display->display_options['fields']['work_phone']['id'] = 'work_phone';
-$handler->display->display_options['fields']['work_phone']['table'] = 'hrjc_contact_details';
-$handler->display->display_options['fields']['work_phone']['field'] = 'work_phone';
-$handler->display->display_options['fields']['work_phone']['relationship'] = 'hrjc_contact_details';
-$handler->display->display_options['fields']['work_phone']['label'] = 'Work Phone';
-$handler->display->display_options['fields']['work_phone']['exclude'] = TRUE;
-/* Field: HRJobContract Contact Work/Home Phone and E-mail Entity: Work_phone_ext */
-$handler->display->display_options['fields']['work_phone_ext']['id'] = 'work_phone_ext';
-$handler->display->display_options['fields']['work_phone_ext']['table'] = 'hrjc_contact_details';
-$handler->display->display_options['fields']['work_phone_ext']['field'] = 'work_phone_ext';
-$handler->display->display_options['fields']['work_phone_ext']['relationship'] = 'hrjc_contact_details';
-$handler->display->display_options['fields']['work_phone_ext']['label'] = 'Work Phone Extension';
-$handler->display->display_options['fields']['work_phone_ext']['exclude'] = TRUE;
-/* Field: Global: Custom text */
-$handler->display->display_options['fields']['nothing_1']['id'] = 'nothing_1';
-$handler->display->display_options['fields']['nothing_1']['table'] = 'views';
-$handler->display->display_options['fields']['nothing_1']['field'] = 'nothing';
-$handler->display->display_options['fields']['nothing_1']['label'] = 'Work Phone';
-$handler->display->display_options['fields']['nothing_1']['alter']['text'] = '[work_phone] ext. [work_phone_ext]';
-/* Field: HRJobContract Contact Work/Home Phone and E-mail Entity: Work_email */
-$handler->display->display_options['fields']['work_email']['id'] = 'work_email';
-$handler->display->display_options['fields']['work_email']['table'] = 'hrjc_contact_details';
-$handler->display->display_options['fields']['work_email']['field'] = 'work_email';
-$handler->display->display_options['fields']['work_email']['relationship'] = 'hrjc_contact_details';
-$handler->display->display_options['fields']['work_email']['label'] = 'Work Email';
-/* Field: CiviCRM Contacts: Birth Date */
-$handler->display->display_options['fields']['birth_date']['id'] = 'birth_date';
-$handler->display->display_options['fields']['birth_date']['table'] = 'civicrm_contact';
-$handler->display->display_options['fields']['birth_date']['field'] = 'birth_date';
-$handler->display->display_options['fields']['birth_date']['label'] = 'Date of birth';
-$handler->display->display_options['fields']['birth_date']['date_format'] = 'custom';
-$handler->display->display_options['fields']['birth_date']['custom_date_format'] = 'd.m.Y';
-$handler->display->display_options['fields']['birth_date']['second_date_format'] = 'long';
-/* Field: HRJobContract Contact Work/Home Phone and E-mail Entity: Home_phone */
-$handler->display->display_options['fields']['home_phone']['id'] = 'home_phone';
-$handler->display->display_options['fields']['home_phone']['table'] = 'hrjc_contact_details';
-$handler->display->display_options['fields']['home_phone']['field'] = 'home_phone';
-$handler->display->display_options['fields']['home_phone']['relationship'] = 'hrjc_contact_details';
-$handler->display->display_options['fields']['home_phone']['label'] = 'Personal Phone';
-/* Field: HRJobContract Contact Work/Home Phone and E-mail Entity: Home_email */
-$handler->display->display_options['fields']['home_email']['id'] = 'home_email';
-$handler->display->display_options['fields']['home_email']['table'] = 'hrjc_contact_details';
-$handler->display->display_options['fields']['home_email']['field'] = 'home_email';
-$handler->display->display_options['fields']['home_email']['relationship'] = 'hrjc_contact_details';
-$handler->display->display_options['fields']['home_email']['label'] = 'Personal Email';
-/* Field: CiviCRM Address: Full Street Address */
-$handler->display->display_options['fields']['street_address']['id'] = 'street_address';
-$handler->display->display_options['fields']['street_address']['table'] = 'civicrm_address';
-$handler->display->display_options['fields']['street_address']['field'] = 'street_address';
-$handler->display->display_options['fields']['street_address']['exclude'] = TRUE;
-$handler->display->display_options['fields']['street_address']['location_type'] = '1';
-$handler->display->display_options['fields']['street_address']['location_op'] = '0';
-$handler->display->display_options['fields']['street_address']['is_primary'] = 1;
-$handler->display->display_options['fields']['street_address']['is_billing'] = 0;
-/* Field: CiviCRM Address: Supplemental Street Address */
-$handler->display->display_options['fields']['supplemental_address_1']['id'] = 'supplemental_address_1';
-$handler->display->display_options['fields']['supplemental_address_1']['table'] = 'civicrm_address';
-$handler->display->display_options['fields']['supplemental_address_1']['field'] = 'supplemental_address_1';
-$handler->display->display_options['fields']['supplemental_address_1']['exclude'] = TRUE;
-$handler->display->display_options['fields']['supplemental_address_1']['location_type'] = '1';
-$handler->display->display_options['fields']['supplemental_address_1']['location_op'] = '0';
-$handler->display->display_options['fields']['supplemental_address_1']['is_primary'] = 1;
-$handler->display->display_options['fields']['supplemental_address_1']['is_billing'] = 0;
-/* Field: CiviCRM Address: City / Suburb */
-$handler->display->display_options['fields']['city']['id'] = 'city';
-$handler->display->display_options['fields']['city']['table'] = 'civicrm_address';
-$handler->display->display_options['fields']['city']['field'] = 'city';
-$handler->display->display_options['fields']['city']['exclude'] = TRUE;
-$handler->display->display_options['fields']['city']['location_type'] = '1';
-$handler->display->display_options['fields']['city']['location_op'] = '0';
-$handler->display->display_options['fields']['city']['is_primary'] = 1;
-$handler->display->display_options['fields']['city']['is_billing'] = 0;
-/* Field: CiviCRM Address: Postal Code */
-$handler->display->display_options['fields']['postal_code']['id'] = 'postal_code';
-$handler->display->display_options['fields']['postal_code']['table'] = 'civicrm_address';
-$handler->display->display_options['fields']['postal_code']['field'] = 'postal_code';
-$handler->display->display_options['fields']['postal_code']['exclude'] = TRUE;
-$handler->display->display_options['fields']['postal_code']['location_type'] = '1';
-$handler->display->display_options['fields']['postal_code']['location_op'] = '0';
-$handler->display->display_options['fields']['postal_code']['is_primary'] = 1;
-$handler->display->display_options['fields']['postal_code']['is_billing'] = 0;
-/* Field: CiviCRM Address: Country */
-$handler->display->display_options['fields']['country']['id'] = 'country';
-$handler->display->display_options['fields']['country']['table'] = 'civicrm_address';
-$handler->display->display_options['fields']['country']['field'] = 'country';
-$handler->display->display_options['fields']['country']['exclude'] = TRUE;
-$handler->display->display_options['fields']['country']['location_type'] = '1';
-$handler->display->display_options['fields']['country']['location_op'] = '0';
-$handler->display->display_options['fields']['country']['is_primary'] = 1;
-$handler->display->display_options['fields']['country']['is_billing'] = 0;
-$handler->display->display_options['fields']['country']['country_display'] = '2';
-/* Field: CiviCRM Address: State/Province */
-$handler->display->display_options['fields']['state_province']['id'] = 'state_province';
-$handler->display->display_options['fields']['state_province']['table'] = 'civicrm_address';
-$handler->display->display_options['fields']['state_province']['field'] = 'state_province';
-$handler->display->display_options['fields']['state_province']['location_type'] = '1';
-$handler->display->display_options['fields']['state_province']['location_op'] = '0';
-$handler->display->display_options['fields']['state_province']['is_primary'] = 1;
-$handler->display->display_options['fields']['state_province']['is_billing'] = 0;
-$handler->display->display_options['fields']['state_province']['prov_display'] = '2';
-/* Field: Global: Custom text */
-$handler->display->display_options['fields']['nothing']['id'] = 'nothing';
-$handler->display->display_options['fields']['nothing']['table'] = 'views';
-$handler->display->display_options['fields']['nothing']['field'] = 'nothing';
-$handler->display->display_options['fields']['nothing']['label'] = 'Address';
-$handler->display->display_options['fields']['nothing']['alter']['text'] = '[street_address] <br />
-[supplemental_address_1] <br />
-[city] [postal_code] <br />
-[state_province] <br />
-[country]';
-
-/* Display: Emergency Contact (full) */
-$handler = $view->new_display('block', 'Emergency Contact (full)', 'my_details_emergency_contact');
-$handler->display->display_options['defaults']['title'] = FALSE;
-$handler->display->display_options['title'] = 'Emergency Contact';
-$handler->display->display_options['defaults']['fields'] = FALSE;
-/* Field: CiviCRM Custom: Emergency Contacts: Name */
-$handler->display->display_options['fields']['name_80']['id'] = 'name_80';
-$handler->display->display_options['fields']['name_80']['table'] = 'civicrm_value_emergency_contacts_21';
-$handler->display->display_options['fields']['name_80']['field'] = 'name_80';
-$handler->display->display_options['fields']['name_80']['label'] = 'Contact name';
-$handler->display->display_options['fields']['name_80']['alter']['strip_tags'] = TRUE;
-/* Field: CiviCRM Custom: Emergency Contacts: Mobile number */
-$handler->display->display_options['fields']['mobile_number_91']['id'] = 'mobile_number_91';
-$handler->display->display_options['fields']['mobile_number_91']['table'] = 'civicrm_value_emergency_contacts_21';
-$handler->display->display_options['fields']['mobile_number_91']['field'] = 'mobile_number_91';
-$handler->display->display_options['fields']['mobile_number_91']['alter']['strip_tags'] = TRUE;
-/* Field: CiviCRM Custom: Emergency Contacts: Phone number */
-$handler->display->display_options['fields']['phone_number_81']['id'] = 'phone_number_81';
-$handler->display->display_options['fields']['phone_number_81']['table'] = 'civicrm_value_emergency_contacts_21';
-$handler->display->display_options['fields']['phone_number_81']['field'] = 'phone_number_81';
-$handler->display->display_options['fields']['phone_number_81']['alter']['strip_tags'] = TRUE;
-/* Field: CiviCRM Custom: Emergency Contacts: Email */
-$handler->display->display_options['fields']['email_82']['id'] = 'email_82';
-$handler->display->display_options['fields']['email_82']['table'] = 'civicrm_value_emergency_contacts_21';
-$handler->display->display_options['fields']['email_82']['field'] = 'email_82';
-$handler->display->display_options['fields']['email_82']['label'] = 'Primary email';
-$handler->display->display_options['fields']['email_82']['alter']['strip_tags'] = TRUE;
-/* Field: CiviCRM Custom: Emergency Contacts: Street Address */
-$handler->display->display_options['fields']['street_address_93']['id'] = 'street_address_93';
-$handler->display->display_options['fields']['street_address_93']['table'] = 'civicrm_value_emergency_contacts_21';
-$handler->display->display_options['fields']['street_address_93']['field'] = 'street_address_93';
-$handler->display->display_options['fields']['street_address_93']['alter']['strip_tags'] = TRUE;
-/* Field: CiviCRM Custom: Emergency Contacts: Street Address Line 2 */
-$handler->display->display_options['fields']['street_address_line_2_94']['id'] = 'street_address_line_2_94';
-$handler->display->display_options['fields']['street_address_line_2_94']['table'] = 'civicrm_value_emergency_contacts_21';
-$handler->display->display_options['fields']['street_address_line_2_94']['field'] = 'street_address_line_2_94';
-$handler->display->display_options['fields']['street_address_line_2_94']['alter']['strip_tags'] = TRUE;
-/* Field: CiviCRM Custom: Emergency Contacts: City */
-$handler->display->display_options['fields']['city_95']['id'] = 'city_95';
-$handler->display->display_options['fields']['city_95']['table'] = 'civicrm_value_emergency_contacts_21';
-$handler->display->display_options['fields']['city_95']['field'] = 'city_95';
-$handler->display->display_options['fields']['city_95']['alter']['strip_tags'] = TRUE;
-/* Field: CiviCRM Custom: Emergency Contacts: Postal Code */
-$handler->display->display_options['fields']['postal_code_96']['id'] = 'postal_code_96';
-$handler->display->display_options['fields']['postal_code_96']['table'] = 'civicrm_value_emergency_contacts_21';
-$handler->display->display_options['fields']['postal_code_96']['field'] = 'postal_code_96';
-$handler->display->display_options['fields']['postal_code_96']['alter']['strip_tags'] = TRUE;
-/* Field: CiviCRM Custom: Emergency Contacts: Country */
-$handler->display->display_options['fields']['country_98']['id'] = 'country_98';
-$handler->display->display_options['fields']['country_98']['table'] = 'civicrm_value_emergency_contacts_21';
-$handler->display->display_options['fields']['country_98']['field'] = 'country_98';
-$handler->display->display_options['fields']['country_98']['alter']['strip_tags'] = TRUE;
-/* Field: CiviCRM Custom: Emergency Contacts: State/Province */
-$handler->display->display_options['fields']['province_97']['id'] = 'province_97';
-$handler->display->display_options['fields']['province_97']['table'] = 'civicrm_value_emergency_contacts_21';
-$handler->display->display_options['fields']['province_97']['field'] = 'province_97';
-$handler->display->display_options['fields']['province_97']['alter']['strip_tags'] = TRUE;
-/* Field: CiviCRM Custom: Emergency Contacts: Relationship with Employee */
-$handler->display->display_options['fields']['relationship_with_employee_83']['id'] = 'relationship_with_employee_83';
-$handler->display->display_options['fields']['relationship_with_employee_83']['table'] = 'civicrm_value_emergency_contacts_21';
-$handler->display->display_options['fields']['relationship_with_employee_83']['field'] = 'relationship_with_employee_83';
-$handler->display->display_options['fields']['relationship_with_employee_83']['alter']['strip_tags'] = TRUE;
-/* Field: CiviCRM Custom: Emergency Contacts: Notes */
-$handler->display->display_options['fields']['notes_84']['id'] = 'notes_84';
-$handler->display->display_options['fields']['notes_84']['table'] = 'civicrm_value_emergency_contacts_21';
-$handler->display->display_options['fields']['notes_84']['field'] = 'notes_84';
-$handler->display->display_options['fields']['notes_84']['alter']['strip_tags'] = TRUE;
-/* Field: CiviCRM Custom: Emergency Contacts: Dependant(s) */
-$handler->display->display_options['fields']['dependant_s__92']['id'] = 'dependant_s__92';
-$handler->display->display_options['fields']['dependant_s__92']['table'] = 'civicrm_value_emergency_contacts_21';
-$handler->display->display_options['fields']['dependant_s__92']['field'] = 'dependant_s__92';
-$handler->display->display_options['fields']['dependant_s__92']['alter']['strip_tags'] = TRUE;
 $translatables['my_details_block'] = array(
   t('Master'),
   t('My Details Block'),
@@ -537,43 +313,20 @@ $translatables['my_details_block'] = array(
   t('Work Phone Extension'),
   t('[work_phone] ext. [work_phone_ext]'),
   t('Work E-mail'),
-  t('Designation'),
+  t('Birth Date'),
   t('Location'),
+  t('Designation'),
   t('Role title'),
   t('Role Department'),
+  t('Address'),
   t('All'),
   t('My address'),
   t('My Address Block'),
   t('Personal Phone'),
   t('Personal E-mail'),
-  t('Address'),
   t('Address Line 2'),
   t('City / Suburb'),
   t('Postal Code'),
   t('State/Province'),
   t('Country'),
-  t('My details (full)'),
-  t('My Details'),
-  t('Display name'),
-  t('Work Email'),
-  t('Date of birth'),
-  t('Personal Email'),
-  t('Full Street Address'),
-  t('Supplemental Street Address'),
-  t('[street_address] <br />
-[supplemental_address_1] <br />
-[city] [postal_code] <br />
-[state_province] <br />
-[country]'),
-  t('Emergency Contact (full)'),
-  t('Contact name'),
-  t('Mobile number'),
-  t('Phone number'),
-  t('Primary email'),
-  t('Street Address'),
-  t('Street Address Line 2'),
-  t('City'),
-  t('Relationship with Employee'),
-  t('Notes'),
-  t('Dependant(s)'),
 );


### PR DESCRIPTION
## Overview

The "My Details" block has a few different displays. We're using different ones on the `/hr-details` page and `/dashboard`. These will be unified and old displays removed.

## Before

- `/hr-details` used a different display for the "My Details" view than on `/dashboard`.
- The master display for this view did not show Contact ID and Birth Date
- The address in the "My Address View" showed each address field separately
- The "My Details" view had 4 displays

#### master Display

![image](https://user-images.githubusercontent.com/6374064/32268761-340d07e0-bee8-11e7-943a-c693b508794e.png)

#### hr-details Display

![image](https://user-images.githubusercontent.com/6374064/32237522-0e8776e4-be5d-11e7-9411-dd9f9bf98c2a.png)

## After

- `/hr-details` uses the same "My Details" (master) display as on `/dashboard`.
- The master display for this view adds Contact ID and Birth Date
- The address in the "Contact Information (renamed)" is aggregated to a single field
- 2 obsolete displays are removed from "My Details" 

#### both hr-details and master

![image](https://user-images.githubusercontent.com/6374064/32237678-7f9d5006-be5d-11e7-998c-49bcf342c8a3.png)

## Technical Details

Previously we were adding all the address fields to the view, hiding them, and then using a global text field and replacement tokens to show the address as one field. It seems cleaner to use a custom handler so I added one.

---

- [x] Tests Pass
