### PR TITLE
PCHR-2855: Expose Emergency Contact to Views

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5884,31 +5884,35 @@ function civihr_employee_portal_tokens($type, $tokens, array $data = array(), ar
  */
 function civihr_employee_portal_module_implements_alter(&$implementations, $hook) {
 
-    if ($hook != 'views_data_alter') {
-        return;
-    }
+  if ($hook != 'views_data_alter') {
+    return;
+  }
 
-    watchdog('alter default order', print_r($implementations, TRUE));
+  watchdog('alter default order', print_r($implementations, TRUE));
 
-    $group = [];
+  $group = [];
 
-    // Check if the module exists and it's installed
-    if (module_exists('views_autocomplete_filters')) {
-        // Put the views autocomplete filters after civicrm
-        $module = 'views_autocomplete_filters';
-        $group += array($module => $implementations[$module]);
-        unset($implementations[$module]);
-    }
+  // Check if the module exists and it's installed
+  if (module_exists('views_autocomplete_filters')) {
+    // Put the views autocomplete filters after civicrm
+    $module = 'views_autocomplete_filters';
+    $group += array($module => $implementations[$module]);
+    unset($implementations[$module]);
+  }
 
-    // Put the civihr employee portal module after civicrm module (breaks the Calendar view)
-    // $module = 'civihr_employee_portal';
-    // $group += array($module => $implementations[$module]);
-    // unset($implementations[$module]);
+  /**
+   * Put the civihr employee portal module after civicrm module. The civicrm
+   * module will ruthlessly replace all changes from views_data_alter hook
+   * @see civicrm_views_data_alter
+   */
+  $module = 'civihr_employee_portal';
+  $group += array($module => $implementations[$module]);
+  unset($implementations[$module]);
 
-    // Make sure some modules are after civicrm to avoid error with autocomplete search or drush cc all
-    $implementations = $implementations + $group;
+  // Make sure some modules are after civicrm to avoid error with autocomplete search or drush cc all
+  $implementations = $implementations + $group;
 
-    watchdog('alter modified order', print_r($implementations, TRUE));
+  watchdog('alter modified order', print_r($implementations, TRUE));
 }
 
 function civihr_employee_portal_civicrm_post($op, $objectName, $objectId, &$objectRef) {

--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -844,28 +844,28 @@ function civihr_employee_portal_views_data_alter(&$data) {
   );
 
   // Add link to contact ID
-  $data['civicrm_value_emergency_contacts_21']['entity_id'] = array(
+  $data['civicrm_value_emergency_contacts_21']['entity_id'] = [
     'title' => t('Entity ID'),
     'real field' => 'entity_id',
-    'help' => t('The contact this emergency contact is related to.'),
-    'field' => array(
+    'help' => t('The contact ID this emergency contact is related to.'),
+    'field' => [
       'handler' => 'views_handler_field',
       'click sortable' => FALSE,
-    ),
-    'argument' => array(
+    ],
+    'argument' => [
       'handler' => 'views_handler_argument',
-    ),
-    'relationship' => array(
+    ],
+    'relationship' => [
       'base' => 'civicrm_contact',
       'base field' => 'id',
       'handler' => 'views_handler_relationship',
-      'label' => t('CiviCRM Emergency Contact Contact ID'),
-    ),
-    'filter' => array(
+      'label' => t('CiviCRM Contact ID'),
+    ],
+    'filter' => [
       'handler' => 'views_handler_filter_numeric',
       'allow empty' => TRUE,
-    )
-  );
+    ]
+  ];
 
   $data['hrjc_contact_details']['work_email']['field']['handler'] = 'civihr_employee_portal_handler_email';
 

--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -843,13 +843,41 @@ function civihr_employee_portal_views_data_alter(&$data) {
     ),
   );
 
-  // Add custom date handler
-//    $data['absence_activity']['absence_date']['field']['handler'] = 'views_handler_field_date';
-//    $data['absence_activity']['absence_date']['sort']['handler'] = 'views_handler_sort_date';
-//    $data['absence_activity']['absence_date']['filter']['handler'] = 'views_handler_filter_date';
-//    $data['absence_activity']['absence_date']['argument']['handler'] = 'views_handler_argument_date';
+  // Add link to contact ID
+  $data['civicrm_value_emergency_contacts_21']['entity_id'] = array(
+    'title' => t('Entity ID'),
+    'real field' => 'entity_id',
+    'help' => t('The contact this emergency contact is related to.'),
+    'field' => array(
+      'handler' => 'views_handler_field',
+      'click sortable' => FALSE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument',
+    ),
+    'relationship' => array(
+      'base' => 'civicrm_contact',
+      'base field' => 'id',
+      'handler' => 'views_handler_relationship',
+      'label' => t('CiviCRM Emergency Contact Contact ID'),
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_numeric',
+      'allow empty' => TRUE,
+    )
+  );
 
   $data['hrjc_contact_details']['work_email']['field']['handler'] = 'civihr_employee_portal_handler_email';
+
+  /**
+   * Required to show entity in views list.
+   * @see views_fetch_base_tables
+   */
+  $data['civicrm_value_emergency_contacts_21']['table']['base'] = [
+    'field' => 'id',
+    'title' => 'CiviHR Emergency Contacts',
+    'help' => 'emergency_contacts'
+  ];
 
   return $data;
 }


### PR DESCRIPTION
## Overview

Emergency Contacts are not currently selectable as a base entity for Drupal views to display. future tickets they are required so will need to be exposed to views.

## Before

The dropdown on the create view page did not show emergency contacts

![image](https://user-images.githubusercontent.com/6374064/32275101-d0a29a5c-bf01-11e7-94ad-7e9130015a3a.png)

## After

The dropdown shows emergency contacts

![image](https://user-images.githubusercontent.com/6374064/32275303-a458c754-bf02-11e7-8e29-6a7e4c6f3470.png)

## Technical Details

Two things were preventing emergency contacts from being displayed:

- Only entities with base table info will be shown. This was not added by the CiviCRM module
- Attempts to add this data were overwritten by the CiviCRM module as the `views_data_alter` hook was called _after_ civihr_employee_portal

## Notes

- The lines I uncommented were originally commented as part of [PCHR-539](https://compucorp.atlassian.net/browse/PCHR-539). I tested adding a leave to a staff member and could see it in the calendar both from admin and staff side so I'm guessing either this was unrelated to that ticket or L&A has changed so much since then that it no longer affects it.

---

- [x] Tests Pass
