### PR TITLE
PCHR-2869: Swap assignment with workflow in SSP

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -2701,7 +2701,7 @@ function civihr_employee_portal_civi_tasks_form($form, &$form_state) {
 
     $form['assignment'] = array(
         '#type' => 'textfield',
-        '#title' => t('Assignment:'),
+        '#title' => t('Workflow:'),
         '#default_value' => '',
         '#attributes' => $disabledAttr,
         '#label_class' => 'col-sm-3 control-label',

--- a/civihr_employee_portal/js/tasks.js
+++ b/civihr_employee_portal/js/tasks.js
@@ -85,7 +85,7 @@
         buildAssignmentsSelect: function (assignmentsSelectOptions, defaultValue) {
             CRM.$('#edit-assignment').select2({
                 allowClear: true,
-                placeholder: "Search for assignment",
+                placeholder: "Search for workflow",
                 data: assignmentsSelectOptions
             });
             CRM.$('#edit-assignment').select2("data", defaultValue);

--- a/civihr_employee_portal/views/views_export/views_documents.inc
+++ b/civihr_employee_portal/views/views_export/views_documents.inc
@@ -112,7 +112,7 @@ $handler->display->display_options['fields']['activity_type_id']['element_wrappe
 $handler->display->display_options['fields']['case_id']['id'] = 'case_id';
 $handler->display->display_options['fields']['case_id']['table'] = 'documents';
 $handler->display->display_options['fields']['case_id']['field'] = 'case_id';
-$handler->display->display_options['fields']['case_id']['label'] = 'Assignment';
+$handler->display->display_options['fields']['case_id']['label'] = 'Workflow';
 $handler->display->display_options['fields']['case_id']['exclude'] = TRUE;
 $handler->display->display_options['fields']['case_id']['element_type'] = 'div';
 $handler->display->display_options['fields']['case_id']['element_label_type'] = 'strong';
@@ -328,7 +328,7 @@ $translatables['Documents'] = array(
   t('Document ID'),
   t('.'),
   t('Type'),
-  t('Assignment'),
+  t('Workflow'),
   t('Subject'),
   t('Due Date'),
   t('Expire Date'),

--- a/civihr_employee_portal/views/views_export/views_tasks.inc
+++ b/civihr_employee_portal/views/views_export/views_tasks.inc
@@ -51,7 +51,7 @@ $handler->display->display_options['fields']['activity_type_id']['field'] = 'act
 $handler->display->display_options['fields']['case_id']['id'] = 'case_id';
 $handler->display->display_options['fields']['case_id']['table'] = 'tasks';
 $handler->display->display_options['fields']['case_id']['field'] = 'case_id';
-$handler->display->display_options['fields']['case_id']['label'] = 'Assignment';
+$handler->display->display_options['fields']['case_id']['label'] = 'Workflow';
 $handler->display->display_options['fields']['case_id']['exclude'] = TRUE;
 $handler->display->display_options['fields']['case_id']['element_type'] = 'div';
 $handler->display->display_options['fields']['case_id']['element_label_type'] = 'strong';
@@ -166,7 +166,7 @@ $handler->display->display_options['fields']['activity_type_id']['field'] = 'act
 $handler->display->display_options['fields']['case_id']['id'] = 'case_id';
 $handler->display->display_options['fields']['case_id']['table'] = 'tasks';
 $handler->display->display_options['fields']['case_id']['field'] = 'case_id';
-$handler->display->display_options['fields']['case_id']['label'] = 'Assignment';
+$handler->display->display_options['fields']['case_id']['label'] = 'Workflow';
 $handler->display->display_options['fields']['case_id']['exclude'] = TRUE;
 $handler->display->display_options['fields']['case_id']['element_type'] = 'div';
 $handler->display->display_options['fields']['case_id']['element_label_type'] = 'strong';
@@ -284,7 +284,7 @@ $handler->display->display_options['fields']['activity_type_id']['field'] = 'act
 $handler->display->display_options['fields']['case_id']['id'] = 'case_id';
 $handler->display->display_options['fields']['case_id']['table'] = 'tasks';
 $handler->display->display_options['fields']['case_id']['field'] = 'case_id';
-$handler->display->display_options['fields']['case_id']['label'] = 'Assignment';
+$handler->display->display_options['fields']['case_id']['label'] = 'Workflow';
 $handler->display->display_options['fields']['case_id']['exclude'] = TRUE;
 $handler->display->display_options['fields']['case_id']['element_type'] = 'div';
 $handler->display->display_options['fields']['case_id']['element_label_type'] = 'strong';
@@ -387,7 +387,7 @@ $translatables['tasks'] = array(
   t('Task ID'),
   t('.'),
   t('Task type'),
-  t('Assignment'),
+  t('Workflow'),
   t('Subject'),
   t('Due date'),
   t('Status'),


### PR DESCRIPTION
## Overview
This PR swaps every occurrence of the work "Assignment" with the word "Workflow" in the SSP, like it was done [here](https://github.com/compucorp/civihr-tasks-assignments/pull/276) in the T&A extension

## Before
<img width="250" alt="before" src="https://user-images.githubusercontent.com/6400898/32410126-a788fd7c-c1b9-11e7-8468-c874fe7bf200.png">

## After
<img width="250" alt="after" src="https://user-images.githubusercontent.com/6400898/32410125-a76e7b28-c1b9-11e7-912d-afe6c8ca9fd8.png">