### PR TITLE
PCHR-2864: Add Explanation for Onboarding Wizard for Existing Users

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -4760,14 +4760,10 @@ function civihr_employee_portal_form_alter(&$form, &$form_state, $form_id) {
         }
     }
 
-  /**
-   * Remove empty components keys from $form['submitted'] as they break markup.
-   * @see https://www.drupal.org/node/2916491
-   */
   if (isset($form['#node']) && $form['#node']->title == OnboardingWebForm::NAME) {
-    $form['submitted'] = array_filter(CRM_Utils_Array::value('submitted', $form));
+    $onboardingForm = new OnboardingWebForm();
+    $onboardingForm->alter($form);
   }
-
 }
 
 /**
@@ -5021,7 +5017,7 @@ function civihr_employee_portal_user_login(&$edit, $account) {
     }
 
     if (_civihr_employee_portal_should_do_onboarding($account)) {
-       $_GET['destination'] = $onboardingFormPath;
+      $_GET['destination'] = $onboardingFormPath;
     }
   }
 }

--- a/civihr_employee_portal/src/Forms/OnboardingWebForm.php
+++ b/civihr_employee_portal/src/Forms/OnboardingWebForm.php
@@ -174,7 +174,8 @@ class OnboardingWebForm {
    */
   private function userCreatedAfterOnboardingReleased() {
     global $user;
-    $onboardingRelease = (new \DateTime('13 November 2017'))->getTimestamp();
+    $onboardingForm = WebformHelper::findOneByTitle(self::NAME);
+    $onboardingRelease = $onboardingForm->created;
 
     return $user->created > $onboardingRelease;
   }


### PR DESCRIPTION
## Overview

Existing CiviHR users might be a bit confused when required to complete onboarding. To help this we will add a message showing them why they're seeing it.

## Before

Anyone who hadn't completed onboarding would be redirected to the onboarding form without explanation.

![image](https://user-images.githubusercontent.com/6374064/32452920-cfdee98a-c312-11e7-87c0-61b8e7db32c0.png)

## After

There will be an explanation message on the first page of the onboarding form _only_ if the user was created before the onboarding form release date.

![image](https://user-images.githubusercontent.com/6374064/32452950-e416ce2c-c312-11e7-8035-73ae56819d0d.png)

## Notes

- Because the logic for form alterations was becoming more complicated I moved it into the form class itself.

---

- [x] Tests Pass
