### PR TITLE
PCHR-2862: Add the Absence Duration in Hours field to the SSP Leave and Absence Report.

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5,6 +5,7 @@ use Drupal\civihr_employee_portal\Helpers\HelperClass;
 use Drupal\civihr_employee_portal\Security\PublicFirewall;
 use Drupal\civihr_employee_portal\Helpers\ImageResizer;
 use Drupal\civihr_employee_portal\Forms\ContactForm;
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
 
 /**
  * Implements hook_css_alter().
@@ -375,6 +376,8 @@ function _rebuild_length_of_service_view() {
 function _rebuild_absence_activity_view() {
   $civi_settings = parse_url(CIVICRM_DSN);
   $civi_db_name = trim($civi_settings['path'], '/');
+  $calculationUnitOptions = array_flip(AbsenceType::buildOptions('calculation_unit', 'validate'));
+  $hoursUnit = $calculationUnitOptions['hours'];
 
   db_query('DROP VIEW IF EXISTS absence_activity');
   db_query("CREATE VIEW absence_activity AS
@@ -389,7 +392,8 @@ function _rebuild_absence_activity_view() {
               lr.to_date AS absence_end_date,
               DATE_FORMAT(DATE(lr.to_date), '%Y-%m') AS absence_end_date_month,
               CONCAT(IF (DATE_FORMAT(lrd.date, '%w') = 0, 7, DATE_FORMAT(lrd.date, '%w')), '. ', DATE_FORMAT(lrd.date, '%W')) AS absence_day_of_week,
-              ABS(bc.amount) as absence_duration,
+              IF(at.calculation_unit != {$hoursUnit}, ABS(bc.amount), NULL) as absence_duration_days,
+              IF(at.calculation_unit = {$hoursUnit}, ABS(bc.amount), NULL) as absence_duration_hours,
               IF(lr.request_type != 'toil', ABS(bc.amount), NULL) AS absence_amount_taken,
               IF(lr.request_type = 'toil', bc.amount, NULL) AS absence_amount_accrued,
               IF(lr.request_type = 'toil', -bc.amount, -bc.amount) AS absence_absolute_amount,

--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.views_default.inc
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.views_default.inc
@@ -367,10 +367,15 @@ function civihr_employee_portal_features_views_default_views() {
   $handler->display->display_options['fields']['absence_end_date_month']['relationship'] = 'absence_activity';
   $handler->display->display_options['fields']['absence_end_date_month']['label'] = 'Absence end month';
   /* Field: Absence Activity entity: Absence duration in days */
-  $handler->display->display_options['fields']['absence_duration']['id'] = 'absence_duration';
-  $handler->display->display_options['fields']['absence_duration']['table'] = 'absence_activity';
-  $handler->display->display_options['fields']['absence_duration']['field'] = 'absence_duration';
-  $handler->display->display_options['fields']['absence_duration']['relationship'] = 'absence_activity';
+  $handler->display->display_options['fields']['absence_duration_days']['id'] = 'absence_duration_days';
+  $handler->display->display_options['fields']['absence_duration_days']['table'] = 'absence_activity';
+  $handler->display->display_options['fields']['absence_duration_days']['field'] = 'absence_duration_days';
+  $handler->display->display_options['fields']['absence_duration_days']['relationship'] = 'absence_activity';
+  /* Field: Absence Activity entity: Absence duration in hours */
+  $handler->display->display_options['fields']['absence_duration_hours']['id'] = 'absence_duration_hours';
+  $handler->display->display_options['fields']['absence_duration_hours']['table'] = 'absence_activity';
+  $handler->display->display_options['fields']['absence_duration_hours']['field'] = 'absence_duration_hours';
+  $handler->display->display_options['fields']['absence_duration_hours']['relationship'] = 'absence_activity';
   /* Field: Absence Activity entity: Absence_type */
   $handler->display->display_options['fields']['absence_type']['id'] = 'absence_type';
   $handler->display->display_options['fields']['absence_type']['table'] = 'absence_activity';
@@ -994,6 +999,7 @@ function civihr_employee_portal_features_views_default_views() {
     t('Absence end date'),
     t('Absence end month'),
     t('Absence duration in days'),
+    t('Absence duration in hours'),
     t('Absence type'),
     t('Sickness reason'),
     t('Absence status'),

--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -693,15 +693,15 @@ function civihr_employee_portal_views_data_alter(&$data) {
     'sort' => array('handler' => 'views_json_query_handler_sort'),
   );
 
-  $data['absence_activity']['absence_duration'] = array(
+  $data['absence_activity']['absence_duration_days'] = array(
     'title' => t('Absence duration in days'),
-    'real field' => 'absence_duration',
+    'real field' => 'absence_duration_days',
     'field' => array(
       'click sortable' => TRUE,
     ),
     'argument' => array(
       'handler' => 'views_json_query_argument_request_handler',
-      'name_field' => 'absence_duration',
+      'name_field' => 'absence_duration_days',
       'string' => TRUE
     ),
     'filter' => array(
@@ -710,6 +710,25 @@ function civihr_employee_portal_views_data_alter(&$data) {
     ),
     'sort' => array('handler' => 'views_json_query_handler_sort'),
   );
+
+  $data['absence_activity']['absence_duration_hours'] = array(
+    'title' => t('Absence duration in hours'),
+    'real field' => 'absence_duration_hours',
+    'field' => array(
+      'click sortable' => TRUE,
+    ),
+    'argument' => array(
+      'handler' => 'views_json_query_argument_request_handler',
+      'name_field' => 'absence_duration_hours',
+      'string' => TRUE
+    ),
+    'filter' => array(
+      'handler' => 'views_json_query_handler_filter',
+      'help' => t('Filter results to a particular result set'),
+    ),
+    'sort' => array('handler' => 'views_json_query_handler_sort'),
+  );
+  
   $data['absence_activity']['absence_amount_taken'] = array(
     'title' => t('Absence amount taken'),
     'real field' => 'absence_amount_taken',

--- a/civihr_employee_portal/views/views_export/views_civihr_report_leave_and_absence.inc
+++ b/civihr_employee_portal/views/views_export/views_civihr_report_leave_and_absence.inc
@@ -360,10 +360,15 @@ $handler->display->display_options['fields']['absence_end_date_month']['field'] 
 $handler->display->display_options['fields']['absence_end_date_month']['relationship'] = 'absence_activity';
 $handler->display->display_options['fields']['absence_end_date_month']['label'] = 'Absence end month';
 /* Field: Absence Activity entity: Absence duration in days */
-$handler->display->display_options['fields']['absence_duration']['id'] = 'absence_duration';
-$handler->display->display_options['fields']['absence_duration']['table'] = 'absence_activity';
-$handler->display->display_options['fields']['absence_duration']['field'] = 'absence_duration';
-$handler->display->display_options['fields']['absence_duration']['relationship'] = 'absence_activity';
+$handler->display->display_options['fields']['absence_duration_days']['id'] = 'absence_duration_days';
+$handler->display->display_options['fields']['absence_duration_days']['table'] = 'absence_activity';
+$handler->display->display_options['fields']['absence_duration_days']['field'] = 'absence_duration_days';
+$handler->display->display_options['fields']['absence_duration_days']['relationship'] = 'absence_activity';
+/* Field: Absence Activity entity: Absence duration in hours */
+$handler->display->display_options['fields']['absence_duration_hours']['id'] = 'absence_duration_hours';
+$handler->display->display_options['fields']['absence_duration_hours']['table'] = 'absence_activity';
+$handler->display->display_options['fields']['absence_duration_hours']['field'] = 'absence_duration_hours';
+$handler->display->display_options['fields']['absence_duration_hours']['relationship'] = 'absence_activity';
 /* Field: Absence Activity entity: Absence_type */
 $handler->display->display_options['fields']['absence_type']['id'] = 'absence_type';
 $handler->display->display_options['fields']['absence_type']['table'] = 'absence_activity';
@@ -988,6 +993,7 @@ $translatables['civihr_report_leave_and_absence'] = array(
   t('Absence end date'),
   t('Absence end month'),
   t('Absence duration in days'),
+  t('Absence duration in hours'),
   t('Absence type'),
   t('Sickness reason'),
   t('Absence status'),


### PR DESCRIPTION
## Overview
Since Leave can now be requested in Hours, a new field is needed on the SSP Leave and Absence Report as well as on the Pivot table that works the same way the Absence Duration in days field work.

## Before
The Absence duration in hours field does not exist.

## After
- The Absence duration in hours field is added to the Leave and Absence report. 
The field is empty for absences in days. Also the Absence Duration in days field is empty for absences in hours.

![civihr custom report - civihr 1 7 demo 2017-11-07 13-17-02](https://user-images.githubusercontent.com/6951813/32493453-312bcc66-c3be-11e7-99a9-7bc1babd17c7.png)

![civihr custom report - civihr 1 7 demo 2017-11-07 13-22-08](https://user-images.githubusercontent.com/6951813/32493616-c4a59d3c-c3be-11e7-8449-df86de7f749d.png)

---
This PR does not affect tests.
- [ ] Tests Pass
