### PR TITLE
PCHR 2849: Emergency Contact Views

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.info
+++ b/civihr_employee_portal/civihr_employee_portal.info
@@ -44,6 +44,7 @@ files[] = views/includes/civihr_employee_portal_argument_contact_id.inc
 files[] = views/includes/civihr_employee_portal_handler_email.inc
 files[] = views/includes/civihr_employee_portal_handler_age_group.inc
 files[] = views/includes/civihr_employee_portal_handler_aggregated_address.inc
+files[] = views/includes/civihr_employee_portal_handler_emergency_contact_aggregated_address.inc
 files[] = views/includes/civihr_employee_portal_argument_age_group.inc
 files[] = views/includes/civihr_employee_portal_handler_absence_duration.inc
 files[] = views/includes/civihr_employee_portal_handler_activity_type.inc

--- a/civihr_employee_portal/src/Blocks/MyDetailsData.php
+++ b/civihr_employee_portal/src/Blocks/MyDetailsData.php
@@ -3,33 +3,45 @@
 namespace Drupal\civihr_employee_portal\Blocks;
 
 class MyDetailsData {
-    
-    public function generateBlock() {
-        
-        $contact_data = '';
-        
-        // If we have logged in user, get his details
-        if (isset($_SESSION['CiviCRM']['userID'])) {
-            $contact_data = get_civihr_contact_data($_SESSION['CiviCRM']['userID']);
 
-        }
+  public function generateBlock() {
 
-        // Get the contact details view
-        $contact_details = views_embed_view('my_details_block', 'my_details_block');
+    $contact_data = '';
 
-        // Get the address details view
-        $address_data = views_embed_view('my_details_block', 'my_address_block');
-        $address_data_title = t('Contact Information');
-
-        // Output the themed details block
-        return theme('civihr_employee_portal_my_details_block', 
-            array(
-                'contact_data' => $contact_data,
-                'contact_details' => $contact_details,
-                'address_data' => $address_data,
-                'address_data_title' => $address_data_title
-            )
-        );
-                
+    // If we have logged in user, get his details
+    if (isset($_SESSION['CiviCRM']['userID'])) {
+      $contact_data = get_civihr_contact_data($_SESSION['CiviCRM']['userID']);
     }
+
+    // Get the contact details view
+    $contact_details = views_embed_view('my_details_block', 'my_details_block');
+
+    // Get the address details view
+    $address_data = views_embed_view('my_details_block', 'my_address_block');
+    $address_data_title = t('Contact Information');
+
+    $emergencyContactsBlock = views_embed_view(
+      'emergency_contacts',
+      'non_dependant_emergency_contact'
+    );
+
+    $dependantsBlock = views_embed_view(
+      'emergency_contacts',
+      'dependant_emergency_contact'
+    );
+
+    // Output the themed details block
+    return theme('civihr_employee_portal_my_details_block',
+      [
+        'contact_data' => $contact_data,
+        'contact_details' => $contact_details,
+        'address_data' => $address_data,
+        'address_data_title' => $address_data_title,
+        'emergencyContactsBlock' => $emergencyContactsBlock,
+        'emergencyContactsTitle' => t('Emergency Contacts'),
+        'dependantsBlock' => $dependantsBlock,
+        'dependantsTitle' => t('Dependants')
+      ]
+    );
+  }
 }

--- a/civihr_employee_portal/src/Blocks/MyDetailsData.php
+++ b/civihr_employee_portal/src/Blocks/MyDetailsData.php
@@ -5,7 +5,6 @@ namespace Drupal\civihr_employee_portal\Blocks;
 class MyDetailsData {
 
   public function generateBlock() {
-
     $contact_data = '';
 
     // If we have logged in user, get his details

--- a/civihr_employee_portal/templates/civihr-employee-portal-my-details--block.tpl.php
+++ b/civihr_employee_portal/templates/civihr-employee-portal-my-details--block.tpl.php
@@ -1,29 +1,29 @@
 <?php
 
 /**
- * @file
- * Default theme implementation to display a block.
- *
- * Available variables:
- * - $block->subject: Block title.
- * - $content: Block content.
- * - $block->module: Module that generated the block.
- * - $block->delta: An ID for the block, unique within each module.
- * - $block->region: The block region embedding the current block.
- * - $classes: String of classes that can be used to style contextually through
- *   CSS. It can be manipulated through the variable $classes_array from
- *   preprocess functions. The default values can be one or more of the
- *   following:
- *   - block: The current template type, i.e., "theming hook".
- *   - block-[module]: The module generating the block. For example, the user
- *     module is responsible for handling the default user navigation block. In
- *     that case the class would be 'block-user'.
- * - $title_prefix (array): An array containing additional output populated by
- *   modules, intended to be displayed in front of the main title tag that
- *   appears in the template.
- * - $title_suffix (array): An array containing additional output populated by
+ * @var string $address_data
+ *   The content of the "Contact Information" block
+ * @var string $address_data_title
+ *   The title of the "Contact Information" block
+ * @var string $contact_details
+ *   The content of the "My Details" block
+ * @var string $emergencyContactsBlock
+ *   The rendered content of the emergency contact block
+ * @var string $emergencyContactsTitle
+ *   The title for the emergency contact block
+ * @var string $dependantsBlock
+ *   The rendered content of the dependants block
+ * @var string $dependantsTitle
+ *   The title for the dependants block
+ * @var array $title_prefix
+ *   An array containing additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * @var array $title_suffix
+ *   An array containing additional output populated by
  *   modules, intended to be displayed after the main title tag that appears in
  *   the template.
+ * @var string $attributes
+ *   Attributes for the block
  *
  * Helper variables:
  * - $classes_array: Array of html class attribute values. It is flattened
@@ -36,58 +36,56 @@
  * - $logged_in: Flags true when the current user is a logged-in member.
  * - $is_admin: Flags true when the current user is an administrator.
  * - $block_html_id: A valid HTML ID and guaranteed unique.
- *
- * @see template_preprocess()
- * @see template_preprocess_block()
- * @see template_process()
- *
- * @ingroup themeable
  */
 
-?>
+global $user; // Show only if we have the logged in user
+$actionsClasses = 'ctools-use-modal ctools-modal-civihr-custom-style chr_action--icon--edit';
 
-<?php
-    global $user; // Show only if we have the logged in user
-
-    $actions_classes = 'ctools-use-modal ctools-modal-civihr-custom-style chr_action--icon--edit';
-
-    if ($user->uid) {
+if (!$user->uid) {
+  return '';
+}
 ?>
 
 <div class="<?php print $classes; ?>"<?php print $attributes; ?>>
-    <div class="row relative">
-        <div class="col-md-2">
-            <div class="chr_profile-card hidden-xs hidden-sm">
-                <div class="chr_profile-card__picture">
-                    <?php if (isset($contact_data['image_URL']) && !empty($contact_data['image_URL'])) { ?>
-                        <img src="<?php print $contact_data['image_URL']; ?>" />
-                    <?php } else { ?>
-                        <img src="<?php print drupal_get_path('module', 'civihr_employee_portal') . '/images/profile-default.png' ?>"/>
-                    <?php } ?>
-                </div>
-            </div>
+  <div class="row relative">
+    <div class="col-md-2">
+      <div class="chr_profile-card hidden-xs hidden-sm">
+        <div class="chr_profile-card__picture">
+          <?php if (isset($contact_data['image_URL']) && !empty($contact_data['image_URL'])) { ?>
+            <img src="<?php print $contact_data['image_URL']; ?>"/>
+          <?php } else { ?>
+            <img
+              src="<?php print drupal_get_path('module', 'civihr_employee_portal') . '/images/profile-default.png' ?>"/>
+          <?php } ?>
         </div>
-        <div class="col-md-5 chr_panel--my-details__data-group">
-            <h5 class="chr_panel--my-details__data-group__title"><?php print t('My Details'); ?></h5>
-            <div class="chr_panel--my-details__data-group__content">
-                <?php print $contact_details; ?>
-            </div>
-        </div>
-        <div class="col-md-offset-7 vertical-splitter hidden-xs hidden-sm"></div>
-        <div class="col-md-5 chr_panel--my-details__data-group">
-            <h5 class="chr_panel--my-details__data-group__title"><?php print $address_data_title ?></h5>
-            <div class="chr_panel--my-details__data-group__content">
-                <?php print $address_data; ?>
-            </div>
-        </div>
+      </div>
     </div>
-    <div class="chr_panel__footer">
-        <div class="chr_actions-wrapper">
-            <?php print l(t('Edit my details'), 'my_details/nojs/view', array('attributes' => array('class' => $actions_classes))); ?>
-            <?php print l(t('Edit emergency contact'), 'emergency_contacts/nojs/view', array('attributes' => array('class' => $actions_classes))); ?>
-        </div>
+    <div class="col-md-5 chr_panel--my-details__data-group">
+      <h5
+        class="chr_panel--my-details__data-group__title"><?php print t('My Details'); ?></h5>
+      <div class="chr_panel--my-details__data-group__content">
+        <?php print $contact_details; ?>
+      </div>
     </div>
+    <div class="col-md-offset-7 vertical-splitter hidden-xs hidden-sm"></div>
+    <div class="col-md-5 chr_panel--my-details__data-group">
+      <h5
+        class="chr_panel--my-details__data-group__title"><?php print $address_data_title ?></h5>
+      <div class="chr_panel--my-details__data-group__content">
+        <?php print $address_data; ?>
+      </div>
+    </div>
+  </div>
+  <div class="chr_panel__footer">
+    <div class="chr_actions-wrapper">
+      <?php print l(t('Edit my details'), 'my_details/nojs/view', array('attributes' => array('class' => $actionsClasses))); ?>
+      <?php print l(t('Edit emergency contact'), 'emergency_contacts/nojs/view', array('attributes' => array('class' => $actionsClasses))); ?>
+    </div>
+  </div>
 </div>
-<?php
-    }
-?>
+
+<h2><?php print $emergencyContactsTitle; ?></h2>
+<?php print $emergencyContactsBlock; ?>
+
+<h2><?php print $dependantsTitle; ?></h2>
+<?php print $dependantsBlock; ?>

--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -867,6 +867,15 @@ function civihr_employee_portal_views_data_alter(&$data) {
     ]
   ];
 
+  // Emergency contact aggregated address
+  $data['civicrm_value_emergency_contacts_21']['emergency_contact_aggregated_address'] = [
+    'title' => t('Aggregated Emergency Contact Address'),
+    'help' => t('Displays aggregated address for the emergency contact'),
+    'field' => [
+      'handler' => 'civihr_employee_portal_handler_emergency_contact_aggregated_address',
+    ],
+  ];
+
   $data['hrjc_contact_details']['work_email']['field']['handler'] = 'civihr_employee_portal_handler_email';
 
   /**

--- a/civihr_employee_portal/views/includes/civihr_employee_portal_handler_emergency_contact_aggregated_address.inc
+++ b/civihr_employee_portal/views/includes/civihr_employee_portal_handler_emergency_contact_aggregated_address.inc
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * Handles aggregation of emergency contact address fields
+ */
+class civihr_employee_portal_handler_emergency_contact_aggregated_address extends views_handler_field {
+
+  /**
+   * @inheritdoc
+   */
+  public function render($values) {
+    $id = isset($values->id) ? (int) $values->id : NULL;
+
+    if (!$id) {
+      return '';
+    }
+
+    $addressFields = [
+      "Street_Address",
+      "Street_Address_Line_2",
+      "Province",
+      "City",
+      "Postal_Code",
+      "Country"
+    ];
+
+    $fieldMapping = $this->getFieldMapping($addressFields);
+    $result = $this->fetchEntityValues($fieldMapping, $id);
+    $result = $this->replaceCountryIDWithName($fieldMapping, $result);
+    $result = $this->replaceProvinceIDWithName($fieldMapping, $result);
+
+    return implode(', ', $result);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function query() {
+    // override default behaviour as this handler is not tied to a single field
+  }
+
+  /**
+   * Fetch the custom field column names and sort by original order.
+   *
+   * @param array $addressFields
+   *
+   * @return array
+   */
+  private function getFieldMapping($addressFields) {
+    $params = [
+      'custom_group_id' => "Emergency_Contacts",
+      'name' => [
+        'IN' => $addressFields
+      ],
+    ];
+
+    $fields = civicrm_api3('CustomField', 'get', $params);
+    $fields = array_column($fields['values'], 'column_name', 'name');
+
+    $sortedFields = [];
+    foreach ($addressFields as $addressField) {
+      $sortedFields[$addressField] = $fields[$addressField];
+    }
+
+    return $sortedFields;
+  }
+
+  /**
+   * Query the database for the custom entity values.
+   * This is not suitable for an API call because the CustomValue API is broken
+   * and does not respect "ID" in parameters.
+   *
+   * @param array $fieldMapping
+   * @param int $id
+   *
+   * @return array
+   */
+  private function fetchEntityValues($fieldMapping, $id) {
+    $table = $this->view->base_table;
+    $selectFields = implode(', ', $fieldMapping);
+    $format = 'SELECT %s FROM `%s` WHERE id = %d';
+    $query = sprintf($format, $selectFields, $table, $id);
+    $result = CRM_Core_DAO::executeQuery($query);
+    $result = current($result->fetchAll());
+
+    return array_filter($result);
+  }
+
+  /**
+   * @param array $fieldMapping
+   * @param array $result
+   *
+   * @return array
+   */
+  private function replaceCountryIDWithName($fieldMapping, $result) {
+    $countryColumn = $fieldMapping['Country'];
+
+    if (!empty($result[$countryColumn])) {
+      $countryName = CRM_Core_BAO_Country::getFieldValue(
+        CRM_Core_BAO_Country::class,
+        $result[$countryColumn]
+      );
+      $result[$countryColumn] = $countryName;
+    }
+
+    return $result;
+  }
+
+  /**
+   * @param array $fieldMapping
+   * @param array $result
+   *
+   * @return array
+   */
+  private function replaceProvinceIDWithName($fieldMapping, $result) {
+    $provinceColumn = $fieldMapping['Province'];
+    if (!empty($result[$provinceColumn])) {
+      $provinceName = CRM_Core_DAO_StateProvince::getFieldValue(
+        CRM_Core_DAO_StateProvince::class,
+        $result[$provinceColumn]
+      );
+      $result[$provinceColumn] = $provinceName;
+    }
+
+    return $result;
+  }
+
+}

--- a/civihr_employee_portal/views/includes/civihr_employee_portal_handler_emergency_contact_aggregated_address.inc
+++ b/civihr_employee_portal/views/includes/civihr_employee_portal_handler_emergency_contact_aggregated_address.inc
@@ -16,12 +16,12 @@ class civihr_employee_portal_handler_emergency_contact_aggregated_address extend
     }
 
     $addressFields = [
-      "Street_Address",
-      "Street_Address_Line_2",
-      "Province",
-      "City",
-      "Postal_Code",
-      "Country"
+      'Street_Address',
+      'Street_Address_Line_2',
+      'Province',
+      'City',
+      'Postal_Code',
+      'Country'
     ];
 
     $fieldMapping = $this->getFieldMapping($addressFields);
@@ -48,7 +48,7 @@ class civihr_employee_portal_handler_emergency_contact_aggregated_address extend
    */
   private function getFieldMapping($addressFields) {
     $params = [
-      'custom_group_id' => "Emergency_Contacts",
+      'custom_group_id' => 'Emergency_Contacts',
       'name' => [
         'IN' => $addressFields
       ],
@@ -87,6 +87,8 @@ class civihr_employee_portal_handler_emergency_contact_aggregated_address extend
   }
 
   /**
+   * Checks for the country ID and replaces it with the country name.
+   *
    * @param array $fieldMapping
    * @param array $result
    *
@@ -107,6 +109,8 @@ class civihr_employee_portal_handler_emergency_contact_aggregated_address extend
   }
 
   /**
+   * Checks for the province ID and replaces it with the country name.
+   *
    * @param array $fieldMapping
    * @param array $result
    *

--- a/civihr_employee_portal/views/views_export/emergency_contacts.inc
+++ b/civihr_employee_portal/views/views_export/emergency_contacts.inc
@@ -1,0 +1,144 @@
+<?php
+
+$view = new view();
+$view->name = 'emergency_contacts';
+$view->description = '';
+$view->tag = 'default';
+$view->base_table = 'civicrm_value_emergency_contacts_21';
+$view->human_name = 'Emergency Contacts';
+$view->core = 7;
+$view->api_version = '3.0';
+$view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
+
+/* Display: Master */
+$handler = $view->new_display('default', 'Master', 'default');
+$handler->display->display_options['use_more_always'] = FALSE;
+$handler->display->display_options['access']['type'] = 'none';
+$handler->display->display_options['cache']['type'] = 'none';
+$handler->display->display_options['query']['type'] = 'views_query';
+$handler->display->display_options['exposed_form']['type'] = 'basic';
+$handler->display->display_options['pager']['type'] = 'full';
+$handler->display->display_options['style_plugin'] = 'table';
+$handler->display->display_options['style_options']['columns'] = array(
+  'name_80' => 'name_80',
+);
+$handler->display->display_options['style_options']['default'] = '-1';
+$handler->display->display_options['style_options']['info'] = array(
+  'name_80' => array(
+    'sortable' => 0,
+    'default_sort_order' => 'asc',
+    'align' => '',
+    'separator' => '',
+    'empty_column' => 0,
+  ),
+);
+/* Field: CiviCRM Custom: Emergency Contacts: Emergency Contact ID */
+$handler->display->display_options['fields']['id']['id'] = 'id';
+$handler->display->display_options['fields']['id']['table'] = 'civicrm_value_emergency_contacts_21';
+$handler->display->display_options['fields']['id']['field'] = 'id';
+$handler->display->display_options['fields']['id']['label'] = '';
+$handler->display->display_options['fields']['id']['exclude'] = TRUE;
+$handler->display->display_options['fields']['id']['element_label_colon'] = FALSE;
+/* Field: CiviCRM Custom: Emergency Contacts: Entity ID */
+$handler->display->display_options['fields']['entity_id']['id'] = 'entity_id';
+$handler->display->display_options['fields']['entity_id']['table'] = 'civicrm_value_emergency_contacts_21';
+$handler->display->display_options['fields']['entity_id']['field'] = 'entity_id';
+$handler->display->display_options['fields']['entity_id']['label'] = '';
+$handler->display->display_options['fields']['entity_id']['exclude'] = TRUE;
+$handler->display->display_options['fields']['entity_id']['element_label_colon'] = FALSE;
+/* Field: CiviCRM Custom: Emergency Contacts: Name */
+$handler->display->display_options['fields']['name_80']['id'] = 'name_80';
+$handler->display->display_options['fields']['name_80']['table'] = 'civicrm_value_emergency_contacts_21';
+$handler->display->display_options['fields']['name_80']['field'] = 'name_80';
+/* Field: CiviCRM Custom: Emergency Contacts: Mobile number */
+$handler->display->display_options['fields']['mobile_number_91']['id'] = 'mobile_number_91';
+$handler->display->display_options['fields']['mobile_number_91']['table'] = 'civicrm_value_emergency_contacts_21';
+$handler->display->display_options['fields']['mobile_number_91']['field'] = 'mobile_number_91';
+$handler->display->display_options['fields']['mobile_number_91']['label'] = 'Mobile Number';
+/* Field: CiviCRM Custom: Emergency Contacts: Phone number */
+$handler->display->display_options['fields']['phone_number_81']['id'] = 'phone_number_81';
+$handler->display->display_options['fields']['phone_number_81']['table'] = 'civicrm_value_emergency_contacts_21';
+$handler->display->display_options['fields']['phone_number_81']['field'] = 'phone_number_81';
+$handler->display->display_options['fields']['phone_number_81']['label'] = 'Phone Number';
+/* Field: CiviCRM Custom: Emergency Contacts: Email */
+$handler->display->display_options['fields']['email_82']['id'] = 'email_82';
+$handler->display->display_options['fields']['email_82']['table'] = 'civicrm_value_emergency_contacts_21';
+$handler->display->display_options['fields']['email_82']['field'] = 'email_82';
+$handler->display->display_options['fields']['email_82']['label'] = 'Primary Email';
+/* Field: CiviCRM Custom: Emergency Contacts: Aggregated Emergency Contact Address */
+$handler->display->display_options['fields']['emergency_contact_aggregated_address']['id'] = 'emergency_contact_aggregated_address';
+$handler->display->display_options['fields']['emergency_contact_aggregated_address']['table'] = 'civicrm_value_emergency_contacts_21';
+$handler->display->display_options['fields']['emergency_contact_aggregated_address']['field'] = 'emergency_contact_aggregated_address';
+$handler->display->display_options['fields']['emergency_contact_aggregated_address']['label'] = 'Address';
+/* Field: CiviCRM Custom: Emergency Contacts: Relationship with Employee */
+$handler->display->display_options['fields']['relationship_with_employee_83']['id'] = 'relationship_with_employee_83';
+$handler->display->display_options['fields']['relationship_with_employee_83']['table'] = 'civicrm_value_emergency_contacts_21';
+$handler->display->display_options['fields']['relationship_with_employee_83']['field'] = 'relationship_with_employee_83';
+/* Field: CiviCRM Custom: Emergency Contacts: Notes */
+$handler->display->display_options['fields']['notes_84']['id'] = 'notes_84';
+$handler->display->display_options['fields']['notes_84']['table'] = 'civicrm_value_emergency_contacts_21';
+$handler->display->display_options['fields']['notes_84']['field'] = 'notes_84';
+/* Field: CiviCRM Custom: Emergency Contacts: Is a Dependant? */
+$handler->display->display_options['fields']['dependant_s__92']['id'] = 'dependant_s__92';
+$handler->display->display_options['fields']['dependant_s__92']['table'] = 'civicrm_value_emergency_contacts_21';
+$handler->display->display_options['fields']['dependant_s__92']['field'] = 'dependant_s__92';
+$handler->display->display_options['fields']['dependant_s__92']['label'] = '';
+$handler->display->display_options['fields']['dependant_s__92']['exclude'] = TRUE;
+$handler->display->display_options['fields']['dependant_s__92']['element_label_colon'] = FALSE;
+/* Filter criterion: Global: Combine fields filter */
+$handler->display->display_options['filters']['combine']['id'] = 'combine';
+$handler->display->display_options['filters']['combine']['table'] = 'views';
+$handler->display->display_options['filters']['combine']['field'] = 'combine';
+$handler->display->display_options['filters']['combine']['value'] = 'No';
+$handler->display->display_options['filters']['combine']['group'] = 1;
+$handler->display->display_options['filters']['combine']['fields'] = array(
+  'dependant_s__92' => 'dependant_s__92',
+);
+
+/* Display: Non Dependant Emergency Contacts */
+$handler = $view->new_display('block', 'Non Dependant Emergency Contacts', 'block_1');
+$handler->display->display_options['display_description'] = 'A list of emergency contacts where the "dependant" flag is false';
+
+/* Display: Dependant Emergency Contacts */
+$handler = $view->new_display('block', 'Dependant Emergency Contacts', 'block_2');
+$handler->display->display_options['display_description'] = 'A list of emergency contacts where the "dependant" flag is true';
+$handler->display->display_options['defaults']['filter_groups'] = FALSE;
+$handler->display->display_options['defaults']['filters'] = FALSE;
+/* Filter criterion: Global: Combine fields filter */
+$handler->display->display_options['filters']['combine']['id'] = 'combine';
+$handler->display->display_options['filters']['combine']['table'] = 'views';
+$handler->display->display_options['filters']['combine']['field'] = 'combine';
+$handler->display->display_options['filters']['combine']['value'] = 'Yes';
+$handler->display->display_options['filters']['combine']['group'] = 1;
+$handler->display->display_options['filters']['combine']['fields'] = array(
+  'dependant_s__92' => 'dependant_s__92',
+);
+$translatables['emergency_contacts'] = array(
+  t('Master'),
+  t('more'),
+  t('Apply'),
+  t('Reset'),
+  t('Sort by'),
+  t('Asc'),
+  t('Desc'),
+  t('Items per page'),
+  t('- All -'),
+  t('Offset'),
+  t('« first'),
+  t('‹ previous'),
+  t('next ›'),
+  t('last »'),
+  t('.'),
+  t(','),
+  t('Name'),
+  t('Mobile Number'),
+  t('Phone Number'),
+  t('Primary Email'),
+  t('Address'),
+  t('Relationship with Employee'),
+  t('Notes'),
+  t('Non Dependant Emergency Contacts'),
+  t('A list of emergency contacts where the "dependant" flag is false'),
+  t('Dependant Emergency Contacts'),
+  t('A list of emergency contacts where the "dependant" flag is true'),
+);

--- a/civihr_employee_portal/views/views_export/views_emergency_contacts.inc
+++ b/civihr_employee_portal/views/views_export/views_emergency_contacts.inc
@@ -96,11 +96,11 @@ $handler->display->display_options['filters']['combine']['fields'] = array(
 );
 
 /* Display: Non Dependant Emergency Contacts */
-$handler = $view->new_display('block', 'Non Dependant Emergency Contacts', 'block_1');
+$handler = $view->new_display('block', 'Non Dependant Emergency Contacts', 'non_dependant_emergency_contact');
 $handler->display->display_options['display_description'] = 'A list of emergency contacts where the "dependant" flag is false';
 
 /* Display: Dependant Emergency Contacts */
-$handler = $view->new_display('block', 'Dependant Emergency Contacts', 'block_2');
+$handler = $view->new_display('block', 'Dependant Emergency Contacts', 'dependant_emergency_contact');
 $handler->display->display_options['display_description'] = 'A list of emergency contacts where the "dependant" flag is true';
 $handler->display->display_options['defaults']['filter_groups'] = FALSE;
 $handler->display->display_options['defaults']['filters'] = FALSE;
@@ -113,6 +113,7 @@ $handler->display->display_options['filters']['combine']['group'] = 1;
 $handler->display->display_options['filters']['combine']['fields'] = array(
   'dependant_s__92' => 'dependant_s__92',
 );
+$handler->display->display_options['block_description'] = 'dependant_emergency_contact';
 $translatables['emergency_contacts'] = array(
   t('Master'),
   t('more'),
@@ -139,6 +140,8 @@ $translatables['emergency_contacts'] = array(
   t('Notes'),
   t('Non Dependant Emergency Contacts'),
   t('A list of emergency contacts where the "dependant" flag is false'),
+  t('non_dependant_emergency_contact'),
   t('Dependant Emergency Contacts'),
   t('A list of emergency contacts where the "dependant" flag is true'),
+  t('dependant_emergency_contact'),
 );


### PR DESCRIPTION
## Overview

To display the emergency contacts and dependants to the user we need to create a view with two displays.

## Before

There was no view for emergency contacts. The `/hr-details` page did not show emergency contacts or dependants.

![image](https://user-images.githubusercontent.com/6374064/32496230-6c1f730c-c3c0-11e7-9c37-d917ea6cdb62.png)

## After

The `/hr-details` page shows both emergency contacts and dependants.

![image](https://user-images.githubusercontent.com/6374064/32496182-40a3d8b2-c3c0-11e7-9469-12bf68502f33.png)

---

- [x] Tests Pass
