### PR TITLE
PCHR-2852: Minor Fixes

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.install
+++ b/civihr_employee_portal/civihr_employee_portal.install
@@ -1,5 +1,7 @@
 <?php
 
+use Drupal\civihr_employee_portal\Helpers\WebformHelper;
+
 /**
  * Create Report Pages and Report Age Settings menu links.
  */
@@ -221,6 +223,19 @@ function civihr_employee_portal_update_7010() {
       break;
     }
   }
+}
+
+/**
+ * Removes the "Emergency contact - edit" webform
+ */
+function civihr_employee_portal_update_7011() {
+  $node = WebformHelper::findOneByTitle('Emergency contact - edit');
+
+  if (!$node) {
+    return;
+  }
+
+  node_delete($node->nid);
 }
 
 /**

--- a/civihr_employee_portal/src/Blocks/MyDetailsData.php
+++ b/civihr_employee_portal/src/Blocks/MyDetailsData.php
@@ -19,16 +19,6 @@ class MyDetailsData {
     $address_data = views_embed_view('my_details_block', 'my_address_block');
     $address_data_title = t('Contact Information');
 
-    $emergencyContactsBlock = views_embed_view(
-      'emergency_contacts',
-      'non_dependant_emergency_contact'
-    );
-
-    $dependantsBlock = views_embed_view(
-      'emergency_contacts',
-      'dependant_emergency_contact'
-    );
-
     // Output the themed details block
     return theme('civihr_employee_portal_my_details_block',
       [
@@ -36,10 +26,6 @@ class MyDetailsData {
         'contact_details' => $contact_details,
         'address_data' => $address_data,
         'address_data_title' => $address_data_title,
-        'emergencyContactsBlock' => $emergencyContactsBlock,
-        'emergencyContactsTitle' => t('Emergency Contacts'),
-        'dependantsBlock' => $dependantsBlock,
-        'dependantsTitle' => t('Dependants')
       ]
     );
   }

--- a/civihr_employee_portal/templates/civihr-employee-portal-my-details--block.tpl.php
+++ b/civihr_employee_portal/templates/civihr-employee-portal-my-details--block.tpl.php
@@ -79,13 +79,6 @@ if (!$user->uid) {
   <div class="chr_panel__footer">
     <div class="chr_actions-wrapper">
       <?php print l(t('Edit my details'), 'my_details/nojs/view', array('attributes' => array('class' => $actionsClasses))); ?>
-      <?php print l(t('Edit emergency contact'), 'emergency_contacts/nojs/view', array('attributes' => array('class' => $actionsClasses))); ?>
     </div>
   </div>
 </div>
-
-<h2><?php print $emergencyContactsTitle; ?></h2>
-<?php print $emergencyContactsBlock; ?>
-
-<h2><?php print $dependantsTitle; ?></h2>
-<?php print $dependantsBlock; ?>

--- a/civihr_employee_portal/views/includes/civihr_employee_portal_handler_emergency_contact_aggregated_address.inc
+++ b/civihr_employee_portal/views/includes/civihr_employee_portal_handler_emergency_contact_aggregated_address.inc
@@ -18,9 +18,9 @@ class civihr_employee_portal_handler_emergency_contact_aggregated_address extend
     $addressFields = [
       'Street_Address',
       'Street_Address_Line_2',
-      'Province',
       'City',
       'Postal_Code',
+      'Province',
       'Country'
     ];
 


### PR DESCRIPTION
## Overview

This PR combines a few minor planned fixes with some fixes that were discovered during the course of development.

## Before

- "Edit Emergency Contact" button appeared on /dashboard and /hr-details
- "Edit emergency contact" webform was still available
- "Emergency contact" and "dependants" displays were appearing in all "my details" blocks, not just on `/hr-details` as expected
- The emergency contact address order did not match the contact address order from `/dashboard`

![image](https://user-images.githubusercontent.com/6374064/32509258-b6f9c9e4-c3e4-11e7-9131-aa5706127c8e.png)

## After

- "Edit Emergency Contact" button does not appear on /dashboard and /hr-details
- "Edit emergency contact" webform is deleted
- "Emergency contact" and "dependants" displays appear under the "my details" block on `/hr-details` only

![image](https://user-images.githubusercontent.com/6374064/32509173-7bbb1018-c3e4-11e7-823a-aaa994cab0ac.png)

- The emergency contact address order now matches the contact address order from `/dashboard`

![image](https://user-images.githubusercontent.com/6374064/32509277-c5fddd90-c3e4-11e7-8978-086d6f13e6d9.png)

---

- [x] Tests Pass
