### PR TITLE
PCHR-2927: My Details Contract Filter Fix

### DIFF
--- a/civihr_employee_portal/src/View/AbstractView.php
+++ b/civihr_employee_portal/src/View/AbstractView.php
@@ -2,15 +2,25 @@
 
 namespace Drupal\civihr_employee_portal\View;
 
+/**
+ * Contains methods common to views. Extend to encapsulate functionality
+ * specific to certain views, such as what code should be executed for certain
+ * view hooks.
+ */
 abstract class AbstractView {
 
+  /**
+   * This should be defined in child classes.
+   *
+   * @var string|NULL
+   */
   protected static $name = NULL;
 
   /**
    * @param \view $view
    * @param \views_plugin_query_default $query
    */
-  public function alter(&$view, &$query) {
+  public function alter($view, $query) {
     // do nothing
   }
 

--- a/civihr_employee_portal/src/View/AbstractView.php
+++ b/civihr_employee_portal/src/View/AbstractView.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Drupal\civihr_employee_portal\View;
+
+abstract class AbstractView {
+
+  protected static $name = NULL;
+
+  /**
+   * @param \view $view
+   * @param \views_plugin_query_default $query
+   */
+  public function alter(&$view, &$query) {
+    // do nothing
+  }
+
+  /**
+   * @return string
+   */
+  public static function getName() {
+    if (NULL === static::$name) {
+      throw new \Exception(sprintf('Please define $name in %s', static::class));
+    }
+
+    return static::$name;
+  }
+
+  /**
+   * Takes the where part of a query and returns an array of fields => values
+   *
+   * @param mixed $part
+   *  The $query->where part
+   * @param array $fields
+   *  An array to store the fields
+   */
+  public function getWhereFields($part, &$fields) {
+    if (isset($part['conditions'])) {
+      $part = $part['conditions'];
+    }
+    if (isset($part['field']) && $part['field'] instanceof \DatabaseCondition) {
+      $part = $part['field']->conditions();
+    }
+
+    if (isset($part['field'])) {
+      $fields[$part['field']] = $part['value'];
+    }
+    elseif (is_array($part)) {
+      foreach ($part as $item) {
+        $this->getWhereFields($item, $fields);
+      }
+    }
+  }
+}

--- a/civihr_employee_portal/src/View/MyDetailsView.php
+++ b/civihr_employee_portal/src/View/MyDetailsView.php
@@ -16,7 +16,7 @@ class MyDetailsView extends AbstractView {
    *
    * @inheritdoc
    */
-  public function alter(&$view, &$query) {
+  public function alter($view, $query) {
     // Only applies to my_details_block display
     if ($view->current_display !== self::$name) {
       return;
@@ -30,9 +30,7 @@ class MyDetailsView extends AbstractView {
     $roleRevisionID = $revision ? $revision['role_revision_id'] : 0;
     $detailsRevisionID = $revision ? $revision['details_revision_id'] : 0;
 
-    $revisionTable = 'hrjc_revision';
-    $contactTable = 'civicrm_contact';
-    $revisionAlias = sprintf('%s_%s', $revisionTable, $contactTable);
+    $revisionAlias = 'hrjc_revision_civicrm_contact';
 
     // Single condition for revision ID would be better, but revision ID does
     // not exist in hrjc_details
@@ -53,7 +51,7 @@ class MyDetailsView extends AbstractView {
       'contact_id' => $contactID,
     ]);
 
-    // God knows why but this result is a stdClass and count is always "1"
+    // God knows why but this result is a stdClass
     if (!isset($contract['values']->contract_id)) {
       return NULL;
     }
@@ -73,9 +71,9 @@ class MyDetailsView extends AbstractView {
    * @param string $field
    * @param int $id
    */
-  private function addJoinCondition(&$query, $joinAlias, $field, $id) {
+  private function addJoinCondition($query, $joinAlias, $field, $id) {
     $joinCondition = sprintf('%s.%s = %d', $joinAlias, $field, $id);
-    $join = &$query->table_queue[$joinAlias]['join'];
+    $join = $query->table_queue[$joinAlias]['join'];
 
     if (empty($join->extra)) {
       $join->extra = $joinCondition;

--- a/civihr_employee_portal/src/View/MyDetailsView.php
+++ b/civihr_employee_portal/src/View/MyDetailsView.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Drupal\civihr_employee_portal\View;
+
+class MyDetailsView extends AbstractView {
+
+  /**
+   * @var string
+   */
+  protected static $name = 'my_details_block';
+
+  /**
+   * This is responsible for altering the query for the my details block to
+   * use data from only active job contracts. It does this by adding an extra
+   * join condition on the job contract revision table.
+   *
+   * @inheritdoc
+   */
+  public function alter(&$view, &$query) {
+    // Only applies to my_details_block display
+    if ($view->current_display !== self::$name) {
+      return;
+    }
+
+    $currentContactID = \CRM_Core_Session::getLoggedInContactID();
+    $contractID = $this->getCurrentContractID($currentContactID);
+
+    // If no current contract then add an impossible join condition
+    $filterID = $contractID ? $contractID : 0;
+
+    $revisionTable = 'hrjc_revision';
+    $contactTable = 'civicrm_contact';
+    $joinAlias = sprintf('%s_%s', $revisionTable, $contactTable);
+    $joinCondition = sprintf('%s.jobcontract_id = %d', $joinAlias, $filterID);
+
+    // Set the condition in the query
+    $join = &$query->table_queue[$joinAlias]['join'];
+    $join->extra = $joinCondition;
+  }
+
+  /**
+   * Gets the current contract ID for the given contact ID
+   *
+   * @param int $contactID
+   *
+   * @return int|null
+   */
+  private function getCurrentContractID($contactID) {
+    $result = civicrm_api3('HRJobContract', 'getcurrentcontract', [
+      'contact_id' => $contactID,
+    ]);
+
+    // God knows why but this result is a stdClass and count is always "1"
+    if (isset($result['values']->contract_id)) {
+      return $result['values']->contract_id;
+    }
+
+    return NULL;
+  }
+}

--- a/civihr_employee_portal/src/View/StaffDirectoryView.php
+++ b/civihr_employee_portal/src/View/StaffDirectoryView.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\civihr_employee_portal\View;
+
+class StaffDirectoryView extends AbstractView {
+
+  /**
+   * @var string
+   */
+  protected static $name = 'civihr_staff_directory';
+
+  /**
+   * @inheritdoc
+   */
+  public function alter(&$view, &$query) {
+    $queryParts = [];
+    $this->getWhereFields($query->where, $queryParts);
+    $departmentField = 'hrjc_role_hrjc_revision.role_department';
+    $roleEndField = 'hrjc_role_hrjc_revision.role_end_date';
+
+    // if department is set we must limit to only current roles
+    if (!empty($queryParts[$departmentField])) {
+      $group = $query->set_where_group('OR'); // add a new WHERE group
+      $query->add_where($group, $roleEndField, date('Y-m-d'), '>=');
+      $query->add_where($group, $roleEndField, NULL, 'IS');
+    }
+  }
+}

--- a/civihr_employee_portal/src/View/StaffDirectoryView.php
+++ b/civihr_employee_portal/src/View/StaffDirectoryView.php
@@ -12,7 +12,7 @@ class StaffDirectoryView extends AbstractView {
   /**
    * @inheritdoc
    */
-  public function alter(&$view, &$query) {
+  public function alter($view, $query) {
     $queryParts = [];
     $this->getWhereFields($query->where, $queryParts);
     $departmentField = 'hrjc_role_hrjc_revision.role_department';

--- a/civihr_employee_portal/tests/HelperFunctionsTest.php
+++ b/civihr_employee_portal/tests/HelperFunctionsTest.php
@@ -32,7 +32,8 @@ class HelperFunctionsTest extends PHPUnit_Framework_TestCase {
 
   public function testGetWhereFields() {
     $parts = [];
-    getWhereFields($this->sampleWherePart, $parts);
+    $view = new \Drupal\civihr_employee_portal\View\MyDetailsView();
+    $view->getWhereFields($this->sampleWherePart, $parts);
     $expectedCount = 4;
     $this->assertCount($expectedCount, $parts);
     for ($i = 1; $i < $expectedCount + 1; $i++) {

--- a/civihr_employee_portal/tests/View/AbstractViewTest.php
+++ b/civihr_employee_portal/tests/View/AbstractViewTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__ . '/../views/civihr_employee_portal.views.inc';
+use Drupal\civihr_employee_portal\View\AbstractView;
 
 class HelperFunctionsTest extends PHPUnit_Framework_TestCase {
   protected $sampleWherePart = [
@@ -32,7 +32,7 @@ class HelperFunctionsTest extends PHPUnit_Framework_TestCase {
 
   public function testGetWhereFields() {
     $parts = [];
-    $view = new \Drupal\civihr_employee_portal\View\MyDetailsView();
+    $view = $this->getMockForAbstractClass(AbstractView::class);
     $view->getWhereFields($this->sampleWherePart, $parts);
     $expectedCount = 4;
     $this->assertCount($expectedCount, $parts);

--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -1092,12 +1092,10 @@ function civihr_employee_portal_views_query_alter(&$view, &$query) {
       $viewClass = new MyDetailsView();
       break;
     default:
-      $viewClass = NULL;
+      return;
   }
 
-  if ($viewClass) {
-    $viewClass->alter($view, $query);
-  }
+  $viewClass->alter($view, $query);
 }
 
 /**

--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -2,6 +2,9 @@
 
 // This file must be at civihr_employee_portal/views directory.
 
+use Drupal\civihr_employee_portal\View\StaffDirectoryView;
+use Drupal\civihr_employee_portal\View\MyDetailsView;
+
 /**
  * @file
  * Views definitions for civihr_employee_portal module.
@@ -1080,20 +1083,20 @@ function removeInactiveRoleDetails($results = []) {
  * @param views_plugin_query_default $query
  */
 function civihr_employee_portal_views_query_alter(&$view, &$query) {
-  if ($view->name !== 'civihr_staff_directory') {
-    return;
+
+  switch ($view->name) {
+    case StaffDirectoryView::getName():
+      $viewClass = new StaffDirectoryView();
+      break;
+    case MyDetailsView::getName():
+      $viewClass = new MyDetailsView();
+      break;
+    default:
+      $viewClass = NULL;
   }
 
-  $queryParts = [];
-  getWhereFields($query->where, $queryParts);
-  $departmentField = 'hrjc_role_hrjc_revision.role_department';
-  $roleEndField = 'hrjc_role_hrjc_revision.role_end_date';
-
-  // if department is set we must limit to only current roles
-  if (!empty($queryParts[$departmentField])) {
-    $group = $query->set_where_group('OR'); // add a new WHERE group
-    $query->add_where($group, $roleEndField, date('Y-m-d'), '>=');
-    $query->add_where($group, $roleEndField, NULL, 'IS');
+  if ($viewClass) {
+    $viewClass->alter($view, $query);
   }
 }
 
@@ -1119,29 +1122,3 @@ function civihr_employee_portal_views_pre_view(&$view, &$display_id, &$args) {
     );
   }
 }
-
-/**
- * Takes the where part of a query and returns an array of fields => values
- *
- * @param mixed $part
- *  The $query->where part
- * @param array $fields
- *  An array to store the fields
- */
-function getWhereFields($part, &$fields) {
-  if (isset($part['conditions'])) {
-    $part = $part['conditions'];
-  }
-  if (isset($part['field']) && $part['field'] instanceof DatabaseCondition) {
-    $part = $part['field']->conditions();
-  }
-
-  if (isset($part['field'])) {
-    $fields[$part['field']] = $part['value'];
-  }
-  elseif (is_array($part)) {
-    foreach ($part as $item) {
-      getWhereFields($item, $fields);
-    }
-  }
-};

--- a/civihr_employee_portal/views/views_export/views_my_details_block.inc
+++ b/civihr_employee_portal/views/views_export/views_my_details_block.inc
@@ -164,45 +164,6 @@ $handler->display->display_options['fields']['role_department']['field'] = 'role
 $handler->display->display_options['fields']['role_department']['relationship'] = 'role_jobcontract_id';
 $handler->display->display_options['fields']['role_department']['label'] = 'Role Department';
 $handler->display->display_options['defaults']['arguments'] = FALSE;
-/* Contextual filter: HRJobContract Details entity: Period start date */
-$handler->display->display_options['arguments']['period_start_date']['id'] = 'period_start_date';
-$handler->display->display_options['arguments']['period_start_date']['table'] = 'hrjc_details';
-$handler->display->display_options['arguments']['period_start_date']['field'] = 'period_start_date';
-$handler->display->display_options['arguments']['period_start_date']['relationship'] = 'details_revision_id';
-$handler->display->display_options['arguments']['period_start_date']['default_action'] = 'default';
-$handler->display->display_options['arguments']['period_start_date']['default_argument_type'] = 'php';
-$handler->display->display_options['arguments']['period_start_date']['default_argument_options']['code'] = 'return date(\'Y-m-d\');';
-$handler->display->display_options['arguments']['period_start_date']['summary']['number_of_records'] = '0';
-$handler->display->display_options['arguments']['period_start_date']['summary']['format'] = 'default_summary';
-$handler->display->display_options['arguments']['period_start_date']['summary_options']['items_per_page'] = '25';
-$handler->display->display_options['arguments']['period_start_date']['civihr_range'] = '<=';
-$handler->display->display_options['arguments']['period_start_date']['civihr_range_empty'] = '1';
-/* Contextual filter: HRJobContract Details entity: Period end date */
-$handler->display->display_options['arguments']['period_end_date']['id'] = 'period_end_date';
-$handler->display->display_options['arguments']['period_end_date']['table'] = 'hrjc_details';
-$handler->display->display_options['arguments']['period_end_date']['field'] = 'period_end_date';
-$handler->display->display_options['arguments']['period_end_date']['relationship'] = 'details_revision_id';
-$handler->display->display_options['arguments']['period_end_date']['default_action'] = 'default';
-$handler->display->display_options['arguments']['period_end_date']['default_argument_type'] = 'php';
-$handler->display->display_options['arguments']['period_end_date']['default_argument_options']['code'] = 'return date(\'Y-m-d\');';
-$handler->display->display_options['arguments']['period_end_date']['summary']['number_of_records'] = '0';
-$handler->display->display_options['arguments']['period_end_date']['summary']['format'] = 'default_summary';
-$handler->display->display_options['arguments']['period_end_date']['summary_options']['items_per_page'] = '25';
-$handler->display->display_options['arguments']['period_end_date']['civihr_range'] = '>=';
-$handler->display->display_options['arguments']['period_end_date']['civihr_range_empty'] = '1';
-/* Contextual filter: HRJobContract Revision entity: Effective_end_date */
-$handler->display->display_options['arguments']['effective_end_date']['id'] = 'effective_end_date';
-$handler->display->display_options['arguments']['effective_end_date']['table'] = 'hrjc_revision';
-$handler->display->display_options['arguments']['effective_end_date']['field'] = 'effective_end_date';
-$handler->display->display_options['arguments']['effective_end_date']['relationship'] = 'hrjc_revision';
-$handler->display->display_options['arguments']['effective_end_date']['default_action'] = 'default';
-$handler->display->display_options['arguments']['effective_end_date']['default_argument_type'] = 'php';
-$handler->display->display_options['arguments']['effective_end_date']['default_argument_options']['code'] = 'return date(\'Y-m-d\');';
-$handler->display->display_options['arguments']['effective_end_date']['summary']['number_of_records'] = '0';
-$handler->display->display_options['arguments']['effective_end_date']['summary']['format'] = 'default_summary';
-$handler->display->display_options['arguments']['effective_end_date']['summary_options']['items_per_page'] = '25';
-$handler->display->display_options['arguments']['effective_end_date']['civihr_range'] = '>=';
-$handler->display->display_options['arguments']['effective_end_date']['civihr_range_empty'] = '1';
 
 /* Display: Contact Information */
 $handler = $view->new_display('block', 'Contact Information', 'my_address_block');


### PR DESCRIPTION
## Overview

The "my details" block uses filters for job contract and revision. These filters are problematic because if they don't match then nothing will be shown in the view at all.

## Before

The "my details" block used contextual filters for job contract and revision. Users without contracts only in the past or future would see no data at all on the "My Details" block on `/dashboard`.

![image](https://user-images.githubusercontent.com/6374064/33134091-b6e299dc-cf96-11e7-9215-e0ec7f5c3a8a.png)

## After

The contextual filters are gone, and the "My Details" block on `/dashboard` will always show basic info, as well as contract and role data for the current contract _if_ it is available.

![image](https://user-images.githubusercontent.com/6374064/33134102-be63050c-cf96-11e7-84ee-366eb6d4f8bb.png)

## Notes

I also moved some code out of the module file into a separate class to represent each view we have. This should help keep the module file smaller and improve encapsulation.

## Technical Details

This uses the `hook_views_query_alter` hook to change the query. By limiting the join on the contract revision table to join only on the current contract we can hide results for inactive contracts.

If there is no current contract an impossible join (jobcontact_id = 0) will be added:

```
LEFT JOIN {hrjc_revision} hrjc_revision_civicrm_contact 
ON civicrm_contact.id = hrjc_revision_civicrm_contact.contact_id 
AND (hrjc_revision_civicrm_contact.jobcontract_id = 0)
```

To restrict the view data to only the current contract revision it adds a conditional to the join. It would be a lot easier to do this using revision ID, but revision ID is not present in the view table. Instead of this it selects by details and role revision IDs to find a single revision record to join on:

```
LEFT JOIN {hrjc_revision} hrjc_revision_civicrm_contact 
ON civicrm_contact.id = hrjc_revision_civicrm_contact.contact_id 
AND (hrjc_revision_civicrm_contact.jobcontract_id = 22 
AND hrjc_revision_civicrm_contact.role_revision_id = 24 
AND hrjc_revision_civicrm_contact.details_revision_id = 25)
```

This ensures the view will always return data, but fields from inactive contracts will not be shown.

---

- [x] Tests Pass
