### PR TITLE
PCHR-2949: Avoid injection of Shoreditch assets in SSP

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -415,28 +415,6 @@ function _rebuild_view($viewName) {
 }
 
 /**
- * Get the module URL
- *
- * @param  string $moduleName <Module name>
- *
- * @return string             <Module url>
- */
-function getModuleUrl($moduleName) {
-  global $base_url;
-
-  $path = CRM_Core_Resources::singleton()->getUrl($moduleName);
-
-  // Need to do this to avoid some configurations issues
-  // Some environments return /sites/all/modules/civicrm
-  // And others return http://localhost:8900/sites/all/modules/civicrm
-  if (strstr($path, "$base_url/")) {
-    $path = explode("$base_url/", $path)[1];
-  }
-
-  return ltrim($path, '/');
-}
-
-/**
  * Implements hook_coreResourceList
  *
  * @param array $list
@@ -479,7 +457,6 @@ function civihr_employee_portal_init() {
 
     // Add our additional css libraries
     drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/css/custom.css");
-    drupal_add_css(getModuleUrl('org.civicrm.shoreditch') . 'css/bootstrap.css');
     drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/lib/sweetalert/sweetalert.css");
     drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/lib/tablesaw/tablesaw.css");
 

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -10,13 +10,9 @@ use Drupal\civihr_employee_portal\Forms\ContactForm;
  * Implements hook_css_alter().
  */
 function civihr_employee_portal_css_alter(&$css) {
-
-  // Remove defaults system messages css file.
   unset($css[drupal_get_path('module', 'system') . '/system.messages.css']);
 
-  // Removing unwanted css files from civicrm pages.
   if (_isCiviCRM()) {
-    // Multi-dimensional array containing module name and file path.
     $removeFiles = [
       ['module_name' => 'ctools', 'file_name' => '/css/ctools.css'],
       ['module_name' => 'date_api', 'file_name' => '/date.css'],
@@ -26,7 +22,7 @@ function civihr_employee_portal_css_alter(&$css) {
       ['module_name' => 'views_tooltip', 'file_name' => '/views_tooltip.css'],
       ['module_name' => 'tipsy', 'file_name' => '/stylesheets/tipsy.css'],
     ];
-    // Removes above files.
+
    _remove_resources($css, $removeFiles);
   }
 }
@@ -35,11 +31,11 @@ function civihr_employee_portal_css_alter(&$css) {
  * Implements hook_js_alter()
  */
 function civihr_employee_portal_js_alter(&$javascript) {
-
   global $user;
+
   $uf = get_civihr_uf_match_data($user->uid);
 
-  // Unset jcarousel on panel admin pages as it's causes infinite loops
+  // Unset jcarousel on panel admin pages as it  causes infinite loops
   // "admin/structure/pages"
   if (strpos(current_path(), 'admin/structure/pages') !== FALSE) {
     foreach ($javascript['settings']['data'] as $key => $value) {
@@ -54,16 +50,13 @@ function civihr_employee_portal_js_alter(&$javascript) {
 
   _setup_modals();
 
-  // Removing unwanted js files from civicrm pages.
   if (_isCiviCRM()) {
-
-    // Multi-dimensional array containing module name and file path.
     $removeFiles = [
       ['module_name' => 'tipsy', 'file_name' => '/javascripts/jquery.tipsy.js'],
       ['module_name' => 'tipsy', 'file_name' => '/javascripts/tipsy.js']
     ];
-    // Removes above files.
-     _remove_resources($javascript, $removeFiles);
+
+    _remove_resources($javascript, $removeFiles);
   }
 }
 
@@ -72,7 +65,6 @@ function civihr_employee_portal_js_alter(&$javascript) {
  *
  * @param array &$resourcesList variable contains all the references to loaded
  *   js/css array from alter.
- *
  * @param array $blacklist contains multi-dimensional array : module_name key
  *   as name of the contrib module from which we need to remove corresponding
  *   file using file_name key.
@@ -113,7 +105,7 @@ function _civihr_employee_portal_taxonomy_form_access_callback() {
  * to (HR Resource types) Vocabulary.
  *
  * @return bool
- * True if the user has access, false otherwise
+ *   True if the user has access, false otherwise
  */
 function _civihr_employee_portal_has_hr_resource_types_form_access() {
   $vocabularyNameLocationInURL = 3;
@@ -121,11 +113,7 @@ function _civihr_employee_portal_has_hr_resource_types_form_access() {
   $resourceTypesVocabularyID = taxonomy_vocabulary_machine_name_load('hr_resource_type')->vid;
   $hasHRResourceTypesAccess = ($vocabularyName == 'hr_resource_type') && user_access("edit terms in {$resourceTypesVocabularyID}");
 
-  if ($hasHRResourceTypesAccess) {
-    return true;
-  }
-
-  return false;
+  return $hasHRResourceTypesAccess;
 }
 
 /**
@@ -133,7 +121,6 @@ function _civihr_employee_portal_has_hr_resource_types_form_access() {
  *
  * @return bool
  *  Returns true when the current page is on CiviCRM.
- *
  */
 function _isCiviCRM() {
   return arg(0) == 'civicrm';
@@ -143,33 +130,33 @@ function _isCiviCRM() {
  * Sets up all the different type of ctools modals that are used on the site
  */
 function _setup_modals() {
-    $basic_modal = array(
-        'modalOptions' => array('opacity' => .5, 'background-color' => '#000'),
-        'animation' => 'fadeIn'
-    );
+  $basic_modal = [
+    'modalOptions' => ['opacity' => .5, 'background-color' => '#000'],
+    'animation' => 'fadeIn'
+  ];
 
-    $bootstrap_modal = array_replace_recursive($basic_modal, array(
-        'modalSize' => array('height' => 'auto', 'width' => 'auto'),
-        'modalTheme' => 'ctools_custom_modal_html',
-        'modalClass' => 'civihr-bootstrap'
-    ));
+  $bootstrap_modal = array_replace_recursive($basic_modal, [
+    'modalSize' => ['height' => 'auto', 'width' => 'auto'],
+    'modalTheme' => 'ctools_custom_modal_html',
+    'modalClass' => 'civihr-bootstrap'
+  ]);
 
-    $custom_modal = array_replace_recursive($basic_modal, array(
-        'modalSize' => array('height' => 'auto', 'width' => 'auto'),
-        'animation' => 'fadeIn',
-        'modalClass' => 'civihr-custom'
-    ));
+  $custom_modal = array_replace_recursive($basic_modal, [
+    'modalSize' => ['height' => 'auto', 'width' => 'auto'],
+    'animation' => 'fadeIn',
+    'modalClass' => 'civihr-custom'
+  ]);
 
-    $custom_modal__large = array_replace_recursive($custom_modal, array(
-        'modalClass' => 'civihr-custom--large'
-    ));
+  $custom_modal__large = array_replace_recursive($custom_modal, [
+    'modalClass' => 'civihr-custom--large'
+  ]);
 
-    drupal_add_js(array(
-        'civihr-default-style' => $basic_modal,
-        'civihr-bootstrap-style' => $bootstrap_modal,
-        'civihr-custom-style' => $custom_modal,
-        'civihr-custom-large-style' => $custom_modal__large
-    ), 'setting');
+  drupal_add_js([
+    'civihr-default-style' => $basic_modal,
+    'civihr-bootstrap-style' => $bootstrap_modal,
+    'civihr-custom-style' => $custom_modal,
+    'civihr-custom-large-style' => $custom_modal__large
+  ], 'setting');
 }
 
 /**
@@ -207,6 +194,7 @@ function _add_script_to_page($resources, $extension = NULL, $page = NULL, $scope
  */
 function _rebuild_appraisal_view() {
   $extensions = CRM_Core_PseudoConstant::getExtensions();
+
   if (!empty($extensions['uk.co.compucorp.civicrm.appraisals'])) {
     $civi_settings = parse_url(CIVICRM_DSN);
     $civi_db_name = trim($civi_settings['path'], '/');
@@ -218,7 +206,6 @@ function _rebuild_appraisal_view() {
               LEFT JOIN {$civi_db_name}.civicrm_appraisal_cycle ac ON ac.id = a.appraisal_cycle_id
               ORDER BY a.id ASC");
 
-    // Set to false so it will not rebuild until not asked to rebuild
     variable_set('rebuild_appraisal_view', 'FALSE');
   }
 }
@@ -228,6 +215,7 @@ function _rebuild_appraisal_view() {
  */
 function _rebuild_hrvacancy_view() {
   $extensions = CRM_Core_PseudoConstant::getExtensions();
+
   if (!empty($extensions['org.civicrm.hrrecruitment'])) {
     $civi_settings = parse_url(CIVICRM_DSN);
     $civi_db_name = trim($civi_settings['path'], '/');
@@ -238,7 +226,6 @@ function _rebuild_hrvacancy_view() {
               FROM {$civi_db_name}.civicrm_hrvacancy
               WHERE status_id = 2");
 
-    // Set to false so it will not rebuild until not asked to rebuild
     variable_set('rebuild_hrvacancy_view', 'FALSE');
   }
 }
@@ -248,13 +235,13 @@ function _rebuild_hrvacancy_view() {
  */
 function _rebuild_tasks_view() {
   $extensions = CRM_Core_PseudoConstant::getExtensions();
+
   if (!empty($extensions['uk.co.compucorp.civicrm.tasksassignments'])) {
     $activityTypes = _get_activity_type_ids_by_component('CiviTask');
     if (!empty($activityTypes)) {
       db_query('DROP VIEW IF EXISTS tasks');
       db_query('CREATE VIEW tasks AS ' . _get_tasks_documents_sql_query($activityTypes));
 
-      // Set to false so it will not rebuild until not asked to rebuild
       variable_set('rebuild_tasks_view', 'FALSE');
     }
   }
@@ -265,13 +252,13 @@ function _rebuild_tasks_view() {
  */
 function _rebuild_documents_view() {
   $extensions = CRM_Core_PseudoConstant::getExtensions();
+
   if (!empty($extensions['uk.co.compucorp.civicrm.tasksassignments'])) {
     $activityTypes = _get_activity_type_ids_by_component('CiviDocument');
     if (!empty($activityTypes)) {
       db_query('DROP VIEW IF EXISTS documents');
       db_query('CREATE VIEW documents AS ' . _get_tasks_documents_sql_query($activityTypes));
 
-      // Set to false so it will not rebuild until not asked to rebuild
       variable_set('rebuild_documents_view', 'FALSE');
     }
   }
@@ -281,35 +268,36 @@ function _rebuild_documents_view() {
  * Return an array containg activity type IDs of given component.
  *
  * @param string $component
+ *
  * @return array
+ *
  * @throws API_Exception
  */
 function _get_activity_type_ids_by_component($component) {
   $civi_settings = parse_url(CIVICRM_DSN);
   $civi_db_name = trim($civi_settings['path'], '/');
-  $typeIds = array();
-  $optionGroup = civicrm_api3('OptionGroup', 'get', array(
+  $typeIds = [];
+  $optionGroup = civicrm_api3('OptionGroup', 'get', [
     'sequential' => 1,
     'name' => "activity_type",
-  ));
+  ]);
 
   if (!isset($optionGroup['id'])) {
     throw new API_Exception(ts("Cannot find OptionGroup with 'name' = 'activity_type'."));
   }
 
   $componentQuery = "SELECT * FROM {$civi_db_name}.civicrm_component WHERE name = %1";
-  $componentParams = array(
-    1 => array($component, 'String'),
-  );
+  $componentParams = [ 1 => [$component, 'String'], ];
   $componentResult = CRM_Core_DAO::executeQuery($componentQuery, $componentParams);
-  if ($componentResult->fetch())
-  {
+
+  if ($componentResult->fetch()) {
     $componentId = $componentResult->id;
-    $result = civicrm_api3('OptionValue', 'get', array(
+    $result = civicrm_api3('OptionValue', 'get', [
       'sequential' => 0,
       'option_group_id' => $optionGroup['id'],
       'component_id' => $componentId,
-    ));
+    ]);
+
     if (!empty($result['values'])) {
       foreach ($result['values'] as $value) {
         $typeIds[] = $value['value'];
@@ -327,6 +315,7 @@ function _get_activity_type_ids_by_component($component) {
  * Task types or Document types.
  *
  * @param array $activityTypes
+ *
  * @return string
  */
 function _get_tasks_documents_sql_query(array $activityTypes) {
@@ -339,7 +328,7 @@ function _get_tasks_documents_sql_query(array $activityTypes) {
             contact_source.sort_name AS source_contact_name, act.contact_id AS target_contact_id,
             contact_target.sort_name AS target_contact_name, aca.contact_id AS assignee_contact_id,
             contact_assignee.sort_name AS assignee_contact_name
-            FROM {$civi_db_name}.civicrm_activity a
+          FROM {$civi_db_name}.civicrm_activity a
             LEFT JOIN {$civi_db_name}.civicrm_value_activity_custom_fields_11 acustom ON acustom.entity_id = a.id
             LEFT JOIN {$civi_db_name}.civicrm_case_activity ca ON ca.activity_id = a.id
             LEFT JOIN {$civi_db_name}.civicrm_entity_file ef ON ef.entity_id = a.id AND ef.entity_table = 'civicrm_activity'
@@ -349,8 +338,8 @@ function _get_tasks_documents_sql_query(array $activityTypes) {
             LEFT JOIN {$civi_db_name}.civicrm_contact contact_target ON contact_target.id = act.contact_id
             LEFT JOIN {$civi_db_name}.civicrm_activity_contact aca ON aca.activity_id = a.id AND aca.record_type_id = 1
             LEFT JOIN {$civi_db_name}.civicrm_contact contact_assignee ON contact_assignee.id = aca.contact_id
-            WHERE a.is_deleted = 0 AND a.is_current_revision = 1 AND a.activity_type_id IN (" . implode(',', $activityTypes) . ")
-            GROUP BY a.id, aca.contact_id";
+          WHERE a.is_deleted = 0 AND a.is_current_revision = 1 AND a.activity_type_id IN (" . implode(',', $activityTypes) . ")
+          GROUP BY a.id, aca.contact_id";
 }
 
 /**
@@ -365,7 +354,6 @@ function _rebuild_length_of_service_view() {
                       SELECT id, entity_id, length_of_service
                       FROM {$civi_db_name}.civicrm_value_length_of_service_11");
 
-  // Set to false so it will not rebuild until not asked to rebuild
   variable_set('rebuild_length_of_service', 'FALSE');
 }
 
@@ -400,7 +388,6 @@ function _rebuild_absence_activity_view() {
             INNER JOIN {$civi_db_name}.civicrm_hrleaveandabsences_absence_type at ON at.id = lr.type_id
             INNER JOIN {$civi_db_name}.civicrm_hrleaveandabsences_leave_balance_change bc ON bc.source_id = lrd.id and bc.source_type = 'leave_request_day'");
 
-  // Set to false so it will not rebuild until not asked to rebuild
   variable_set('rebuild_absence_activity', 'FALSE');
 
 }
@@ -431,6 +418,7 @@ function _rebuild_view($viewName) {
  * Get the module URL
  *
  * @param  string $moduleName <Module name>
+ *
  * @return string             <Module url>
  */
 function getModuleUrl($moduleName) {
@@ -558,301 +546,266 @@ function _rebuild_reports_views() {
  * When caches are cleared rebuild the helper mysql views
  */
 function civihr_employee_portal_flush_caches() {
-    _run_civihr_tasks();
+  _run_civihr_tasks();
 }
 
 /**
  * Implement hook_cron()
  */
 function civihr_employee_portal_cron() {
-    _run_civihr_tasks();
+  _run_civihr_tasks();
 }
 
 function _run_civihr_tasks() {
+  //clear views cache to reflect changes
+  if (drupal_is_cli()) {
+    _clear_json_cache(TRUE);
+  }
+  else {
+    _clear_json_cache();
+  }
 
-    //clear views cache to reflect changes
-    if (drupal_is_cli()) {
-        _clear_json_cache(TRUE);
-    }
-    else {
-        _clear_json_cache();
-    }
+  // Set variable to TRUE so the mysql database views will be refreshed
+  variable_set('rebuild_length_of_service_view', 'TRUE');
+  variable_set('rebuild_absence_activity_view', 'TRUE');
+  variable_set('rebuild_appraisal_view', 'TRUE');
+  variable_set('rebuild_hrvacancy_view', 'TRUE');
+  variable_set('rebuild_tasks_view', 'TRUE');
+  variable_set('rebuild_documents_view', 'TRUE');
+  variable_set('rebuild_hrjobcontract_entities_view', 'TRUE');
 
-    // Set variable to TRUE so the mysql database views will be refreshed
-    variable_set('rebuild_length_of_service_view', 'TRUE');
-    variable_set('rebuild_absence_activity_view', 'TRUE');
-    variable_set('rebuild_appraisal_view', 'TRUE');
-    variable_set('rebuild_hrvacancy_view', 'TRUE');
-    variable_set('rebuild_tasks_view', 'TRUE');
-    variable_set('rebuild_documents_view', 'TRUE');
-    variable_set('rebuild_hrjobcontract_entities_view', 'TRUE');
-
-    watchdog('Rebuild view REQUEST', 'ABSENCE LIST MYSQL VIEW');
-
+  watchdog('Rebuild view REQUEST', 'ABSENCE LIST MYSQL VIEW');
 }
 
 function _remove_json_cache_files($folder_path = null, $cli = FALSE) {
+  if (is_dir($folder_path)) {
+    $dirHandle = opendir($folder_path);
 
-    // If we the views_json_query directory exists, check the cached files and remove them
-    if (is_dir($folder_path)) {
+    while ($file = readdir($dirHandle)) {
+      if (!is_dir($file)) {
+        unlink(drupal_realpath($folder_path . $file));
 
-        $dirHandle = opendir($folder_path);
-
-        // Loop over all of the files in the folder
-        while ($file = readdir($dirHandle)) {
-
-            // If $file is NOT a directory remove it
-            if (!is_dir($file)) {
-
-                $real_path = drupal_realpath($folder_path . $file);
-                unlink($real_path); // unlink() delete the file
-
-                // Log message if running from drush
-                if ($cli == TRUE) {
-                    drush_log($file . ' deleted');
-                }
-            }
+        if ($cli == TRUE) {
+          drush_log($file . ' deleted');
         }
-
-        // Close the directory
-        closedir($dirHandle);
-
+      }
     }
 
+    closedir($dirHandle);
+  }
 }
 
 function _clear_json_cache($cli = FALSE) {
-    // @ TODO -> get the sites/default/files location from proper drupal function
-    $folder_real_path = drupal_realpath('public://') . '/views_json_query/';
-    _remove_json_cache_files($folder_real_path, $cli);
+  // @ TODO -> get the sites/default/files location from proper drupal function
+  $folder_real_path = drupal_realpath('public://') . '/views_json_query/';
+  _remove_json_cache_files($folder_real_path, $cli);
 }
 
 /**
  * Implements hook_permission().
  */
 function civihr_employee_portal_permission() {
-  return array(
-    'can create and edit tasks' => array(
+  return [
+    'can create and edit tasks' => [
       'title' => t('Create and edit Tasks'),
       'description' => t('Availability to create and edit Tasks.'),
-    ),
-    'view my details' => array(
+    ],
+    'view my details' => [
       'title' => t('View My Details'),
       'description' => t('Availability for the user to view my details block and page')
-    ),
-    'view my tasks and documents blocks' => array(
+    ],
+    'view my tasks and documents blocks' => [
       'title' => t('View My Tasks and Documents Blocks'),
       'description' => t('Availability for the user to view my tasks and documents blocks')
-    ),
-    'view appraisals' => array(
+    ],
+    'view appraisals' => [
       'title' => t('View Appraisals'),
       'description' => t('Availability for the user to view appraisals block and page')
-    ),
-    'view staff directory' => array(
+    ],
+    'view staff directory' => [
       'title' => t('View Staff Directory'),
       'description' => t('Availability for the user to view staff directory block and page')
-    ),
-    'view hr resources' => array(
+    ],
+    'view hr resources' => [
       'title' => t('View HR Resources'),
       'description' => t('Availability for the user to view hr resources block and page')
-    ),
-    'change document status' => array(
+    ],
+    'change document status' => [
       'title' => t('Change Document Status'),
       'description' => t('Availability for the user to change document status')
-    ),
-    'view vacancies' => array(
+    ],
+    'view vacancies' => [
       'title' => t('View Vacancies'),
       'description' => t('Availability for the user to view vacancies block and page')
-    ),
-    'access hrreports' => array(
+    ],
+    'access hrreports' => [
       'title' => t('Access HR Reports'),
       'description' => t('Availability to access HR Report pages'),
-    ),
-    'manage hrreports settings' => array(
+    ],
+    'manage hrreports settings' => [
       'title' => t('Manage HR Reports settings'),
       'description' => t('Availability to manage HR Reports settings'),
-    ),
-    'manage hrreports configuration' => array(
+    ],
+    'manage hrreports configuration' => [
       'title' => t('Manage HR Reports configuration'),
       'description' => t('Availability to manage HR Reports configuration'),
-    ),
-  );
+    ],
+  ];
 }
 
 /**
  * Implements hook_theme().
  */
 function civihr_employee_portal_theme($existing, $type, $theme, $path) {
-    // This will hold any custom view display names where we need to override the template file
-    $theme_hooks = array();
-    return $theme_hooks + array(
-        'user_login_block' => array(
-            'render element' => 'form',
-            'template' => 'templates/civihr-employee-portal-user-login',
-            'preprocess functions' => array(
-                'civihr_employee_portal_preprocess_user_login'
-            ),
-        ),
-        'civihr_employee_portal_my_details_block' => array(
-            'variables' => array(
-                'profile_image' => NULL,
-                'contact_details' => NULL,
-                'address_data' => NULL,
-                'address_data_title' => NULL,
-            ),
-            'template' => 'templates/civihr-employee-portal-my-details--block',
-        ),
-        'civihr_employee_portal_login_block' => array(
-            'variables' => array(
-                'custom_data' => NULL
-            ),
-            'template' => 'templates/civihr-employee-portal-login-block--block',
-        ),
-        'civihr_employee_portal_document_form' => array(
-            //'arguments' => array('form' => NULL),
-            'variables' => array(
-                'custom_data' => NULL
-            ),
-//            'template' => 'templates/civihr-employee-portal-document-form',
-            'render element' => 'form',
-        ),
-        'civihr_employee_portal_civihr_report_landing_page' => array(
-            'variables' => array(
-                'title' => NULL,
-                'data' => NULL,
-                'settings_url' => NULL
-            ),
-            'template' => 'templates/civihr-employee-portal-civihr-report-landing-page',
-        ),
-        'civihr_employee_portal_civihr_report_settings_age_group' => array(
-            'variables' => array(
-                'title' => NULL,
-                'data' => NULL,
-                'settings_url' => NULL
-            ),
-            'template' => 'templates/civihr-employee-portal-civihr-report-settings-age-group',
-        ),
-        'civihr_employee_portal_civihr_report_custom' => array(
-            'variables' => array(
-                'title' => NULL,
-                'data' => NULL,
-                'settings_url' => NULL
-            ),
-            'template' => 'templates/civihr-employee-portal-civihr-report-custom',
-        ),
+  // This will hold any custom view display names where we need to override the template file
+  $theme_hooks = [];
 
-        'menu_tree__hr_reports_settings' => array(
-            'render element' => 'block',
-            'template' => 'templates/block--menu--reports-settings-menu-tree',
-        ),
-        'menu_link__hr_reports_settings' => array(
-            'render element' => 'block',
-            'template' => 'templates/block--menu--reports-settings-menu-link',
-        ),
-    );
+  return $theme_hooks + [
+    'user_login_block' => [
+      'render element' => 'form',
+      'template' => 'templates/civihr-employee-portal-user-login',
+      'preprocess functions' => [
+        'civihr_employee_portal_preprocess_user_login'
+      ],
+    ],
+    'civihr_employee_portal_my_details_block' => [
+      'variables' => [
+        'profile_image' => NULL,
+        'contact_details' => NULL,
+        'address_data' => NULL,
+        'address_data_title' => NULL,
+      ],
+      'template' => 'templates/civihr-employee-portal-my-details--block',
+    ],
+    'civihr_employee_portal_login_block' => [
+      'variables' => [
+        'custom_data' => NULL
+      ],
+      'template' => 'templates/civihr-employee-portal-login-block--block',
+    ],
+    'civihr_employee_portal_document_form' => [
+      'variables' => [
+        'custom_data' => NULL
+      ],
+      'render element' => 'form',
+    ],
+    'civihr_employee_portal_civihr_report_landing_page' => [
+      'variables' => [
+        'title' => NULL,
+        'data' => NULL,
+        'settings_url' => NULL
+      ],
+      'template' => 'templates/civihr-employee-portal-civihr-report-landing-page',
+    ],
+    'civihr_employee_portal_civihr_report_settings_age_group' => [
+      'variables' => [
+        'title' => NULL,
+        'data' => NULL,
+        'settings_url' => NULL
+      ],
+      'template' => 'templates/civihr-employee-portal-civihr-report-settings-age-group',
+    ],
+    'civihr_employee_portal_civihr_report_custom' => [
+      'variables' => [
+        'title' => NULL,
+        'data' => NULL,
+        'settings_url' => NULL
+      ],
+      'template' => 'templates/civihr-employee-portal-civihr-report-custom',
+    ],
+    'menu_tree__hr_reports_settings' => [
+      'render element' => 'block',
+      'template' => 'templates/block--menu--reports-settings-menu-tree',
+    ],
+    'menu_link__hr_reports_settings' => [
+      'render element' => 'block',
+      'template' => 'templates/block--menu--reports-settings-menu-link',
+    ],
+  ];
 }
 
 /**
  * Implements hook_views_default_views().
  */
 function civihr_employee_portal_views_default_views() {
-    // Check for all view files in views directory
-    $files = file_scan_directory(drupal_get_path('module', 'civihr_employee_portal') . '/views/views_export', '/.*\.inc$/');
+  // Check for all view files in views directory
+  $files = file_scan_directory(drupal_get_path('module', 'civihr_employee_portal') . '/views/views_export', '/.*\.inc$/');
 
-    // Add view to list of views
-    foreach ($files as $filepath => $file) {
-        require $filepath;
+  foreach ($files as $filepath => $file) {
+    require $filepath;
 
-        // Check if the view object is set
-        if (isset($view)) {
-            $views[$view->name] = $view;
-        }
+    if (isset($view)) {
+      $views[$view->name] = $view;
     }
+  }
 
-    // At the end, return array of default views.
-    return $views;
+  return $views;
 }
 
 /**
- * Function for caching absence types returned from CiviCRM (avoiding expensive DB calls for each dashboard page hit)
+ * Function for caching absence types returned from CiviCRM
+ * (avoiding expensive DB calls for each dashboard page hit)
  */
 function get_civihr_absence_types() {
+  $absenceTypes = &drupal_static(__FUNCTION__);
 
-    $absenceTypes = &drupal_static(__FUNCTION__);
+  if (!isset($absenceTypes)) {
+    $cache = cache_get('civihr_absence_types');
 
-    if (!isset($absenceTypes)) {
-        $cache = cache_get('civihr_absence_types');
-        if (!empty($cache->data)) {
-            $absenceTypes = $cache->data;
-        }
-        else {
-
-            try {
-
-                // Civi init
-                civicrm_initialize();
-
-                $absenceTypes = [];
-                watchdog('DB hit absence types', 'DB');
-
-            }
-
-            catch (CiviCRM_API3_Exception $e) {
-                $error = $e->getMessage();
-            }
-
-            // Cache the absence types for 5 minutes
-            cache_set('civihr_absence_types', $absenceTypes, 'cache', time() + 360);
-
-        }
-
+    if (!empty($cache->data)) {
+      $absenceTypes = $cache->data;
     }
+    else {
+      try {
+        civicrm_initialize();
 
-    return $absenceTypes;
+        $absenceTypes = [];
+        watchdog('DB hit absence types', 'DB');
+      }
+      catch (CiviCRM_API3_Exception $e) {
+        $error = $e->getMessage();
+      }
 
+      // Cache the absence types for 5 minutes
+      cache_set('civihr_absence_types', $absenceTypes, 'cache', time() + 360);
+    }
+  }
+
+  return $absenceTypes;
 }
 
 /**
- * Function for caching absence statuses returned from CiviCRM (avoiding expensive DB calls for each dashboard page hit)
+ * Function for caching absence statuses returned from CiviCRM
+ * (avoiding expensive DB calls for each dashboard page hit)
  */
 function get_civihr_absence_statuses($status_id = NULL) {
+  $absenceStatuses = &drupal_static(__FUNCTION__);
 
-    $absenceStatuses = &drupal_static(__FUNCTION__);
-
-    if (!isset($absenceStatuses)) {
-
-        if ($cache = cache_get('civihr_absence_statuses')) {
-            $absenceStatuses = $cache->data;
-        }
-        else {
-
-            try {
-
-                // Civi init
-                civicrm_initialize();
-
-                // Activity absence statuses array
-                $absenceStatuses = CRM_Core_OptionGroup::values('hrleaveandabsences_leave_request_status', FALSE, FALSE, FALSE, NULL, 'label');
-
-                watchdog('DB hit absence statuses', 'DB');
-
-            }
-
-            catch (CiviCRM_API3_Exception $e) {
-                $error = $e->getMessage();
-            }
-
-            // Cache the absence statuses for 5 minutes
-            cache_set('civihr_absence_statuses', $absenceStatuses, 'cache', time() + 360);
-
-        }
-
+  if (!isset($absenceStatuses)) {
+    if ($cache = cache_get('civihr_absence_statuses')) {
+        $absenceStatuses = $cache->data;
     }
+    else {
+      try {
+        civicrm_initialize();
 
-    // Get the status values based on the status_id
-    $status_id_value = CRM_Utils_Array::value($status_id, $absenceStatuses);
+        $absenceStatuses = CRM_Core_OptionGroup::values('hrleaveandabsences_leave_request_status', FALSE, FALSE, FALSE, NULL, 'label');
 
-    return $status_id_value;
+        watchdog('DB hit absence statuses', 'DB');
+      }
+      catch (CiviCRM_API3_Exception $e) {
+        $error = $e->getMessage();
+      }
+
+      // Cache the absence statuses for 5 minutes
+      cache_set('civihr_absence_statuses', $absenceStatuses, 'cache', time() + 360);
+    }
+  }
+
+  // Get the status values based on the status_id
+  $status_id_value = CRM_Utils_Array::value($status_id, $absenceStatuses);
+
+  return $status_id_value;
 }
 
 /**
@@ -865,138 +818,124 @@ function get_civihr_absence_statuses($status_id = NULL) {
  *
  * @return string
  */
-
 function get_civihr_absence_sickness_reason_label($sicknessReasonValue) {
-    $sicknessReasons = &drupal_static(__FUNCTION__);
-    $SICKNESS_REASONS_CACHE_KEY = 'civihr_absence_sickness_reasons';
+  $sicknessReasons = &drupal_static(__FUNCTION__);
+  $SICKNESS_REASONS_CACHE_KEY = 'civihr_absence_sickness_reasons';
 
-    if (!isset($sicknessReasons)) {
-    	  $cachedSicknessReasons = cache_get($SICKNESS_REASONS_CACHE_KEY);
-        if ($cachedSicknessReasons) {
-            $sicknessReasons = $cachedSicknessReasons->data;
-        }
-        else {
-            civicrm_initialize();
-            $sicknessReasons = [];
-            $result = civicrm_api3('OptionValue', 'get', ['option_group_id' => 'hrleaveandabsences_sickness_reason']);
+  if (!isset($sicknessReasons)) {
+	  $cachedSicknessReasons = cache_get($SICKNESS_REASONS_CACHE_KEY);
 
-            if ($result['count'] > 0) {
-                $sicknessReasons = array_column($result['values'], 'label', 'value');
-            }
-            // Cache the absence sickness reasons for 5 minutes
-            $SECONDS_IN_FIVE_MINUTES = 300;
-            cache_set($SICKNESS_REASONS_CACHE_KEY, $sicknessReasons, 'cache', time() + $SECONDS_IN_FIVE_MINUTES);
-        }
+    if ($cachedSicknessReasons) {
+      $sicknessReasons = $cachedSicknessReasons->data;
     }
+    else {
+      civicrm_initialize();
 
-    $sicknessReasonLabel = '';
-    if (!empty($sicknessReasons[$sicknessReasonValue])) {
-        $sicknessReasonLabel = $sicknessReasons[$sicknessReasonValue];
+      $sicknessReasons = [];
+      $result = civicrm_api3('OptionValue', 'get', ['option_group_id' => 'hrleaveandabsences_sickness_reason']);
+
+      if ($result['count'] > 0) {
+        $sicknessReasons = array_column($result['values'], 'label', 'value');
+      }
+
+      // Cache the absence sickness reasons for 5 minutes
+      cache_set($SICKNESS_REASONS_CACHE_KEY, $sicknessReasons, 'cache', time() + 360);
     }
+  }
 
-    return $sicknessReasonLabel;
+  $sicknessReasonLabel = '';
+
+  if (!empty($sicknessReasons[$sicknessReasonValue])) {
+    $sicknessReasonLabel = $sicknessReasons[$sicknessReasonValue];
+  }
+
+  return $sicknessReasonLabel;
 }
 
 function get_document_statuses($status_id = NULL) {
+  $documentStatuses = &drupal_static(__FUNCTION__);
 
-    $documentStatuses = &drupal_static(__FUNCTION__);
-
-    if (!isset($documentStatuses)) {
-
-        if ($cache = cache_get('civihr_document_statuses')) {
-            $documentStatuses = $cache->data;
-        }
-        else {
-            try {
-                // Civi init
-                civicrm_initialize();
-
-                // Document statuses array
-                $documentStatuses = civicrm_api3('Document', 'getoptions', array(
-                    'field' => "status_id",
-                ));
-            }
-
-            catch (CiviCRM_API3_Exception $e) {
-                $error = $e->getMessage();
-            }
-
-            // Cache the document statuses for 5 minutes
-            cache_set('civihr_document_statuses', $documentStatuses, 'cache', time() + 360);
-        }
+  if (!isset($documentStatuses)) {
+    if ($cache = cache_get('civihr_document_statuses')) {
+      $documentStatuses = $cache->data;
     }
+    else {
+      try {
+        civicrm_initialize();
 
-    // Get the status values based on the status_id
-    $status_id_value = CRM_Utils_Array::value($status_id, $documentStatuses['values']);
+        $documentStatuses = civicrm_api3('Document', 'getoptions', [
+          'field' => "status_id",
+        ]);
+      }
+      catch (CiviCRM_API3_Exception $e) {
+        $error = $e->getMessage();
+      }
 
-    return $status_id_value;
+      cache_set('civihr_document_statuses', $documentStatuses, 'cache', time() + 360);
+    }
+  }
+
+  // Get the status values based on the status_id
+  $status_id_value = CRM_Utils_Array::value($status_id, $documentStatuses['values']);
+
+  return $status_id_value;
 }
 
 function get_task_statuses($status_id = NULL) {
+  $taskStatuses = &drupal_static(__FUNCTION__);
 
-    $taskStatuses = &drupal_static(__FUNCTION__);
-
-    if (!isset($taskStatuses)) {
-
-        if ($cache = cache_get('civihr_task_statuses')) {
-            $taskStatuses = $cache->data;
-        }
-        else {
-            try {
-                // Civi init
-                civicrm_initialize();
-
-                // Task statuses array
-                $taskStatuses = civicrm_api3('Task', 'getoptions', array(
-                    'field' => "status_id",
-                ));
-            }
-
-            catch (CiviCRM_API3_Exception $e) {
-                $error = $e->getMessage();
-            }
-
-            // Cache the task statuses for 5 minutes
-            cache_set('civihr_task_statuses', $taskStatuses, 'cache', time() + 360);
-        }
+  if (!isset($taskStatuses)) {
+    if ($cache = cache_get('civihr_task_statuses')) {
+      $taskStatuses = $cache->data;
     }
+    else {
+      try {
+        civicrm_initialize();
 
-    if ($status_id === null) {
-        return $taskStatuses['values'];
+        $taskStatuses = civicrm_api3('Task', 'getoptions', [
+          'field' => "status_id",
+        ]);
+      }
+      catch (CiviCRM_API3_Exception $e) {
+        $error = $e->getMessage();
+      }
+
+      // Cache the task statuses for 5 minutes
+      cache_set('civihr_task_statuses', $taskStatuses, 'cache', time() + 360);
     }
+  }
 
-    // Get the status values based on the status_id
-    $status_id_value = CRM_Utils_Array::value($status_id, $taskStatuses['values']);
+  if ($status_id === null) {
+    return $taskStatuses['values'];
+  }
 
-    return $status_id_value;
+  // Get the status values based on the status_id
+  $status_id_value = CRM_Utils_Array::value($status_id, $taskStatuses['values']);
+
+  return $status_id_value;
 }
 
 /**
  * Get value (a human-readable label) of given Activity type ID.
  *
  * @param int $type_id
+ *
  * @return string
  */
 function get_activity_type_value($type_id = NULL) {
-
   $activityTypes = &drupal_static(__FUNCTION__);
 
   if (!isset($activityTypes)) {
-
     if ($cache = cache_get('civihr_activity_types')) {
       $activityTypes = $cache->data;
     }
     else {
       try {
-        // Civi init
         civicrm_initialize();
 
-        // Task types array
         $activityTypes = civicrm_api3('Activity', 'getoptions', [
           'field' => "activity_type_id",
         ]);
-
-        // Document types array
         $documentTypes = civicrm_api3('Document', 'getoptions', [
           'field' => "activity_type_id",
         ]);
@@ -1023,679 +962,682 @@ function get_activity_type_value($type_id = NULL) {
 }
 
 function get_appraisal_cycle_type($type_id = NULL) {
-    $appraisalCycleTypes = &drupal_static(__FUNCTION__);
+  $appraisalCycleTypes = &drupal_static(__FUNCTION__);
 
-    if (!isset($appraisalCycleTypes)) {
-
-        if ($cache = cache_get('civihr_appraisal_cycle_types')) {
-            $appraisalCycleTypes = $cache->data;
-        }
-        else {
-            try {
-                // Civi init
-                civicrm_initialize();
-
-                // Appraisal cycle types array
-                $appraisalCycleTypes = CRM_Core_OptionGroup::values('appraisal_cycle_type');
-            }
-
-            catch (CiviCRM_API3_Exception $e) {
-                $error = $e->getMessage();
-            }
-
-            // Cache the Appraisal cycle types for 5 minutes
-            cache_set('civihr_appraisal_cycle_types', $appraisalCycleTypes, 'cache', time() + 360);
-        }
+  if (!isset($appraisalCycleTypes)) {
+    if ($cache = cache_get('civihr_appraisal_cycle_types')) {
+      $appraisalCycleTypes = $cache->data;
     }
+    else {
+      try {
+        civicrm_initialize();
 
-    if ($type_id === null) {
-        return '-';
+        $appraisalCycleTypes = CRM_Core_OptionGroup::values('appraisal_cycle_type');
+      }
+      catch (CiviCRM_API3_Exception $e) {
+        $error = $e->getMessage();
+      }
+
+      // Cache the Appraisal cycle types for 5 minutes
+      cache_set('civihr_appraisal_cycle_types', $appraisalCycleTypes, 'cache', time() + 360);
     }
+  }
 
-    // Get the type values based on the type_id
-    $type_value = $appraisalCycleTypes[$type_id];
+  if ($type_id === null) {
+    return '-';
+  }
 
-    return $type_value;
+  // Get the type values based on the type_id
+  $type_value = $appraisalCycleTypes[$type_id];
+
+  return $type_value;
 }
 
 function get_appraisal_cycle_period($cycleStartDate, $cycleEndDate) {
-    return $cycleStartDate . ' - ' . $cycleEndDate;
+  return $cycleStartDate . ' - ' . $cycleEndDate;
 }
 
 function get_appraisal_status($status_id = NULL) {
-    $appraisalStatuses = &drupal_static(__FUNCTION__);
+  $appraisalStatuses = &drupal_static(__FUNCTION__);
 
-    if (!isset($appraisalStatuses)) {
-
-        if ($cache = cache_get('civihr_appraisal_statuses')) {
-            $appraisalStatuses = $cache->data;
-        }
-        else {
-            try {
-                // Civi init
-                civicrm_initialize();
-
-                // Appraisal cycle types array
-                $appraisalStatuses = CRM_Core_OptionGroup::values('appraisal_status');
-            }
-
-            catch (CiviCRM_API3_Exception $e) {
-                $error = $e->getMessage();
-            }
-
-            // Cache the Appraisal cycle types for 5 minutes
-            cache_set('civihr_appraisal_statuses', $appraisalStatuses, 'cache', time() + 360);
-        }
+  if (!isset($appraisalStatuses)) {
+    if ($cache = cache_get('civihr_appraisal_statuses')) {
+      $appraisalStatuses = $cache->data;
     }
+    else {
+      try {
+        civicrm_initialize();
 
-    if ($status_id === null) {
-        return '-';
+        $appraisalStatuses = CRM_Core_OptionGroup::values('appraisal_status');
+      }
+      catch (CiviCRM_API3_Exception $e) {
+        $error = $e->getMessage();
+      }
+
+      // Cache the Appraisal cycle types for 5 minutes
+      cache_set('civihr_appraisal_statuses', $appraisalStatuses, 'cache', time() + 360);
     }
+  }
 
-    // Get the type values based on the type_id
-    $status_value = $appraisalStatuses[$status_id];
+  if ($status_id === null) {
+    return '-';
+  }
 
-    return $status_value;
+  // Get the type values based on the type_id
+  $status_value = $appraisalStatuses[$status_id];
+
+  return $status_value;
 }
 
 function get_appraisal_due_date($selfAppraisalDue, $managerAppraisalDue, $gradeDue) {
-    $today = date('Y-m-d');
-    $dueDate = $selfAppraisalDue;
-    if ($selfAppraisalDue < $today) {
-        $dueDate = $managerAppraisalDue;
-    }
-    if ($managerAppraisalDue < $today) {
-        $dueDate = $gradeDue;
-    }
+  $today = date('Y-m-d');
+  $dueDate = $selfAppraisalDue;
 
-    return $dueDate;
+  if ($selfAppraisalDue < $today) {
+    $dueDate = $managerAppraisalDue;
+  }
+
+  if ($managerAppraisalDue < $today) {
+    $dueDate = $gradeDue;
+  }
+
+  return $dueDate;
 }
 
 function get_appraisal_employee_chart_data($contactId) {
-    $cycleIds = CRM_Appraisals_BAO_AppraisalCycle::getAllCycleIds(null, $contactId);
-    $cyclesDates = array();
-    $cyclesMyGrades = array();
-    $cyclesAvgGrades = array();
-    $cycleDatesResult = civicrm_api3('AppraisalCycle', 'get', array(
-        'sequential' => 1,
-        'id' => array('IN' => $cycleIds),
-        'return' => "cycle_start_date",
-        'options' => array('sort' => "cycle_start_date ASC"),
-    ));
-    foreach ($cycleDatesResult['values'] as $cycleDateResult) {
-        $cyclesDates[] = '"' . $cycleDateResult['cycle_start_date'] . '"';
-    }
-    foreach ($cycleIds as $cycleId) {
-        $myGradeResult = civicrm_api3('Appraisal', 'getsingle', array(
-            'sequential' => 1,
-            'appraisal_cycle_id' => $cycleId,
-            'contact_id' => $contactId,
-            'is_current' => 1,
-            'return' => "grade",
-        ));
-        $cyclesMyGrades[] = !empty($myGradeResult['grade']) ? (int)$myGradeResult['grade'] : 0;
-        $cyclesAvgGrades[] = CRM_Appraisals_BAO_AppraisalCycle::getCycleAverageGrade($cycleId);
-    }
-    return array(
-        'cyclesDates' => $cyclesDates,
-        'cyclesMyGrades' => $cyclesMyGrades,
-        'cyclesAvgGrades' => $cyclesAvgGrades
-    );
+  $cycleIds = CRM_Appraisals_BAO_AppraisalCycle::getAllCycleIds(null, $contactId);
+  $cyclesDates = [];
+  $cyclesMyGrades = [];
+  $cyclesAvgGrades = [];
+
+  $cycleDatesResult = civicrm_api3('AppraisalCycle', 'get', [
+      'sequential' => 1,
+      'id' => ['IN' => $cycleIds],
+      'return' => "cycle_start_date",
+      'options' => ['sort' => "cycle_start_date ASC"],
+  ]);
+
+  foreach ($cycleDatesResult['values'] as $cycleDateResult) {
+    $cyclesDates[] = '"' . $cycleDateResult['cycle_start_date'] . '"';
+  }
+
+  foreach ($cycleIds as $cycleId) {
+    $myGradeResult = civicrm_api3('Appraisal', 'getsingle', [
+      'sequential' => 1,
+      'appraisal_cycle_id' => $cycleId,
+      'contact_id' => $contactId,
+      'is_current' => 1,
+      'return' => "grade",
+    ]);
+    $cyclesMyGrades[] = !empty($myGradeResult['grade']) ? (int)$myGradeResult['grade'] : 0;
+    $cyclesAvgGrades[] = CRM_Appraisals_BAO_AppraisalCycle::getCycleAverageGrade($cycleId);
+  }
+
+  return [
+    'cyclesDates' => $cyclesDates,
+    'cyclesMyGrades' => $cyclesMyGrades,
+    'cyclesAvgGrades' => $cyclesAvgGrades
+  ];
 }
 
 function get_appraisal_manager_chart_data($managerId) {
-    $appraisalStatuses = CRM_Core_OptionGroup::values('appraisal_status');
-    $cycleStatusDefault = array_combine(array_keys($appraisalStatuses), array_fill(1, count($appraisalStatuses), 0));
-    $cycleStatuses = CRM_Appraisals_BAO_AppraisalCycle::getCurrentCycleStatus($managerId);
-    $labels = array('"Stage 1"', '"Stage 2"', '"Stage 3"', '"Stage 4"', '"Stage 5"');
-    $cycleStatusData = array();
-    foreach ($cycleStatusDefault as $key => $value) {
-        $cycleStatusData[$key] = $value;
-        if (!empty($cycleStatuses[$key])) {
-            $cycleStatusData[$key] += $cycleStatuses[$key];
-        }
+  $appraisalStatuses = CRM_Core_OptionGroup::values('appraisal_status');
+  $cycleStatusDefault = array_combine(array_keys($appraisalStatuses), array_fill(1, count($appraisalStatuses), 0));
+  $cycleStatuses = CRM_Appraisals_BAO_AppraisalCycle::getCurrentCycleStatus($managerId);
+  $labels = ['"Stage 1"', '"Stage 2"', '"Stage 3"', '"Stage 4"', '"Stage 5"'];
+  $cycleStatusData = [];
+
+  foreach ($cycleStatusDefault as $key => $value) {
+    $cycleStatusData[$key] = $value;
+
+    if (!empty($cycleStatuses[$key])) {
+      $cycleStatusData[$key] += $cycleStatuses[$key];
     }
-    return array(
-        'labels' => $labels,
-        'cycleStatusData' => $cycleStatusData,
-    );
+  }
+
+  return [
+    'labels' => $labels,
+    'cycleStatusData' => $cycleStatusData,
+  ];
 }
 
 
 // Helper functions for Reports View handlers
 
-/*
+/**
  * Return Job Contract end reason label by given reason ID.
  *
  * @param int $reasonId
+ *
  * @return string
  */
 function get_jobcontract_end_reason($reasonId = NULL) {
-    $jobcontractEndReasons = &drupal_static(__FUNCTION__);
-    if (!isset($jobcontractEndReasons)) {
-        if ($cache = cache_get('civihr_jobcontract_end_reasons')) {
-            $jobcontractEndReasons = $cache->data;
-        }
-        else {
-            try {
-                civicrm_initialize();
-                $options = CRM_Core_PseudoConstant::get('CRM_Hrjobcontract_DAO_HRJobDetails', 'end_reason');
-            } catch (CiviCRM_API3_Exception $e) {
-                $error = $e->getMessage();
-            }
-            // Cache the data for 5 minutes
-            cache_set('civihr_jobcontract_end_reasons', $options, 'cache', time() + 360);
-        }
+  $jobcontractEndReasons = &drupal_static(__FUNCTION__);
+
+  if (!isset($jobcontractEndReasons)) {
+    if ($cache = cache_get('civihr_jobcontract_end_reasons')) {
+      $jobcontractEndReasons = $cache->data;
     }
-    if ($reasonId === null) {
-        return '';
+    else {
+      try {
+        civicrm_initialize();
+        $options = CRM_Core_PseudoConstant::get('CRM_Hrjobcontract_DAO_HRJobDetails', 'end_reason');
+      } catch (CiviCRM_API3_Exception $e) {
+        $error = $e->getMessage();
+      }
+
+      // Cache the data for 5 minutes
+      cache_set('civihr_jobcontract_end_reasons', $options, 'cache', time() + 360);
     }
-    // Get the type values based on the $reasonId
-    $status_value = $jobcontractEndReasons[$reasonId];
-    return $status_value;
+  }
+  if ($reasonId === null) {
+    return '';
+  }
+
+  // Get the type values based on the $reasonId
+  $status_value = $jobcontractEndReasons[$reasonId];
+
+  return $status_value;
 }
 
-/*
+/**
  * Return Job Contract location and standard hours string by given hours location ID.
  *
  * @param int $hoursLocationId
+ *
  * @return string
  */
 function get_jobcontract_location_standard_hours($hoursLocationId = NULL) {
-    $locationStandardHours = &drupal_static(__FUNCTION__);
-    if (!isset($locationStandardHours)) {
-        if ($cache = cache_get('civihr_jobcontract_location_standard_hours')) {
-            $locationStandardHours = $cache->data;
-        }
-        else {
-            try {
-                civicrm_initialize();
-                $options = array();
-                $hoursLocation = new CRM_Hrjobcontract_BAO_HoursLocation();
-                $hoursLocation->find();
-                while ($hoursLocation->fetch()) {
-                    $row = (array)$hoursLocation;
-                    $options[$hoursLocation->id] = $row['location'] .
-                        ' (' . $row['standard_hours'] .
-                        ' / ' . $row['periodicity'] . ')';
-                }
-            } catch (CiviCRM_API3_Exception $e) {
-                $error = $e->getMessage();
-            }
-            // Cache the data for 5 minutes
-            cache_set('civihr_jobcontract_location_standard_hours', $options, 'cache', time() + 360);
-        }
+  $locationStandardHours = &drupal_static(__FUNCTION__);
+
+  if (!isset($locationStandardHours)) {
+    if ($cache = cache_get('civihr_jobcontract_location_standard_hours')) {
+      $locationStandardHours = $cache->data;
     }
-    if ($hoursLocationId === null) {
-        return '';
+    else {
+      try {
+        civicrm_initialize();
+        $options = [];
+        $hoursLocation = new CRM_Hrjobcontract_BAO_HoursLocation();
+        $hoursLocation->find();
+        while ($hoursLocation->fetch()) {
+          $row = (array)$hoursLocation;
+          $options[$hoursLocation->id] = $row['location'] .
+          ' (' . $row['standard_hours'] .
+          ' / ' . $row['periodicity'] . ')';
+        }
+      } catch (CiviCRM_API3_Exception $e) {
+        $error = $e->getMessage();
+      }
+
+      // Cache the data for 5 minutes
+      cache_set('civihr_jobcontract_location_standard_hours', $options, 'cache', time() + 360);
     }
+  }
+  if ($hoursLocationId === null) {
+    return '';
+  }
     // Get the type values based on the $reasonId
-    return !empty($locationStandardHours[$hoursLocationId]) ? $locationStandardHours[$hoursLocationId] : '';
+  return !empty($locationStandardHours[$hoursLocationId]) ? $locationStandardHours[$hoursLocationId] : '';
 }
 
-/*
+/**
  * Return Job Contract pay scale label string by given pay scale ID.
  *
  * @param int $payScaleId
+ *
  * @return string
  */
 function get_jobcontract_pay_scale($payScaleId = NULL) {
-    $payScales = &drupal_static(__FUNCTION__);
-    if (!isset($payScales)) {
-        if ($cache = cache_get('civihr_jobcontract_pay_scale')) {
-            $payScales = $cache->data;
-        }
-        else {
-            try {
-                civicrm_initialize();
-                $options = array();
-                $payScale = new CRM_Hrjobcontract_BAO_PayScale();
-                $payScale->find();
-                while ($payScale->fetch()) {
-                    $row = (array)$payScale;
-                    $options[$payScale->id] = $row['pay_scale'];
-                    if (!empty($row['pay_grade'])) {
-                        $options[$payScale->id] .= ' - ' . $row['pay_grade'] .
-                            ' (' . $row['amount'] .
-                            ' ' . $row['currency'] .
-                            ' / ' . $row['periodicity'] .
-                            ')';
-                    }
-                }
-            } catch (CiviCRM_API3_Exception $e) {
-                $error = $e->getMessage();
-            }
-            // Cache the data for 5 minutes
-            cache_set('civihr_jobcontract_pay_scale', $options, 'cache', time() + 360);
-        }
+  $payScales = &drupal_static(__FUNCTION__);
+
+  if (!isset($payScales)) {
+    if ($cache = cache_get('civihr_jobcontract_pay_scale')) {
+      $payScales = $cache->data;
     }
-    if ($payScaleId === null) {
-        return '';
+    else {
+      try {
+        civicrm_initialize();
+
+        $options = [];
+        $payScale = new CRM_Hrjobcontract_BAO_PayScale();
+        $payScale->find();
+
+        while ($payScale->fetch()) {
+          $row = (array)$payScale;
+          $options[$payScale->id] = $row['pay_scale'];
+
+          if (!empty($row['pay_grade'])) {
+            $options[$payScale->id] .= ' - ' . $row['pay_grade'] .
+            ' (' . $row['amount'] .
+            ' ' . $row['currency'] .
+            ' / ' . $row['periodicity'] .
+            ')';
+          }
+        }
+      }
+      catch (CiviCRM_API3_Exception $e) {
+        $error = $e->getMessage();
+      }
+
+      // Cache the data for 5 minutes
+      cache_set('civihr_jobcontract_pay_scale', $options, 'cache', time() + 360);
     }
+  }
+
+  if ($payScaleId === null) {
+    return '';
+  }
     // Get the type values based on the $payScaleId
-    $label = !empty($payScales[$payScaleId]) ? $payScales[$payScaleId] : '';
-    return $label;
+  $label = !empty($payScales[$payScaleId]) ? $payScales[$payScaleId] : '';
+
+  return $label;
 }
 
-/*
+/**
  * Return Job Contract pension is_enrolled string by given is_enrolled ID.
  *
  * @param int $isEnrolled
+ *
  * @return string
  */
 function get_jobcontract_pension_is_enrolled($isEnrolledId = NULL) {
-    $pensionIsEnrolled = &drupal_static(__FUNCTION__);
-    if (!isset($pensionIsEnrolled)) {
-        if ($cache = cache_get('civihr_jobcontract_pension_is_enrolled')) {
-            $pensionIsEnrolled = $cache->data;
-        }
-        else {
-            try {
-                civicrm_initialize();
-                $options = array(
-                    0 => t('No'),
-                    1 => t('Yes'),
-                    2 => t('Opted out'),
-                );
-            } catch (CiviCRM_API3_Exception $e) {
-                $error = $e->getMessage();
-            }
-            // Cache the data for 5 minutes
-            cache_set('civihr_jobcontract_pension_is_enrolled', $options, 'cache', time() + 360);
-        }
+  $pensionIsEnrolled = &drupal_static(__FUNCTION__);
+
+  if (!isset($pensionIsEnrolled)) {
+    if ($cache = cache_get('civihr_jobcontract_pension_is_enrolled')) {
+      $pensionIsEnrolled = $cache->data;
     }
-    if ($isEnrolledId === null) {
-        return '';
+    else {
+      try {
+        civicrm_initialize();
+        $options = [
+          0 => t('No'),
+          1 => t('Yes'),
+          2 => t('Opted out'),
+        ];
+      }
+      catch (CiviCRM_API3_Exception $e) {
+        $error = $e->getMessage();
+      }
+
+      // Cache the data for 5 minutes
+      cache_set('civihr_jobcontract_pension_is_enrolled', $options, 'cache', time() + 360);
     }
-    // Get the type values based on the $isEnrolledId
-    return $pensionIsEnrolled[$isEnrolledId];
+  }
+
+  if ($isEnrolledId === null) {
+    return '';
+  }
+
+  // Get the type values based on the $isEnrolledId
+  return $pensionIsEnrolled[$isEnrolledId];
 }
 
 /**
  * Function for caching civicrm_uf_match table from CiviCRM
  */
 function get_civihr_uf_match_data($user_id = NULL) {
+  // Generate unique static callable / uf_match
+  $contact_uf_match = &drupal_static(__FUNCTION__ . '_' . $user_id);
 
-    // Generate unique static callable / uf_match
-    $contact_uf_match = &drupal_static(__FUNCTION__ . '_' . $user_id);
-
-    if (!isset($contact_uf_match)) {
-        if ($cache = cache_get('civihr_uf_match_data_' . $user_id)) {
-            $contact_uf_match = $cache->data;
-        }
-        else {
-
-            try {
-
-                // Civi init
-                civicrm_initialize();
-
-                $params = array(
-                    'uf_id' => $user_id,
-                    'version' => 3,
-                    'sequential' => 1,
-                );
-
-                // Get the contact DATA from the passed user ID
-                $res = civicrm_api3('UFMatch', 'Get', $params);
-                $contact_uf_match = array_shift($res['values']);
-
-                watchdog('DB hit user uf_match data', print_r($user_id, TRUE));
-
-            }
-
-            catch (CiviCRM_API3_Exception $e) {
-                $error = $e->getMessage();
-            }
-
-            // Cache the contact data for 5 minutes
-            cache_set('civihr_uf_match_data_' . $user_id, $contact_uf_match, 'cache', time() + 360);
-        }
+  if (!isset($contact_uf_match)) {
+    if ($cache = cache_get('civihr_uf_match_data_' . $user_id)) {
+      $contact_uf_match = $cache->data;
     }
+    else {
+      try {
+        // Civi init
+        civicrm_initialize();
 
-    return $contact_uf_match;
+        $params = [
+          'uf_id' => $user_id,
+          'version' => 3,
+          'sequential' => 1,
+        ];
+
+        // Get the contact DATA from the passed user ID
+        $res = civicrm_api3('UFMatch', 'Get', $params);
+        $contact_uf_match = array_shift($res['values']);
+
+        watchdog('DB hit user uf_match data', print_r($user_id, TRUE));
+      }
+      catch (CiviCRM_API3_Exception $e) {
+        $error = $e->getMessage();
+      }
+
+      // Cache the contact data for 5 minutes
+      cache_set('civihr_uf_match_data_' . $user_id, $contact_uf_match, 'cache', time() + 360);
+    }
+  }
+
+  return $contact_uf_match;
 }
 
 /**
  * Function for caching contact data returned from CiviCRM
  */
 function get_civihr_contact_data($contact_id = NULL, $user_id = '') {
+  // If $user_id is passed get the contact ID and continue in the function
+  if (isset($user_id) && $user_id != '') {
+    // Get the contact ID based on the USER ID
+    $contact_id = get_civihr_uf_match_data($user_id)['contact_id'];
+  }
 
-    // If $user_id is passed get the contact ID and continue in the function
-    if (isset($user_id) && $user_id != '') {
+  // Generate unique static callable / contact
+  $contact_data = &drupal_static(__FUNCTION__ . '_' . $contact_id);
 
-        // Get the contact ID based on the USER ID
-        $contact_id = get_civihr_uf_match_data($user_id)['contact_id'];
-
+  if (!isset($contact_data)) {
+    if ($cache = cache_get('civihr_contact_data_' . $contact_id)) {
+      $contact_data = $cache->data;
     }
+    else {
+      try {
+        civicrm_initialize();
 
-    // Generate unique static callable / contact
-    $contact_data = &drupal_static(__FUNCTION__ . '_' . $contact_id);
+        $contact_data = civicrm_api('Contact', 'getsingle', [
+          'version' => 3,
+          'return' => ['display_name', 'nick_name', 'image_URL', 'email', 'phone'],
+          'id' => $contact_id
+        ]);
 
-    if (!isset($contact_data)) {
-        if ($cache = cache_get('civihr_contact_data_' . $contact_id)) {
-            $contact_data = $cache->data;
-        }
-        else {
+        watchdog('DB hit contact data', print_r($contact_id, TRUE));
+      }
+      catch (CiviCRM_API3_Exception $e) {
+        $error = $e->getMessage();
+      }
 
-            try {
-
-                // Civi init
-                civicrm_initialize();
-
-                $contact_data = civicrm_api('Contact', 'getsingle', array(
-                    'version' => 3,
-                    'return' => array('display_name', 'nick_name', 'image_URL', 'email', 'phone'),
-                    'id' => $contact_id
-                ));
-                watchdog('DB hit contact data', print_r($contact_id, TRUE));
-
-            }
-
-            catch (CiviCRM_API3_Exception $e) {
-                $error = $e->getMessage();
-            }
-
-            // Cache the contact data for 5 minutes
-            cache_set('civihr_contact_data_' . $contact_id, $contact_data, 'cache', time() + 360);
-        }
+      // Cache the contact data for 5 minutes
+      cache_set('civihr_contact_data_' . $contact_id, $contact_data, 'cache', time() + 360);
     }
+  }
 
-    return $contact_data;
+  return $contact_data;
 }
 
 /**
  * Implementation of hook_menu()
  */
 function civihr_employee_portal_menu() {
-    //get all drupal roles except the default ones (anonymous user) and (authenticated user)
-    $all_roles = user_roles();
-    unset($all_roles[array_search('anonymous user', $all_roles)]);
-    unset($all_roles[array_search('authenticated user', $all_roles)]);
-    $all_roles = array_values($all_roles);
+  //get all drupal roles except the default ones (anonymous user) and (authenticated user)
+  $all_roles = user_roles();
+  unset($all_roles[array_search('anonymous user', $all_roles)]);
+  unset($all_roles[array_search('authenticated user', $all_roles)]);
+  $all_roles = array_values($all_roles);
 
-    $items = array();
-    $items['request_new_account/%ctools_js'] = array(
-        'title' => 'Edit Document',
-        'page callback' => 'civihr_employee_portal_request_new_account',
-        'page arguments' => array(1),
-        'access callback' => TRUE,
-        'type' => MENU_CALLBACK,
-    );
+  $items = [];
+  $items['request_new_account/%ctools_js'] = [
+    'title' => 'Edit Document',
+    'page callback' => 'civihr_employee_portal_request_new_account',
+    'page arguments' => [1],
+    'access callback' => TRUE,
+    'type' => MENU_CALLBACK,
+  ];
 
-    $items['civi_documents/ajax/change_document_status/%/%'] = array(
-        'title' => 'Change Document Status',
-        'page callback' => 'civihr_employee_portal_change_document_status',
-		    'access arguments' => array('change document status'),
-        'page arguments' => array(3, 4),
-        'type' => MENU_CALLBACK,
-    );
+  $items['civi_documents/ajax/change_document_status/%/%'] = [
+    'title' => 'Change Document Status',
+    'page callback' => 'civihr_employee_portal_change_document_status',
+    'access arguments' => ['change document status'],
+    'page arguments' => [3, 4],
+    'type' => MENU_CALLBACK,
+  ];
 
-    $items['civi_documents/%ctools_js/edit/%'] = array(
-        'title' => 'Edit Document',
-        'page callback' => 'civihr_employee_portal_edit_document',
-        'page arguments' => array(1, 3),
-        'access callback' => TRUE,
-        'type' => MENU_CALLBACK,
-    );
+  $items['civi_documents/%ctools_js/edit/%'] = [
+    'title' => 'Edit Document',
+    'page callback' => 'civihr_employee_portal_edit_document',
+    'page arguments' => [1, 3],
+    'access callback' => TRUE,
+    'type' => MENU_CALLBACK,
+  ];
 
-    $items['civi_documents/%ctools_js/delete/%'] = array(
-        'title' => 'Delete Document',
-        'page callback' => 'civihr_employee_portal_delete_document',
-        'page arguments' => array(1, 3),
-        'access callback' => TRUE,
-        'type' => MENU_CALLBACK,
-    );
+  $items['civi_documents/%ctools_js/delete/%'] = [
+    'title' => 'Delete Document',
+    'page callback' => 'civihr_employee_portal_delete_document',
+    'page arguments' => [1, 3],
+    'access callback' => TRUE,
+    'type' => MENU_CALLBACK,
+  ];
 
-    $items['civi_documents/%ctools_js/reminder/%'] = array(
-        'title' => 'Send Reminder',
-        'page callback' => 'civihr_employee_portal_send_reminder_document',
-        'page arguments' => array(1, 3),
-        'access callback' => TRUE,
-        'type' => MENU_CALLBACK,
-    );
+  $items['civi_documents/%ctools_js/reminder/%'] = [
+    'title' => 'Send Reminder',
+    'page callback' => 'civihr_employee_portal_send_reminder_document',
+    'page arguments' => [1, 3],
+    'access callback' => TRUE,
+    'type' => MENU_CALLBACK,
+  ];
 
-    $items['civi_tasks/%ctools_js/view_completed'] = array(
-        'page callback' => 'civihr_employee_portal_civi_tasks_view_completed_callback',
-        'page arguments' => array(1),
-        'access callback' => TRUE,
-        'type' => MENU_CALLBACK,
-    );
+  $items['civi_tasks/%ctools_js/view_completed'] = [
+    'page callback' => 'civihr_employee_portal_civi_tasks_view_completed_callback',
+    'page arguments' => [1],
+    'access callback' => TRUE,
+    'type' => MENU_CALLBACK,
+  ];
 
-    $items['civi_tasks/%ctools_js/create'] = array(
-        'title' => 'Create new Task',
-        'page callback' => 'civihr_employee_portal_civi_tasks_create',
-        'page arguments' => array(1),
-        'access callback' => TRUE,
-        'type' => MENU_CALLBACK,
-    );
+  $items['civi_tasks/%ctools_js/create'] = [
+    'title' => 'Create new Task',
+    'page callback' => 'civihr_employee_portal_civi_tasks_create',
+    'page arguments' => [1],
+    'access callback' => TRUE,
+    'type' => MENU_CALLBACK,
+  ];
 
-    $items['civi_tasks/%ctools_js/edit/%'] = array(
-        'title' => 'Edit Task',
-        'page callback' => 'civihr_employee_portal_civi_tasks_create',
-        'page arguments' => array(1, 3),
-        'access callback' => TRUE,
-        'type' => MENU_CALLBACK,
-    );
+  $items['civi_tasks/%ctools_js/edit/%'] = [
+    'title' => 'Edit Task',
+    'page callback' => 'civihr_employee_portal_civi_tasks_create',
+    'page arguments' => [1, 3],
+    'access callback' => TRUE,
+    'type' => MENU_CALLBACK,
+  ];
 
-    $items['civi_tasks/ajax/complete/%'] = array(
-        'title' => 'Mark Task as complete',
-        'page callback' => 'civihr_employee_portal_civi_tasks_complete',
-        'page arguments' => array(3),
-        'access callback' => TRUE,
-        'type' => MENU_CALLBACK,
-    );
+  $items['civi_tasks/ajax/complete/%'] = [
+    'title' => 'Mark Task as complete',
+    'page callback' => 'civihr_employee_portal_civi_tasks_complete',
+    'page arguments' => [3],
+    'access callback' => TRUE,
+    'type' => MENU_CALLBACK,
+  ];
 
-    /**
-     * Appraisals menu items.
-     */
-    $items['hr-appraisals-manager/%ctools_js/upload/%'] = array(
-        'title' => 'Appraisal Upload',
-        'page callback' => 'civihr_employee_portal_appraisal_manager_upload',
-        'page arguments' => array(1, 3),
-        'access callback' => TRUE,
-        'type' => MENU_CALLBACK,
-    );
+  $items['hr-appraisals-manager/%ctools_js/upload/%'] = [
+    'title' => 'Appraisal Upload',
+    'page callback' => 'civihr_employee_portal_appraisal_manager_upload',
+    'page arguments' => [1, 3],
+    'access callback' => TRUE,
+    'type' => MENU_CALLBACK,
+  ];
 
-    $items['hr-appraisals-manager/%ctools_js/view/%'] = array(
-        'title' => 'Appraisal View',
-        'page callback' => 'civihr_employee_portal_appraisal_manager_view',
-        'page arguments' => array(1, 3),
-        'access callback' => TRUE,
-        'type' => MENU_CALLBACK,
-    );
+  $items['hr-appraisals-manager/%ctools_js/view/%'] = [
+    'title' => 'Appraisal View',
+    'page callback' => 'civihr_employee_portal_appraisal_manager_view',
+    'page arguments' => [1, 3],
+    'access callback' => TRUE,
+    'type' => MENU_CALLBACK,
+  ];
 
-    $items['hr-appraisals-employee/%ctools_js/upload/%'] = array(
-        'title' => 'Appraisal Upload',
-        'page callback' => 'civihr_employee_portal_appraisal_employee_upload',
-        'page arguments' => array(1, 3),
-        'access callback' => TRUE,
-        'type' => MENU_CALLBACK,
-    );
+  $items['hr-appraisals-employee/%ctools_js/upload/%'] = [
+    'title' => 'Appraisal Upload',
+    'page callback' => 'civihr_employee_portal_appraisal_employee_upload',
+    'page arguments' => [1, 3],
+    'access callback' => TRUE,
+    'type' => MENU_CALLBACK,
+  ];
 
-    /**
-     * Not used currently
-    $items['civihr_contacts'] = array(
-        'title' => 'Vacancy list',
-        'page callback' => 'civihr_employee_portal_get_contact_list',
-        'access callback' => TRUE,
-        'type' => MENU_CALLBACK,
-    );
-     */
+  $items['hr_resources/%ctools_js/resource/%'] = [
+    'page callback' => 'civihr_employee_portal_hr_resource_load_callback',
+    'page arguments' => [1, 3],
+    'access callback' => TRUE,
+    'type' => MENU_CALLBACK,
+  ];
 
-    $items['hr_resources/%ctools_js/resource/%'] = array(
-        'page callback' => 'civihr_employee_portal_hr_resource_load_callback',
-        'page arguments' => array(1, 3),
-        'access callback' => TRUE,
-        'type' => MENU_CALLBACK,
-    );
+  $items['my_details/%ctools_js/view'] = [
+    'page callback' => 'civihr_employee_portal_my_details_callback',
+    'page arguments' => [1],
+    'access callback' => TRUE,
+    'type' => MENU_CALLBACK,
+  ];
 
-    $items['my_details/%ctools_js/view'] = array(
-        'page callback' => 'civihr_employee_portal_my_details_callback',
-        'page arguments' => array(1),
-        'access callback' => TRUE,
-        'type' => MENU_CALLBACK,
-    );
+  $items['emergency_contacts/%ctools_js/view'] = [
+    'page callback' => 'civihr_employee_portal_emergency_contacts_callback',
+    'page arguments' => [1],
+    'access callback' => TRUE,
+    'type' => MENU_CALLBACK,
+  ];
 
-    $items['emergency_contacts/%ctools_js/view'] = array(
-        'page callback' => 'civihr_employee_portal_emergency_contacts_callback',
-        'page arguments' => array(1),
-        'access callback' => TRUE,
-        'type' => MENU_CALLBACK,
-    );
+  $items['hr-details'] = [
+    'title' => 'My Details',
+    'page callback' => 'civihr_employee_portal_my_details',
+    'access arguments' => ['view my details'],
+    'type' => MENU_NORMAL_ITEM,
+    'menu_name' => 'main-menu',
+    'weight' => 4
+  ];
 
-    $items['hr-details'] = array(
-        'title' => 'My Details',
-        'page callback' => 'civihr_employee_portal_my_details',
-        'access arguments' => array('view my details'),
-        'type' => MENU_NORMAL_ITEM,
-        'menu_name' => 'main-menu',
-        'weight' => 4
-    );
+  $items['reports'] = [
+    'title' => 'Reports',
+    'page callback' => 'civihr_employee_portal_hrreport_landing_page',
+    'access arguments' => ['access hrreports'],
+    'type' => MENU_NORMAL_ITEM,
+    'menu_name' => 'main-menu',
+    'weight' => 5,
+  ];
+  $items['reports/%'] = [
+    'title' => 'CiviHR Custom Report',
+    'page callback' => 'civihr_employee_portal_hrreport_custom',
+    'page arguments' => [1],
+    'access arguments' => ['access hrreports'],
+    'type' => MENU_CALLBACK,
+  ];
+  $items['reports/%/json'] = [
+    'page callback' => 'civihr_employee_portal_hrreport_get_json',
+    'page arguments' => [1],
+    'access arguments' => ['access hrreports'],
+    'type' => MENU_CALLBACK,
+  ];
+  $items['reports/%/table'] = [
+    'title' => 'CiviHR Custom Report',
+    'page callback' => 'civihr_employee_portal_hrreport_custom_printtable',
+    'page arguments' => [1],
+    'access arguments' => ['access hrreports'],
+    'type' => MENU_CALLBACK,
+  ];
+  $items['reports/settings/age_group'] = [
+    'title' => 'Reports settings - Age group',
+    'page callback' => 'civihr_employee_portal_hrreport_settings_age_group',
+    'access arguments' => ['manage hrreports settings'],
+    'type' => MENU_CALLBACK,
+  ];
+  $items['reports/settings/age_group/%ctools_js/create'] = [
+    'title' => 'Create Age Group',
+    'page callback' => 'civihr_employee_portal_hrreport_settings_age_group_create',
+    'page arguments' => [3],
+    'access arguments' => ['manage hrreports settings'],
+    'type' => MENU_CALLBACK,
+  ];
+  $items['reports/settings/age_group/%ctools_js/edit/%'] = [
+    'title' => 'Edit Age Group',
+    'page callback' => 'civihr_employee_portal_hrreport_settings_age_group_create',
+    'page arguments' => [3, 5],
+    'access arguments' => ['manage hrreports settings'],
+    'type' => MENU_CALLBACK,
+  ];
+  $items['reports/settings/age_group/%ctools_js/delete/%'] = [
+    'title' => 'Delete Age Group',
+    'page callback' => 'civihr_employee_portal_hrreport_settings_age_group_delete',
+    'page arguments' => [3, 5],
+    'access arguments' => ['manage hrreports settings'],
+    'type' => MENU_CALLBACK,
+  ];
+  $items['reports/%/configuration/%'] = [
+    'title' => 'Get Report configuration',
+    'page callback' => 'civihr_employee_portal_get_report_configuration_json',
+    'page arguments' => [1, 3],
+    'access arguments' => ['access hrreports'],
+    'type' => MENU_CALLBACK,
+  ];
+  $items['reports/%/configuration/%/save'] = [
+    'title' => 'Save Report configuration',
+    'page callback' => 'civihr_employee_portal_save_report_configuration_json',
+    'page arguments' => [1, 3],
+    'access arguments' => ['manage hrreports configuration'],
+    'type' => MENU_CALLBACK,
+  ];
+  $items['reports/%/configuration/%/delete'] = [
+    'title' => 'Delete Report configuration',
+    'page callback' => 'civihr_employee_portal_delete_report_configuration_json',
+    'page arguments' => [1, 3],
+    'access arguments' => ['manage hrreports configuration'],
+    'type' => MENU_CALLBACK,
+  ];
 
-    $items['reports'] = array(
-        'title' => 'Reports',
-        'page callback' => 'civihr_employee_portal_hrreport_landing_page',
-        'access arguments' => array('access hrreports'),
-        'type' => MENU_NORMAL_ITEM,
-        'menu_name' => 'main-menu',
-        'weight' => 5,
-    );
-    $items['reports/%'] = array(
-        'title' => 'CiviHR Custom Report',
-        'page callback' => 'civihr_employee_portal_hrreport_custom',
-        'page arguments' => array(1),
-        'access arguments' => array('access hrreports'),
-        'type' => MENU_CALLBACK,
-    );
-    $items['reports/%/json'] = array(
-        'page callback' => 'civihr_employee_portal_hrreport_get_json',
-        'page arguments' => array(1),
-        'access arguments' => array('access hrreports'),
-        'type' => MENU_CALLBACK,
-    );
-    $items['reports/%/table'] = array(
-        'title' => 'CiviHR Custom Report',
-        'page callback' => 'civihr_employee_portal_hrreport_custom_printtable',
-        'page arguments' => array(1),
-        'access arguments' => array('access hrreports'),
-        'type' => MENU_CALLBACK,
-    );
-    $items['reports/settings/age_group'] = array(
-        'title' => 'Reports settings - Age group',
-        'page callback' => 'civihr_employee_portal_hrreport_settings_age_group',
-        'access arguments' => array('manage hrreports settings'),
-        'type' => MENU_CALLBACK,
-    );
-    $items['reports/settings/age_group/%ctools_js/create'] = array(
-        'title' => 'Create Age Group',
-        'page callback' => 'civihr_employee_portal_hrreport_settings_age_group_create',
-        'page arguments' => array(3),
-        'access arguments' => array('manage hrreports settings'),
-        'type' => MENU_CALLBACK,
-    );
-    $items['reports/settings/age_group/%ctools_js/edit/%'] = array(
-        'title' => 'Edit Age Group',
-        'page callback' => 'civihr_employee_portal_hrreport_settings_age_group_create',
-        'page arguments' => array(3, 5),
-        'access arguments' => array('manage hrreports settings'),
-        'type' => MENU_CALLBACK,
-    );
-    $items['reports/settings/age_group/%ctools_js/delete/%'] = array(
-        'title' => 'Delete Age Group',
-        'page callback' => 'civihr_employee_portal_hrreport_settings_age_group_delete',
-        'page arguments' => array(3, 5),
-        'access arguments' => array('manage hrreports settings'),
-        'type' => MENU_CALLBACK,
-    );
-    $items['reports/%/configuration/%'] = array(
-        'title' => 'Get Report configuration',
-        'page callback' => 'civihr_employee_portal_get_report_configuration_json',
-        'page arguments' => array(1, 3),
-        'access arguments' => array('access hrreports'),
-        'type' => MENU_CALLBACK,
-    );
-    $items['reports/%/configuration/%/save'] = array(
-        'title' => 'Save Report configuration',
-        'page callback' => 'civihr_employee_portal_save_report_configuration_json',
-        'page arguments' => array(1, 3),
-        'access arguments' => array('manage hrreports configuration'),
-        'type' => MENU_CALLBACK,
-    );
-    $items['reports/%/configuration/%/delete'] = array(
-        'title' => 'Delete Report configuration',
-        'page callback' => 'civihr_employee_portal_delete_report_configuration_json',
-        'page arguments' => array(1, 3),
-        'access arguments' => array('manage hrreports configuration'),
-        'type' => MENU_CALLBACK,
-    );
-
-    return $items;
+  return $items;
 }
 
 /**
  * Function to check the menu item access against specific roles
+ *
  * @param $roles
+ *
  * @return bool
  */
-function _user_has_role($roles = array()) {
+function _user_has_role($roles = []) {
+  // Check for the logged in user
+  global $user;
 
-    // Check for the logged in user
-    global $user;
-
-    foreach ($roles as $role) {
-        if (in_array($role, $user->roles)) {
-            return TRUE;
-        }
+  foreach ($roles as $role) {
+    if (in_array($role, $user->roles)) {
+      return TRUE;
     }
+  }
 
-    return FALSE;
-
+  return FALSE;
 }
 
 /**
  * Loads civicrm_uf_match data based on passed contact_id
+ *
  * @param $contact_id
+ *
  * @return mixed
+ *
  * @throws CiviCRM_API3_Exception
  */
 function _get_uf_match_contact($contact_id) {
+  $params = [
+    'contact_id' => $contact_id,
+    'version' => 3,
+    'sequential' => 1,
+  ];
 
-    $params = array(
-        'contact_id' => $contact_id,
-        'version' => 3,
-        'sequential' => 1,
-    );
+  // Get the "civicrm_uf_match" data from the passed target contact ID
+  $res = civicrm_api3('UFMatch', 'Get', $params);
+  $uf_match_data = array_shift($res['values']);
 
-    // Get the "civicrm_uf_match" data from the passed target contact ID
-    $res = civicrm_api3('UFMatch', 'Get', $params);
-    $uf_match_data = array_shift($res['values']);
-
-    return $uf_match_data;
+  return $uf_match_data;
 }
 
 /**
  * Gets CiviCRM contact ID based on passed drupal UID
+ *
  * @param $uid
+ *
  * @return int | null
  */
 function _get_civicrm_contact_id_by_drupal_uid($uid) {
+  $params = [
+    'uf_id' => $uid,
+    'version' => 3,
+    'sequential' => 1,
+  ];
 
-    $params = array(
-        'uf_id' => $uid,
-        'version' => 3,
-        'sequential' => 1,
-    );
+  // Get the "civicrm_uf_match" data from the passed target contact ID
+  $res = civicrm_api3('UFMatch', 'Get', $params);
 
-    // Get the "civicrm_uf_match" data from the passed target contact ID
-    $res = civicrm_api3('UFMatch', 'Get', $params);
-    if (empty($res['values'])) {
-        return null;
-    }
+  if (empty($res['values'])) {
+    return null;
+  }
 
-    $uf_match_data = array_shift($res['values']);
+  $uf_match_data = array_shift($res['values']);
 
-    return $uf_match_data['contact_id'];
+  return $uf_match_data['contact_id'];
 }
 
 /**
@@ -1704,131 +1646,123 @@ function _get_civicrm_contact_id_by_drupal_uid($uid) {
  * The links that are known to be a .chr_action element, have their text wrapper in a <span>
  * so that they can be responsive if the class .chr_action--icon--responsive is applied
  *
- *
  * @param string $link_text
  * @param string $link_type
  * @param string $nid
  * @param string $class
  *   Any additional css classes that the links must have
+ *
  * @return string
  */
 function civihr_employee_portal_make_link($link_text, $link_type, $nid = '', $class = '') {
+  // Set a default value if no text in supplied.
+  if (empty($link_text)) {
+    $link_text = t('Modal');
+  }
 
-    // Set a default value if no text in supplied.
-    if (empty($link_text)) {
-        $link_text = t('Modal');
-    }
+  if ($link_type == 'hr-resource') {
+    return '' . l($link_text, 'hr_resources/nojs/resource/' . $nid,
+      ['attributes' => ['class' => "ctools-use-modal ctools-modal-civihr-custom-style $class"]]
+    ) . '';
+  }
 
-    if ($link_type == 'hr-resource') {
-        return '' . l($link_text, 'hr_resources/nojs/resource/' . $nid,
-            array('attributes' => array('class' => "ctools-use-modal ctools-modal-civihr-custom-style $class"))
-        ) . '';
-    }
+  if ($link_type == 'document') {
+    return '' . l($link_text, 'civi_documents/nojs/edit/' . $nid,
+      ['attributes' => ['class' => "ctools-use-modal ctools-modal-civihr-default-style $class"]]
+    ) . '';
+  }
 
-    if ($link_type == 'document') {
-        return '' . l($link_text, 'civi_documents/nojs/edit/' . $nid,
-            array('attributes' => array('class' => "ctools-use-modal ctools-modal-civihr-default-style $class"))
-        ) . '';
-    }
-
-    return '';
+  return '';
 }
 
 /**
  * HR resource modal display callback
  */
 function civihr_employee_portal_hr_resource_load_callback($ajax, $nid) {
+  if ($ajax) {
+    // Get the node data, based on the passed NODE ID
+    $node = node_load($nid);
 
-    if ($ajax) {
+    ctools_include('ajax');
+    ctools_include('modal');
 
-        // Get the node data, based on the passed NODE ID
-        $node = node_load($nid);
+    // Add the responder javascript, required by ctools
+    ctools_add_js('ajax-responder');
 
-        ctools_include('ajax');
-        ctools_include('modal');
+    $output = [];
 
-        // Add the responder javascript, required by ctools
-        ctools_add_js('ajax-responder');
+    // Get the view, filter by the passed NODE ID and Display
+    $output[] = ctools_modal_command_display($node->title, views_embed_view('hr_documents', 'hr_resources_modal', [$nid]));
 
-        $output = array();
-
-        // Get the view, filter by the passed NODE ID and Display
-        $output[] = ctools_modal_command_display($node->title, views_embed_view('hr_documents', 'hr_resources_modal', array($nid)));
-
-        print ajax_render($output);
-        drupal_exit();
-    }
-    else {
-        return '';
-    }
-
+    print ajax_render($output);
+    drupal_exit();
+  }
+  else {
+    return '';
+  }
 }
 
 /**
  * My details / Edit my details callback
  */
 function civihr_employee_portal_my_details_callback($ajax) {
+  if ($ajax) {
+    ctools_include('ajax');
+    ctools_include('modal');
 
-    if ($ajax) {
+    // Add the responder javascript, required by ctools
+    ctools_add_js('ajax-responder');
 
-        ctools_include('ajax');
-        ctools_include('modal');
+    // Load the my details node
+    $contents = t('An error occured while loading Webform.');
+    $my_details_webform_id = variable_get('my_details_webform_nid');
 
-        // Add the responder javascript, required by ctools
-        ctools_add_js('ajax-responder');
-
-        // Load the my details node
-        $contents = t('An error occured while loading Webform.');
-        $my_details_webform_id = variable_get('my_details_webform_nid');
-        if ($my_details_webform_id) {
-            $node = node_load($my_details_webform_id);
-            $node_render = node_view($node, 'full', NULL);
-            $contents = render($node_render);
-        }
-
-        $output = array();
-        $output[] = ctools_modal_command_display(t('My Details'), render($contents));
-
-        print ajax_render($output);
-        drupal_exit();
-    }
-    else {
-        return '';
+    if ($my_details_webform_id) {
+      $node = node_load($my_details_webform_id);
+      $node_render = node_view($node, 'full', NULL);
+      $contents = render($node_render);
     }
 
+    $output = [];
+    $output[] = ctools_modal_command_display(t('My Details'), render($contents));
+
+    print ajax_render($output);
+    drupal_exit();
+  }
+  else {
+    return '';
+  }
 }
 
 /**
  * My details / Edit emergency contacts callback
  */
 function civihr_employee_portal_emergency_contacts_callback($ajax) {
+  if ($ajax) {
+    ctools_include('ajax');
+    ctools_include('modal');
 
-    if ($ajax) {
+    // Add the responder javascript, required by ctools
+    ctools_add_js('ajax-responder');
 
-        ctools_include('ajax');
-        ctools_include('modal');
+    // Load the emergency contacts node
+    $contents = t('An error occured while loading Webform.');
+    $emergency_contact_webform_id = variable_get('emergency_contact_webform_nid');
 
-        // Add the responder javascript, required by ctools
-        ctools_add_js('ajax-responder');
-
-        // Load the emergency contacts node
-        $contents = t('An error occured while loading Webform.');
-        $emergency_contact_webform_id = variable_get('emergency_contact_webform_nid');
-        if ($emergency_contact_webform_id) {
-            $node = node_load($emergency_contact_webform_id);
-            $contents = render(node_view($node, 'full', NULL));
-        }
-
-        $output = array();
-        $output[] = ctools_modal_command_display('Emergency contacts', render($contents));
-
-        print ajax_render($output);
-        drupal_exit();
-    }
-    else {
-        return '';
+    if ($emergency_contact_webform_id) {
+      $node = node_load($emergency_contact_webform_id);
+      $contents = render(node_view($node, 'full', NULL));
     }
 
+    $output = [];
+    $output[] = ctools_modal_command_display('Emergency contacts', render($contents));
+
+    print ajax_render($output);
+    drupal_exit();
+  }
+  else {
+    return '';
+  }
 }
 
 /**
@@ -1841,40 +1775,40 @@ function civihr_employee_portal_emergency_contacts_callback($ajax) {
  *  ID of new status
  */
 function civihr_employee_portal_change_document_status($document_id, $status_id) {
-    $res = array(
-        'success' => 0,
-        'document_id' => $document_id,
+  $res = [
+    'success' => 0,
+    'document_id' => $document_id,
+    'status_id' => $status_id,
+    'message' => t("Error processing status change."),
+  ];
+
+  try {
+    //check whether curent user is assignee of document
+    if (_document_can_be_modified($document_id)) {
+      $result = civicrm_api3('Document', 'create', [
+        'sequential' => 1,
+        'id' => $document_id,
         'status_id' => $status_id,
-        'message' => t("Error processing status change."),
-    );
+      ]);
 
-    try {
-        //check whether curent user is assignee of document
-        if (_document_can_be_modified($document_id)) {
-            $result = civicrm_api3('Document', 'create', array(
-                'sequential' => 1,
-                'id' => $document_id,
-                'status_id' => $status_id,
-            ));
-
-            if ($result['is_error'] !== 1) {
-                $res['success'] = 1;
-                $res['message'] = t("Document status changed.");
-            }
-        } else {
-            $res['message'] = t("Lack of permission to change document status.");
-        }
-    } catch (CiviCRM_API3_Exception $e) {
-        $error = $e->getMessage();
-        $res['message'] = t("Error communicating with API.");
+      if ($result['is_error'] !== 1) {
+        $res['success'] = 1;
+        $res['message'] = t("Document status changed.");
+      }
+    } else {
+      $res['message'] = t("Lack of permission to change document status.");
     }
+  } catch (CiviCRM_API3_Exception $e) {
+    $error = $e->getMessage();
+    $res['message'] = t("Error communicating with API.");
+  }
 
-    //clear views cache to reflect changes
-    _clear_json_cache();
+  //clear views cache to reflect changes
+  _clear_json_cache();
 
-    // Output json
-    drupal_json_output($res);
-    drupal_exit();
+  // Output json
+  drupal_json_output($res);
+  drupal_exit();
 }
 
 /**
@@ -1890,535 +1824,508 @@ function civihr_employee_portal_change_document_status($document_id, $status_id)
  *  TRUE if user has needed permission(s), FALSE if he doesn't
  */
 function _document_can_be_modified($document_id, $user_id = NULL) {
-    $res = FALSE;
+  $res = FALSE;
 
-    if ($user_id === NULL) {
-        global $user;
-    } else {
-        $user = user_load($user_id);
+  if ($user_id === NULL) {
+    global $user;
+  } else {
+    $user = user_load($user_id);
+  }
+
+  if (user_access('change document status')) {
+    try {
+      $result = civicrm_api3('Document', 'get', [
+        'sequential' => 1,
+        'return' => "id,assignee_contact_id",
+        'id' => $document_id,
+      ]);
+
+      $uf = get_civihr_uf_match_data($user->uid);
+      $result_values = reset($result['values']);
+
+      if (in_array($uf['contact_id'], $result_values['assignee_contact_id'])) {
+        $res = TRUE;
+      }
+    } catch (CiviCRM_API3_Exception $e) {
+      $error = $e->getMessage();
     }
+  }
 
-    if (user_access('change document status')) {
-        try {
-            $result = civicrm_api3('Document', 'get', array(
-                'sequential' => 1,
-                'return' => "id,assignee_contact_id",
-                'id' => $document_id,
-            ));
-
-            $uf = get_civihr_uf_match_data($user->uid);
-            $result_values = reset($result['values']);
-
-            if (in_array($uf['contact_id'], $result_values['assignee_contact_id'])) {
-                $res = TRUE;
-            }
-        } catch (CiviCRM_API3_Exception $e) {
-            $error = $e->getMessage();
-        }
-    }
-
-    return $res;
+  return $res;
 }
 
 /**
-* Ajax menu callback.
-*/
+ * Ajax menu callback.
+ */
 function civihr_employee_portal_edit_document($ajax, $id) {
+  if ($ajax) {
+    ctools_include('ajax');
+    ctools_include('modal');
 
-    if ($ajax) {
-        ctools_include('ajax');
-        ctools_include('modal');
+    $title = t('Upload Document');
 
-        $title = t('Upload Document');
+    $form_state = [
+      'ajax' => TRUE,
+      'is_ajax_update' => TRUE,
+      'title' => $title,
+      'id' => $id,
+    ];
 
-        $form_state = array(
-            'ajax' => TRUE,
-            'is_ajax_update' => TRUE,
-            'title' => $title,
-            'id' => $id,
-        );
-
-        // Since this will run again on form rebuild while still in the modal, prevent
-        // form IDs from being incremented.
-        // @todo https://drupal.org/node/1305882
-        if (!empty($_POST['ajax_html_ids'])) {
-            unset($_POST['ajax_html_ids']);
-        }
-
-        // Use ctools to generate ajax instructions for the browser to create
-        // a form in a modal popup.
-        $output = ctools_modal_form_wrapper('civihr_employee_portal_document_form', $form_state);
-
-        // If the form has been submitted, there may be additional instructions
-        // such as dismissing the modal popup.
-        if (!empty($form_state['executed'])) {
-
-            // Add the responder javascript, required by ctools
-            ctools_add_js('ajax-responder');
-
-            $output[] = ajax_command_replace('.messages', 'all good');
-            $output[] = ctools_modal_command_dismiss();
-            $output[] = ctools_ajax_command_redirect('dashboard');
-
-        }
-
-        // Return the ajax instructions to the browser via ajax_render().
-        print ajax_render($output);
-        drupal_exit();
-
+    // Since this will run again on form rebuild while still in the modal, prevent
+    // form IDs from being incremented.
+    // @todo https://drupal.org/node/1305882
+    if (!empty($_POST['ajax_html_ids'])) {
+      unset($_POST['ajax_html_ids']);
     }
 
-    else {
-        return drupal_get_form('civihr_employee_portal_document_form');
+    // Use ctools to generate ajax instructions for the browser to create
+    // a form in a modal popup.
+    $output = ctools_modal_form_wrapper('civihr_employee_portal_document_form', $form_state);
+
+    // If the form has been submitted, there may be additional instructions
+    // such as dismissing the modal popup.
+    if (!empty($form_state['executed'])) {
+      // Add the responder javascript, required by ctools
+      ctools_add_js('ajax-responder');
+
+      $output[] = ajax_command_replace('.messages', 'all good');
+      $output[] = ctools_modal_command_dismiss();
+      $output[] = ctools_ajax_command_redirect('dashboard');
     }
 
+    // Return the ajax instructions to the browser via ajax_render().
+    print ajax_render($output);
+    drupal_exit();
+  }
+  else {
+    return drupal_get_form('civihr_employee_portal_document_form');
+  }
 }
 
 /**
  * Custom Document dashboard block form.
  */
 function civihr_employee_portal_document_form($form, &$form_state) {
+  $result_output = [];
+  $extensions = CRM_Core_PseudoConstant::getExtensions();
 
-    $result_output = array();
-    $extensions = CRM_Core_PseudoConstant::getExtensions();
-    if (empty($extensions['uk.co.compucorp.civicrm.tasksassignments'])) {
-        return $form;
-    }
-
-    $activityOptions = array();
-    $typeResult = civicrm_api3('Activity', 'getoptions', array(
-        'field' => "activity_type_id",
-    ));
-    $activityOptions['type'] = $typeResult['values'];
-
-    $result = civicrm_api3('Document', 'get', array(
-        'sequential' => 1,
-        'id' => $form_state['id'],
-    ));
-    $document = CRM_Utils_Array::first($result['values']);
-
-    $files = CRM_Tasksassignments_Page_Files::fileList(
-        array(
-            'entityTable' => 'civicrm_activity',
-            'entityID' => $document['id'],
-        )
-    );
-    //$files = array();
-
-    $form['#prefix'] = '<article class="node node-webform contextual-links-region clearfix"><div class="content">';
-    $form['#suffix'] = '</div></article>';
-
-    $form['id'] = array(
-        '#type' => 'hidden',
-        '#value' => $document['id'],
-    );
-
-    $form['document_type'] = array(
-        '#type' => 'textfield',
-        '#title' => t('Document type'),
-        '#prefix' => '<div class="row"><div class="col-md-12">',
-        '#suffix' => '</div></div>',
-        '#attributes' => array('readonly' => 'readonly'),
-        '#attributes' => array('disabled' => 'disabled'),
-        '#default_value' => $activityOptions['type'][$document['activity_type_id']],
-    );
-
-    $form['files'] = array(
-        '#type' => 'plupload',
-        '#title' => 'Files',
-        '#prefix' => '<div class="row"><div class="col-md-12"><div class="well drop-zone" id="drop-target">Drop document(s) here</div>',
-        '#suffix' => '<div id="notsupported">Your browser doesn\'t support multiupload feature.</div>
-            <div>
-                <table class="table table-condensed table-upload">
-                    <colgroup>
-                            <col class="col-index">
-                            <col class="col-name">
-                            <col class="col-size">
-                            <col class="col-status">
-                            <col class="col-action">
-                    </colgroup>
-                    <thead>
-                        <tr>
-                            <th>#</th>
-                            <th>Name</th>
-                            <th>Size</th>
-                            <th>Progress</th>
-                            <th></th>
-                        </tr>
-                    </thead>
-                    <tbody id="filelist">
-                    </tbody>
-                </table>
-            </div>
-            <br />
-            <div id="container">
-                <a href class="btn btn-primary" id="pickfiles">Select files</a>
-            </div>
-            <br />
-            <pre id="console"></pre>
-            <script>
-            CRM.$(document).trigger("uploaderFormReady", {id: ' . $document['id'] . ', table: "civicrm_activity", url: "/civicrm/tasksassignments/file/upload", formId: "civihr-employee-portal-document-form", title: "Document files", files:' . json_encode($files) . '});
-            </script>
-        </div></div>',
-    );
-
-    $form['expire_date'] = array(
-        '#type' => 'date_popup',
-        '#title' => t('Expiry date:'),
-        '#prefix' => '<div class="row"><div class="col-md-12">',
-        '#suffix' => '</div></div>',
-        '#date_format' => 'Y-m-d',
-        '#date_year_range' => '-10:+10',
-        '#default_value' => isset($document['expire_date']) ? strip_tags($document['expire_date']) : '',
-    );
-
-    $form['details'] = array(
-        '#type' => 'textarea',
-        '#title' => t('Notes'),
-        '#prefix' => '<div class="row"><div class="col-md-12">',
-        '#suffix' => '</div></div>',
-        '#rows' => 10,
-        '#cols' => 100,
-        '#default_value' => isset($document['details']) ? strip_tags($document['details']) : '',
-    );
-
-    $form['delete_files'] = array(
-        '#type' => 'hidden',
-        //'#tree' => TRUE,
-    );
-
-    $form['save'] = array(
-        '#type' => 'submit',
-        '#value' => t('Save'),
-        '#attributes' => array(
-            'class' => array(
-                'btn',
-                'btn-primary'
-            ),
-        ),
-    );
-
-    // Add the validation function
-    $form['#validate'][] = 'civihr_employee_portal_document_form_validate';
-
-    // Add the submit function
-    $form['#submit'][] = 'civihr_employee_portal_document_form_submit';
-
+  if (empty($extensions['uk.co.compucorp.civicrm.tasksassignments'])) {
     return $form;
+  }
+
+  $activityOptions = [];
+  $typeResult = civicrm_api3('Activity', 'getoptions', [
+    'field' => "activity_type_id",
+  ]);
+  $activityOptions['type'] = $typeResult['values'];
+
+  $result = civicrm_api3('Document', 'get', [
+    'sequential' => 1,
+    'id' => $form_state['id'],
+  ]);
+  $document = CRM_Utils_Array::first($result['values']);
+
+  $files = CRM_Tasksassignments_Page_Files::fileList([
+    'entityTable' => 'civicrm_activity',
+    'entityID' => $document['id'],
+  ]);
+
+  $form['#prefix'] = '<article class="node node-webform contextual-links-region clearfix"><div class="content">';
+  $form['#suffix'] = '</div></article>';
+  $form['id'] = [
+    '#type' => 'hidden',
+    '#value' => $document['id'],
+  ];
+  $form['document_type'] = [
+    '#type' => 'textfield',
+    '#title' => t('Document type'),
+    '#prefix' => '<div class="row"><div class="col-md-12">',
+    '#suffix' => '</div></div>',
+    '#attributes' => ['readonly' => 'readonly'],
+    '#attributes' => ['disabled' => 'disabled'],
+    '#default_value' => $activityOptions['type'][$document['activity_type_id']],
+  ];
+  $form['files'] = [
+    '#type' => 'plupload',
+    '#title' => 'Files',
+    '#prefix' => '<div class="row"><div class="col-md-12"><div class="well drop-zone" id="drop-target">Drop document(s) here</div>',
+    '#suffix' => '<div id="notsupported">Your browser doesn\'t support multiupload feature.</div>
+      <div>
+        <table class="table table-condensed table-upload">
+          <colgroup>
+            <col class="col-index">
+            <col class="col-name">
+            <col class="col-size">
+            <col class="col-status">
+            <col class="col-action">
+          </colgroup>
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Name</th>
+              <th>Size</th>
+              <th>Progress</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody id="filelist">
+          </tbody>
+        </table>
+      </div>
+      <br />
+      <div id="container">
+        <a href class="btn btn-primary" id="pickfiles">Select files</a>
+      </div>
+      <br />
+      <pre id="console"></pre>
+      <script>
+        CRM.$(document).trigger("uploaderFormReady", {id: ' . $document['id'] . ', table: "civicrm_activity", url: "/civicrm/tasksassignments/file/upload", formId: "civihr-employee-portal-document-form", title: "Document files", files:' . json_encode($files) . '});
+      </script>
+    </div></div>',
+  ];
+  $form['expire_date'] = [
+    '#type' => 'date_popup',
+    '#title' => t('Expiry date:'),
+    '#prefix' => '<div class="row"><div class="col-md-12">',
+    '#suffix' => '</div></div>',
+    '#date_format' => 'Y-m-d',
+    '#date_year_range' => '-10:+10',
+    '#default_value' => isset($document['expire_date']) ? strip_tags($document['expire_date']) : '',
+  ];
+
+  $form['details'] = [
+    '#type' => 'textarea',
+    '#title' => t('Notes'),
+    '#prefix' => '<div class="row"><div class="col-md-12">',
+    '#suffix' => '</div></div>',
+    '#rows' => 10,
+    '#cols' => 100,
+    '#default_value' => isset($document['details']) ? strip_tags($document['details']) : '',
+  ];
+  $form['delete_files'] = [
+    '#type' => 'hidden',
+  ];
+  $form['save'] = [
+    '#type' => 'submit',
+    '#value' => t('Save'),
+    '#attributes' => [
+      'class' => [
+        'btn',
+        'btn-primary'
+      ],
+    ],
+  ];
+
+  // Add the validation function
+  $form['#validate'][] = 'civihr_employee_portal_document_form_validate';
+
+  // Add the submit function
+  $form['#submit'][] = 'civihr_employee_portal_document_form_submit';
+
+  return $form;
 }
 
 function civihr_employee_portal_document_form_validate($form, &$form_state) {
 }
 
 function civihr_employee_portal_document_form_submit($form, &$form_state) {
+  $result_output = [];
+  $extensions = CRM_Core_PseudoConstant::getExtensions();
 
-    $result_output = array();
-    $extensions = CRM_Core_PseudoConstant::getExtensions();
-    if (empty($extensions['uk.co.compucorp.civicrm.tasksassignments'])) {
-        return false;
+  if (empty($extensions['uk.co.compucorp.civicrm.tasksassignments'])) {
+    return false;
+  }
+
+  $id = $form_state['values']['id'];
+  $expireDate = substr($form_state['values']['expire_date'], 0, 10);
+  $details = strip_tags($form_state['values']['details']);
+
+  $result = civicrm_api3('Document', 'create', [
+    'sequential' => 1,
+    'id' => $id,
+    'expire_date' => $expireDate,
+    'details' => $details,
+  ]);
+
+  $deleteFiles = json_decode($form_state['values']['delete_files'], true);
+
+  if (!empty($deleteFiles)) {
+    foreach ($deleteFiles as $deleteFile) {
+      $result = CRM_Tasksassignments_Page_Files::fileDelete([
+        'fileID' => (int)$deleteFile['id'],
+        'entityTable' => 'civicrm_activity',
+        'entityID' => $form_state['values']['id'],
+      ]);
     }
+  }
 
-    $id = $form_state['values']['id'];
-    $expireDate = substr($form_state['values']['expire_date'], 0, 10);
-    $details = strip_tags($form_state['values']['details']);
+  $documentResult = civicrm_api3('Document', 'get', [
+    'sequential' => 1,
+    'id' => $id,
+  ]);
 
-    $result = civicrm_api3('Document', 'create', array(
+  if ($documentResult['count']) {
+    $document = CRM_Utils_Array::first($documentResult['values']);
+
+    if ($document['file_count']) {
+      $result = civicrm_api3('Document', 'create', [
         'sequential' => 1,
         'id' => $id,
-        'expire_date' => $expireDate,
-        'details' => $details,
-    ));
-
-    $deleteFiles = json_decode($form_state['values']['delete_files'], true);
-    if (!empty($deleteFiles)) {
-        foreach ($deleteFiles as $deleteFile) {
-            $result = CRM_Tasksassignments_Page_Files::fileDelete(
-                array(
-                    'fileID' => (int)$deleteFile['id'],
-                    'entityTable' => 'civicrm_activity',
-                    'entityID' => $form_state['values']['id'],
-                )
-            );
-        }
+        'status_id' => 2,
+      ]);
     }
+  }
 
-    $documentResult = civicrm_api3('Document', 'get', array(
-        'sequential' => 1,
-        'id' => $id,
-    ));
-    if ($documentResult['count']) {
-        $document = CRM_Utils_Array::first($documentResult['values']);
-        if ($document['file_count']) {
-            $result = civicrm_api3('Document', 'create', array(
-                'sequential' => 1,
-                'id' => $id,
-                'status_id' => 2,
-            ));
-        }
-    }
+  //clear views cache to reflect changes
+  _clear_json_cache();
 
-    //clear views cache to reflect changes
-    _clear_json_cache();
-
-    drupal_set_message(t('Document changes has been saved.'), 'success');
+  drupal_set_message(t('Document changes has been saved.'), 'success');
 }
 
 /**
-* Ajax menu callback.
-*/
+ * Ajax menu callback.
+ */
 function civihr_employee_portal_delete_document($ajax, $id) {
+  if ($ajax) {
+    ctools_include('ajax');
+    ctools_include('modal');
 
-    if ($ajax) {
-        ctools_include('ajax');
-        ctools_include('modal');
+    $title = t('Are you sure you want to delete this Document?');
 
-        $title = t('Are you sure you want to delete this Document?');
+    $form_state = [
+      'ajax' => TRUE,
+      'is_ajax_update' => TRUE,
+      'title' => $title,
+      'id' => $id,
+    ];
 
-        $form_state = array(
-            'ajax' => TRUE,
-            'is_ajax_update' => TRUE,
-            'title' => $title,
-            'id' => $id,
-        );
-
-        // Since this will run again on form rebuild while still in the modal, prevent
-        // form IDs from being incremented.
-        // @todo https://drupal.org/node/1305882
-        if (!empty($_POST['ajax_html_ids'])) {
-            unset($_POST['ajax_html_ids']);
-        }
-
-        // Use ctools to generate ajax instructions for the browser to create
-        // a form in a modal popup.
-        $output = ctools_modal_form_wrapper('civihr_employee_portal_document_form_delete_confirm', $form_state);
-
-        // If the form has been submitted, there may be additional instructions
-        // such as dismissing the modal popup.
-        if (!empty($form_state['executed'])) {
-
-            // Add the responder javascript, required by ctools
-            ctools_add_js('ajax-responder');
-
-            $output[] = ajax_command_replace('.messages', 'all good');
-            $output[] = ctools_modal_command_dismiss();
-            $output[] = ctools_ajax_command_redirect('dashboard');
-
-        }
-
-        // Return the ajax instructions to the browser via ajax_render().
-        print ajax_render($output);
-        drupal_exit();
-
+    // Since this will run again on form rebuild while still in the modal, prevent
+    // form IDs from being incremented.
+    // @todo https://drupal.org/node/1305882
+    if (!empty($_POST['ajax_html_ids'])) {
+      unset($_POST['ajax_html_ids']);
     }
 
-    else {
-        return drupal_get_form('civihr_employee_portal_document_form_delete_confirm');
+    // Use ctools to generate ajax instructions for the browser to create
+    // a form in a modal popup.
+    $output = ctools_modal_form_wrapper('civihr_employee_portal_document_form_delete_confirm', $form_state);
+
+    // If the form has been submitted, there may be additional instructions
+    // such as dismissing the modal popup.
+    if (!empty($form_state['executed'])) {
+      // Add the responder javascript, required by ctools
+      ctools_add_js('ajax-responder');
+
+      $output[] = ajax_command_replace('.messages', 'all good');
+      $output[] = ctools_modal_command_dismiss();
+      $output[] = ctools_ajax_command_redirect('dashboard');
     }
 
+    // Return the ajax instructions to the browser via ajax_render().
+    print ajax_render($output);
+    drupal_exit();
+  }
+  else {
+    return drupal_get_form('civihr_employee_portal_document_form_delete_confirm');
+  }
 }
 
 function civihr_employee_portal_document_form_delete_confirm($form, &$form_state){
+  $form['id'] = [
+    '#type' => 'hidden',
+    '#value' =>  $form_state['id'],
+    '#suffix' => "<script>CRM.$('#edit-cancel').bind('click', function() { Drupal.CTools.Modal.dismiss(); return false; });</script>",
+  ];
 
-    $form['id'] = array(
-        '#type' => 'hidden',
-        '#value' =>  $form_state['id'],
-        '#suffix' => "<script>CRM.$('#edit-cancel').bind('click', function() { Drupal.CTools.Modal.dismiss(); return false; });</script>",
-    );
+  $form['#submit'][] = 'civihr_employee_portal_document_form_delete_submit';
 
-    $form['#submit'][] = 'civihr_employee_portal_document_form_delete_submit';
-
-    return confirm_form($form,
-        t('Are you sure you want to delete this Document?'),
-        'dashboard',
-        t('This action cannot be undone from here.'),
-        t('Delete'),
-        t('Cancel'));
+  return confirm_form($form,
+    t('Are you sure you want to delete this Document?'),
+    'dashboard',
+    t('This action cannot be undone from here.'),
+    t('Delete'),
+    t('Cancel')
+  );
 }
 
 function civihr_employee_portal_document_form_delete_submit($form, &$form_state) {
+  $result_output = [];
+  $extensions = CRM_Core_PseudoConstant::getExtensions();
 
-    $result_output = array();
-    $extensions = CRM_Core_PseudoConstant::getExtensions();
-    if (empty($extensions['uk.co.compucorp.civicrm.tasksassignments'])) {
-        return false;
-    }
+  if (empty($extensions['uk.co.compucorp.civicrm.tasksassignments'])) {
+    return false;
+  }
 
-    $id = (int)$form_state['values']['id'];
+  $id = (int)$form_state['values']['id'];
 
-    $result = civicrm_api3('Document', 'create', array(
-        'sequential' => 1,
-        'id' => $id,
-        'is_deleted' => 1,
-    ));
+  $result = civicrm_api3('Document', 'create', [
+    'sequential' => 1,
+    'id' => $id,
+    'is_deleted' => 1,
+  ]);
 
-    drupal_set_message(t('Document has been deleted.'), 'success');
+  drupal_set_message(t('Document has been deleted.'), 'success');
 }
 
 /**
-* Ajax menu callback.
-*/
+ * Ajax menu callback.
+ */
 function civihr_employee_portal_send_reminder_document($ajax, $id) {
+  if ($ajax) {
+    ctools_include('ajax');
+    ctools_include('modal');
 
-    if ($ajax) {
-        ctools_include('ajax');
-        ctools_include('modal');
+    $title = t('Send Reminder');
 
-        $title = t('Send Reminder');
+    $form_state = [
+      'ajax' => TRUE,
+      'is_ajax_update' => TRUE,
+      'title' => $title,
+      'id' => $id,
+    ];
 
-        $form_state = array(
-            'ajax' => TRUE,
-            'is_ajax_update' => TRUE,
-            'title' => $title,
-            'id' => $id,
-        );
-
-        // Since this will run again on form rebuild while still in the modal, prevent
-        // form IDs from being incremented.
-        // @todo https://drupal.org/node/1305882
-        if (!empty($_POST['ajax_html_ids'])) {
-            unset($_POST['ajax_html_ids']);
-        }
-
-        // Use ctools to generate ajax instructions for the browser to create
-        // a form in a modal popup.
-        $output = ctools_modal_form_wrapper('civihr_employee_portal_document_form_send_reminder', $form_state);
-
-        // If the form has been submitted, there may be additional instructions
-        // such as dismissing the modal popup.
-        if (!empty($form_state['executed'])) {
-
-            // Add the responder javascript, required by ctools
-            ctools_add_js('ajax-responder');
-
-            $output[] = ajax_command_replace('.messages', 'all good');
-            $output[] = ctools_modal_command_dismiss();
-            $output[] = ctools_ajax_command_redirect('dashboard');
-
-        }
-
-        // Return the ajax instructions to the browser via ajax_render().
-        print ajax_render($output);
-        drupal_exit();
-
+    // Since this will run again on form rebuild while still in the modal, prevent
+    // form IDs from being incremented.
+    // @todo https://drupal.org/node/1305882
+    if (!empty($_POST['ajax_html_ids'])) {
+      unset($_POST['ajax_html_ids']);
     }
 
-    else {
-        return drupal_get_form('civihr_employee_portal_document_form_delete_confirm');
+    // Use ctools to generate ajax instructions for the browser to create
+    // a form in a modal popup.
+    $output = ctools_modal_form_wrapper('civihr_employee_portal_document_form_send_reminder', $form_state);
+
+    // If the form has been submitted, there may be additional instructions
+    // such as dismissing the modal popup.
+    if (!empty($form_state['executed'])) {
+      // Add the responder javascript, required by ctools
+      ctools_add_js('ajax-responder');
+
+      $output[] = ajax_command_replace('.messages', 'all good');
+      $output[] = ctools_modal_command_dismiss();
+      $output[] = ctools_ajax_command_redirect('dashboard');
     }
 
+    // Return the ajax instructions to the browser via ajax_render().
+    print ajax_render($output);
+    drupal_exit();
+  }
+  else {
+    return drupal_get_form('civihr_employee_portal_document_form_delete_confirm');
+  }
 }
 
 function civihr_employee_portal_document_form_send_reminder($form, &$form_state){
+  $result_output = [];
+  $extensions = CRM_Core_PseudoConstant::getExtensions();
 
-    $result_output = array();
-    $extensions = CRM_Core_PseudoConstant::getExtensions();
-    if (empty($extensions['uk.co.compucorp.civicrm.tasksassignments'])) {
-        return $form;
-    }
-
-    $form['#prefix'] = '<article class="node node-webform contextual-links-region clearfix"><div class="content">';
-    $form['#suffix'] = '</div></article>';
-
-    $activityOptions = array();
-    $typeResult = civicrm_api3('Activity', 'getoptions', array(
-        'field' => "activity_type_id",
-    ));
-    $activityOptions['type'] = $typeResult['values'];
-
-    $documentResult = civicrm_api3('Document', 'get', array(
-        'sequential' => 1,
-        'id' => $form_state['id'],
-    ));
-    $document = CRM_Utils_Array::first($documentResult['values']);
-
-    $activityContactResult = civicrm_api3('ActivityContact', 'get', array(
-        'sequential' => 1,
-        'activity_id' => $form_state['id'],
-        'record_type_id' => 1,
-    ));
-    $activityContacts = array();
-    foreach ($activityContactResult['values'] as $activityContact) {
-        $contactResult = civicrm_api3('Contact', 'get', array(
-            'sequential' => 1,
-            'id' => $activityContact['contact_id'],
-        ));
-        $contact = CRM_Utils_Array::first($contactResult['values']);
-        $activityContacts[] = $contact['sort_name'];
-    }
-
-    $form['id'] = array(
-        '#type' => 'hidden',
-        '#value' =>  $form_state['id'],
-    );
-
-    $form['document'] = array(
-        '#type' => 'textfield',
-        '#title' => t('Document'),
-        '#prefix' => '<div class="row"><div class="col-md-12">',
-        '#suffix' => '</div></div>',
-        '#attributes' => array('readonly' => 'readonly'),
-        '#attributes' => array('disabled' => 'disabled'),
-        '#value' => $activityOptions['type'][$document['activity_type_id']],
-    );
-
-    $form['due'] = array(
-        '#type' => 'textfield',
-        '#title' => t('Due'),
-        '#prefix' => '<div class="row"><div class="col-md-12">',
-        '#suffix' => '</div></div>',
-        '#attributes' => array('readonly' => 'readonly'),
-        '#attributes' => array('disabled' => 'disabled'),
-        '#value' => $document['activity_date_time'],
-    );
-
-    $form['assignee'] = array(
-        '#type' => 'textfield',
-        '#title' => t('Assignee'),
-        '#prefix' => '<div class="row"><div class="col-md-12">',
-        '#suffix' => '</div></div>',
-        '#attributes' => array('readonly' => 'readonly'),
-        '#attributes' => array('disabled' => 'disabled'),
-        '#value' => implode(', ', $activityContacts),
-    );
-
-    $form['notes'] = array(
-        '#type' => 'textarea',
-        '#title' => t('Notes'),
-        '#rows' => 10,
-        '#cols' => 100,
-        '#prefix' => '<div class="row"><div class="col-md-12">',
-        '#suffix' => '</div></div>',
-        '#default_value' => '',
-    );
-
-    $form['submit'] = array(
-        '#type' => 'submit',
-        '#value' => t('Send'),
-    );
-
-    $form['#submit'][] = 'civihr_employee_portal_document_form_send_reminder_submit';
-
+  if (empty($extensions['uk.co.compucorp.civicrm.tasksassignments'])) {
     return $form;
+  }
+
+  $form['#prefix'] = '<article class="node node-webform contextual-links-region clearfix"><div class="content">';
+  $form['#suffix'] = '</div></article>';
+
+  $activityOptions = [];
+  $typeResult = civicrm_api3('Activity', 'getoptions', [
+    'field' => "activity_type_id",
+  ]);
+  $activityOptions['type'] = $typeResult['values'];
+
+  $documentResult = civicrm_api3('Document', 'get', [
+    'sequential' => 1,
+    'id' => $form_state['id'],
+  ]);
+  $document = CRM_Utils_Array::first($documentResult['values']);
+
+  $activityContactResult = civicrm_api3('ActivityContact', 'get', [
+    'sequential' => 1,
+    'activity_id' => $form_state['id'],
+    'record_type_id' => 1,
+  ]);
+  $activityContacts = [];
+  foreach ($activityContactResult['values'] as $activityContact) {
+    $contactResult = civicrm_api3('Contact', 'get', [
+      'sequential' => 1,
+      'id' => $activityContact['contact_id'],
+    ]);
+    $contact = CRM_Utils_Array::first($contactResult['values']);
+    $activityContacts[] = $contact['sort_name'];
+  }
+
+  $form['id'] = [
+    '#type' => 'hidden',
+    '#value' =>  $form_state['id'],
+  ];
+
+  $form['document'] = [
+    '#type' => 'textfield',
+    '#title' => t('Document'),
+    '#prefix' => '<div class="row"><div class="col-md-12">',
+    '#suffix' => '</div></div>',
+    '#attributes' => ['readonly' => 'readonly'],
+    '#attributes' => ['disabled' => 'disabled'],
+    '#value' => $activityOptions['type'][$document['activity_type_id']],
+  ];
+
+  $form['due'] = [
+    '#type' => 'textfield',
+    '#title' => t('Due'),
+    '#prefix' => '<div class="row"><div class="col-md-12">',
+    '#suffix' => '</div></div>',
+    '#attributes' => ['readonly' => 'readonly'],
+    '#attributes' => ['disabled' => 'disabled'],
+    '#value' => $document['activity_date_time'],
+  ];
+
+  $form['assignee'] = [
+    '#type' => 'textfield',
+    '#title' => t('Assignee'),
+    '#prefix' => '<div class="row"><div class="col-md-12">',
+    '#suffix' => '</div></div>',
+    '#attributes' => ['readonly' => 'readonly'],
+    '#attributes' => ['disabled' => 'disabled'],
+    '#value' => implode(', ', $activityContacts),
+  ];
+
+  $form['notes'] = [
+    '#type' => 'textarea',
+    '#title' => t('Notes'),
+    '#rows' => 10,
+    '#cols' => 100,
+    '#prefix' => '<div class="row"><div class="col-md-12">',
+    '#suffix' => '</div></div>',
+    '#default_value' => '',
+  ];
+
+  $form['submit'] = [
+    '#type' => 'submit',
+    '#value' => t('Send'),
+  ];
+
+  $form['#submit'][] = 'civihr_employee_portal_document_form_send_reminder_submit';
+
+  return $form;
 }
 
 function civihr_employee_portal_document_form_send_reminder_submit($form, &$form_state) {
+  $result_output = [];
+  $extensions = CRM_Core_PseudoConstant::getExtensions();
 
-    $result_output = array();
-    $extensions = CRM_Core_PseudoConstant::getExtensions();
-    if (empty($extensions['uk.co.compucorp.civicrm.tasksassignments'])) {
-        return false;
-    }
+  if (empty($extensions['uk.co.compucorp.civicrm.tasksassignments'])) {
+    return false;
+  }
 
-    $id = (int)$form_state['values']['id'];
-    $notes = $form_state['values']['notes'];
+  $id = (int)$form_state['values']['id'];
+  $notes = $form_state['values']['notes'];
 
-    $result = civicrm_api3('Document', 'sendreminder', array(
-        'sequential' => 1,
-        'activity_id' => $id,
-        'notes' => $notes,
-    ));
+  $result = civicrm_api3('Document', 'sendreminder', [
+    'sequential' => 1,
+    'activity_id' => $id,
+    'notes' => $notes,
+  ]);
 
-    drupal_set_message(t('Reminder has been sent.'), 'success');
+  drupal_set_message(t('Reminder has been sent.'), 'success');
 }
 
 /**
@@ -2427,375 +2334,374 @@ function civihr_employee_portal_document_form_send_reminder_submit($form, &$form
 
 /**
  * Show all completed Tasks in modal window and not seperate page
+ *
  * @param $ajax
  */
 function civihr_employee_portal_civi_tasks_view_completed_callback($ajax) {
+  if ($ajax) {
+    ctools_include('ajax');
+    ctools_include('modal');
 
-    if ($ajax) {
+    // Add the responder javascript, required by ctools
+    ctools_add_js('ajax-responder');
 
-        ctools_include('ajax');
-        ctools_include('modal');
+    // Get the view for approved absences
+    $output[] = ctools_modal_command_display(t('My Completed Tasks'), views_embed_view('Tasks', 'block_1'));
 
-        // Add the responder javascript, required by ctools
-        ctools_add_js('ajax-responder');
-
-        // Get the view for approved absences
-        $output[] = ctools_modal_command_display(t('My Completed Tasks'), views_embed_view('Tasks', 'block_1'));
-
-        print ajax_render($output);
-        drupal_exit();
-    }
-    else {
-        return 'Javascript not enabled';
-    }
-
+    print ajax_render($output);
+    drupal_exit();
+  }
+  else {
+    return 'Javascript not enabled';
+  }
 }
 
 /**
-* Ajax menu callback.
-*/
+ * Ajax menu callback.
+ */
 function civihr_employee_portal_civi_tasks_create($ajax, $id = null) {
+  if ($ajax) {
+    ctools_include('ajax');
+    ctools_include('modal');
 
-    if ($ajax) {
-        ctools_include('ajax');
-        ctools_include('modal');
+    $title = t('Create new Task');
 
-        $title = t('Create new Task');
-        if ($id) {
-            $title = t('Task Details');
-        }
-
-        $form_state = array(
-            'ajax' => TRUE,
-            'is_ajax_update' => TRUE,
-            'title' => $title,
-            'id' => $id,
-        );
-
-        // Since this will run again on form rebuild while still in the modal, prevent
-        // form IDs from being incremented.
-        // @todo https://drupal.org/node/1305882
-        if (!empty($_POST['ajax_html_ids'])) {
-            unset($_POST['ajax_html_ids']);
-        }
-
-        // Use ctools to generate ajax instructions for the browser to create
-        // a form in a modal popup.
-        $output = ctools_modal_form_wrapper('civihr_employee_portal_civi_tasks_form', $form_state);
-
-        // If the form has been submitted, there may be additional instructions
-        // such as dismissing the modal popup.
-        if (!empty($form_state['executed'])) {
-
-            // Add the responder javascript, required by ctools
-            ctools_add_js('ajax-responder');
-
-            $output[] = ajax_command_replace('.messages', 'all good');
-            $output[] = ctools_modal_command_dismiss();
-            $output[] = ctools_ajax_command_redirect('dashboard');
-
-        }
-
-        // Return the ajax instructions to the browser via ajax_render().
-        print ajax_render($output);
-        drupal_exit();
-
+    if ($id) {
+      $title = t('Task Details');
     }
 
-    else {
-        return drupal_get_form('civihr_employee_portal_civi_tasks_form');
+    $form_state = [
+      'ajax' => TRUE,
+      'is_ajax_update' => TRUE,
+      'title' => $title,
+      'id' => $id,
+    ];
+
+    // Since this will run again on form rebuild while still in the modal, prevent
+    // form IDs from being incremented.
+    // @todo https://drupal.org/node/1305882
+    if (!empty($_POST['ajax_html_ids'])) {
+      unset($_POST['ajax_html_ids']);
     }
 
+    // Use ctools to generate ajax instructions for the browser to create
+    // a form in a modal popup.
+    $output = ctools_modal_form_wrapper('civihr_employee_portal_civi_tasks_form', $form_state);
+
+    // If the form has been submitted, there may be additional instructions
+    // such as dismissing the modal popup.
+    if (!empty($form_state['executed'])) {
+      // Add the responder javascript, required by ctools
+      ctools_add_js('ajax-responder');
+
+      $output[] = ajax_command_replace('.messages', 'all good');
+      $output[] = ctools_modal_command_dismiss();
+      $output[] = ctools_ajax_command_redirect('dashboard');
+    }
+
+    // Return the ajax instructions to the browser via ajax_render().
+    print ajax_render($output);
+    drupal_exit();
+  }
+  else {
+    return drupal_get_form('civihr_employee_portal_civi_tasks_form');
+  }
 }
 
 /**
  * Custom Document dashboard block form.
  */
 function civihr_employee_portal_civi_tasks_form($form, &$form_state) {
+  global $user;
 
-    global $user;
-    $contactId = _get_civicrm_contact_id_by_drupal_uid($user->uid);
-    $targetId = $contactId;
-    $assignmentsSelectOptions = array();
-    $assigneeSelected = null;
-    $targetSelected = null;
-    $assignmentSelected = null;
-    $id = isset($form_state['id']) ? $form_state['id'] : null;
+  $contactId = _get_civicrm_contact_id_by_drupal_uid($user->uid);
+  $targetId = $contactId;
+  $assignmentsSelectOptions = [];
+  $assigneeSelected = null;
+  $targetSelected = null;
+  $assignmentSelected = null;
+  $id = isset($form_state['id']) ? $form_state['id'] : null;
 
-    $disabledAttr = array('disabled' => 'disabled');
-    if (_task_can_be_edited($id)) {
-        $disabledAttr = array();
-    }
+  $disabledAttr = ['disabled' => 'disabled'];
 
-    $result_output = array();
-    $extensions = CRM_Core_PseudoConstant::getExtensions();
-    if (empty($extensions['uk.co.compucorp.civicrm.tasksassignments'])) {
-        return $form;
-    }
+  if (_task_can_be_edited($id)) {
+    $disabledAttr = [];
+  }
 
-    if ($id) {
-        $result = civicrm_api3('Task', 'get', array(
-            'sequential' => 1,
-            'id' => $id,
-            'return' => "id,activity_type_id,subject,activity_date_time,details,status_id,priority_id,is_current_revision,is_deleted,assignee_contact_id,source_contact_id,target_contact_id,case_id",
-        ));
-        $task = CRM_Utils_Array::first($result['values']);
-        $assigneeId = CRM_Utils_array::first($task['assignee_contact_id']);
-        $targetId = CRM_Utils_Array::first($task['target_contact_id']);
+  $result_output = [];
+  $extensions = CRM_Core_PseudoConstant::getExtensions();
 
-        // Getting Assignee data:
-        $result = civicrm_api3('Contact', 'get', array(
-            'sequential' => 1,
-            'id' => $assigneeId,
-        ));
-        $assignee = CRM_Utils_Array::first($result['values']);
-        $assigneeSelected = array(
-            'id' => $assigneeId,
-            'text' => $assignee['sort_name'],
-        );
-
-        // Getting Target data:
-        $result = civicrm_api3('Contact', 'get', array(
-            'sequential' => 1,
-            'id' => $targetId,
-        ));
-        $target = CRM_Utils_Array::first($result['values']);
-        $targetSelected = array(
-            'id' => $targetId,
-            'text' => $target['sort_name'],
-        );
-
-        // Getting Assignment data:
-        if ($task['case_id']) {
-            $result = civicrm_api3('Assignment', 'get', array(
-                'sequential' => 1,
-                'id' => $task['case_id'],
-            ));
-            $assignment = CRM_Utils_Array::first($result['values']);
-            $assignmentSelected = array(
-                'id' => $assignment['id'],
-                'text' => $target['sort_name'] . ' - '. $assignment['subject'],
-            );
-        }
-    }
-
-    $result = civicrm_api3('Contact', 'get', array(
-        'sequential' => 1,
-        'id' => $targetId,
-    ));
-    $target = CRM_Utils_Array::first($result['values']);
-
-    // get all Assignments of the target:
-    $result = civicrm_api3('Assignment', 'get', array(
-        'sequential' => 1,
-        'contact_id' => $targetId,
-    ));
-    foreach ($result['values'] as $assignment) {
-        $assignmentsSelectOptions[] = array(
-            'id' => $assignment['id'],
-            'text' => $target['sort_name'] . ' - ' . $assignment['subject'],
-        );
-    }
-
-    $taskTypes = civicrm_api3('Task', 'getoptions', array(
-      'field' => "activity_type_id",
-    ));
-
-    $taskStatuses = get_task_statuses();
-
-    $activityOptions = array();
-    $typeResult = civicrm_api3('Activity', 'getoptions', array(
-        'field' => "activity_type_id",
-    ));
-    $activityOptions['type'] = $typeResult['values'];
-
-    $form['#attributes']['class'][] = 'form-horizontal civihr_form';
-
-    $form['section_open'] = array(
-        '#markup' => '<div class="modal-civihr-custom__section">'
-    );
-
-    $form['id'] = array(
-        '#type' => 'hidden',
-        '#value' => $id,
-    );
-
-    $form['activity_type_id'] = array(
-        '#type' => 'select',
-        '#title' => t('Task type:'),
-        '#options' => $taskTypes['values'],
-        '#attributes' => $disabledAttr,
-        '#label_class' => 'col-sm-3 control-label',
-        '#field_prefix' => '<div class="col-sm-9">',
-        '#field_suffix' => '</div>',
-    );
-
-    if ($id) {
-        $form['activity_type_id']['#default_value'] = $task['activity_type_id'];
-    }
-
-    $form['activity_date_time'] = array(
-        '#type' => 'date_popup',
-        '#title' => t('Due:'),
-        '#date_format' => 'Y-m-d',
-        '#date_year_range' => '-10:+10',
-        '#default_value' => isset($task['activity_date_time']) ? strip_tags($task['activity_date_time']) : '',
-        '#attributes' => $disabledAttr,
-        '#label_class' => 'col-xs-12 col-sm-3 control-label',
-        '#prefix' => '<div class="civihr_container-inline-date--reset">',
-        '#field_prefix' => '<div class="col-xs-4 col-sm-4">',
-        '#field_suffix' => '</div>',
-        '#suffix' => '</div>'
-    );
-
-    $form['subject'] = array(
-        '#type' => 'textfield',
-        '#title' => t('Subject:'),
-        '#default_value' => isset($task['subject']) ? strip_tags($task['subject']) : '',
-        '#attributes' => $disabledAttr,
-        '#label_class' => 'col-sm-3 control-label',
-        '#field_prefix' => '<div class="col-sm-9">',
-        '#field_suffix' => '</div>',
-    );
-
-    $form['assignee'] = array(
-        '#type' => 'textfield',
-        '#title' => t('Assignee:'),
-        '#default_value' => '',
-        '#attributes' => $disabledAttr,
-        '#label_class' => 'col-sm-3 control-label',
-        '#field_prefix' => '<div class="col-sm-9">',
-        '#field_suffix' => '</div>',
-    );
-
-    $form['target'] = array(
-        '#type' => 'textfield',
-        '#title' => t('Target:'),
-        '#default_value' => '',
-        '#attributes' => $disabledAttr,
-        '#label_class' => 'col-sm-3 control-label',
-        '#field_prefix' => '<div class="col-sm-9">',
-        '#field_suffix' => '</div>',
-    );
-
-    $form['status_id'] = array(
-        '#type' => 'select',
-        '#title' => t('Status:'),
-        '#options' => $taskStatuses,
-        '#default_value' => isset($task['status_id']) ? $task['status_id'] : '',
-        '#attributes' => $disabledAttr,
-        '#label_class' => 'col-sm-3 control-label',
-        '#field_prefix' => '<div class="col-sm-9">',
-        '#field_suffix' => '</div>',
-    );
-
-    $form['details'] = array(
-        '#type' => 'textarea',
-        '#title' => t('Details:'),
-        '#rows' => 10,
-        '#cols' => 100,
-        '#default_value' => isset($task['details']) ? strip_tags($task['details']) : '',
-        '#attributes' => $disabledAttr,
-        '#label_class' => 'col-sm-3 control-label',
-        '#field_prefix' => '<div class="col-sm-9">',
-        '#field_suffix' => '</div>',
-    );
-
-    $form['assignment'] = array(
-        '#type' => 'textfield',
-        '#title' => t('Workflow:'),
-        '#default_value' => '',
-        '#attributes' => $disabledAttr,
-        '#label_class' => 'col-sm-3 control-label',
-        '#field_prefix' => '<div class="col-sm-9">',
-        '#field_suffix' => '</div>',
-    );
-
-    $form['section_close'] = array(
-        '#markup' => '</div>'
-    );
-
-    if (_task_can_be_edited($id)) {
-        $form['save'] = array(
-            '#type' => 'submit',
-            '#value' => t('Save'),
-            '#attributes' => array('class' => array('chr_action')),
-            '#prefix' => '<div class="modal-civihr-custom__footer"><div class="chr_actions-wrapper">',
-            '#suffix'=> '</div></div>'
-        );
-    }
-
-    // Add the validation function
-    $form['#validate'][] = 'civihr_employee_portal_civi_tasks_form_validate';
-
-    // Add the submit function
-    $form['#submit'][] = 'civihr_employee_portal_civi_tasks_form_submit';
-
-    $form['javascript'] = array(
-        '#markup' =>
-          '<script type="text/javascript">'
-        . 'Drupal.behaviors.civihr_employee_portal_tasks.buildAssigneeSelect(' . json_encode($assigneeSelected) . ');'
-        . 'Drupal.behaviors.civihr_employee_portal_tasks.buildTargetSelect(' . json_encode($targetSelected) . ');'
-        . 'Drupal.behaviors.civihr_employee_portal_tasks.buildAssignmentsSelect(' . json_encode($assignmentsSelectOptions) . ', ' . json_encode($assignmentSelected) . ');'
-        . '</script>',
-    );
-
-    drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . '/js/tasks.js');
-
+  if (empty($extensions['uk.co.compucorp.civicrm.tasksassignments'])) {
     return $form;
+  }
+
+  if ($id) {
+    $result = civicrm_api3('Task', 'get', [
+      'sequential' => 1,
+      'id' => $id,
+      'return' => "id,activity_type_id,subject,activity_date_time,details,status_id,priority_id,is_current_revision,is_deleted,assignee_contact_id,source_contact_id,target_contact_id,case_id",
+    ]);
+    $task = CRM_Utils_Array::first($result['values']);
+    $assigneeId = CRM_Utils_array::first($task['assignee_contact_id']);
+    $targetId = CRM_Utils_Array::first($task['target_contact_id']);
+
+    // Getting Assignee data:
+    $result = civicrm_api3('Contact', 'get', [
+      'sequential' => 1,
+      'id' => $assigneeId,
+    ]);
+    $assignee = CRM_Utils_Array::first($result['values']);
+    $assigneeSelected = [
+      'id' => $assigneeId,
+      'text' => $assignee['sort_name'],
+    ];
+
+    // Getting Target data:
+    $result = civicrm_api3('Contact', 'get', [
+      'sequential' => 1,
+      'id' => $targetId,
+    ]);
+    $target = CRM_Utils_Array::first($result['values']);
+    $targetSelected = [
+      'id' => $targetId,
+      'text' => $target['sort_name'],
+    ];
+
+    // Getting Assignment data:
+    if ($task['case_id']) {
+      $result = civicrm_api3('Assignment', 'get', [
+        'sequential' => 1,
+        'id' => $task['case_id'],
+      ]);
+      $assignment = CRM_Utils_Array::first($result['values']);
+      $assignmentSelected = [
+        'id' => $assignment['id'],
+        'text' => $target['sort_name'] . ' - '. $assignment['subject'],
+      ];
+    }
+  }
+
+  $result = civicrm_api3('Contact', 'get', [
+    'sequential' => 1,
+    'id' => $targetId,
+  ]);
+  $target = CRM_Utils_Array::first($result['values']);
+
+  // get all Assignments of the target:
+  $result = civicrm_api3('Assignment', 'get', [
+    'sequential' => 1,
+    'contact_id' => $targetId,
+  ]);
+
+  foreach ($result['values'] as $assignment) {
+    $assignmentsSelectOptions[] = [
+      'id' => $assignment['id'],
+      'text' => $target['sort_name'] . ' - ' . $assignment['subject'],
+    ];
+  }
+
+  $taskTypes = civicrm_api3('Task', 'getoptions', [
+    'field' => "activity_type_id",
+  ]);
+
+  $taskStatuses = get_task_statuses();
+
+  $activityOptions = [];
+  $typeResult = civicrm_api3('Activity', 'getoptions', [
+    'field' => "activity_type_id",
+  ]);
+  $activityOptions['type'] = $typeResult['values'];
+
+  $form['#attributes']['class'][] = 'form-horizontal civihr_form';
+
+  $form['section_open'] = [
+    '#markup' => '<div class="modal-civihr-custom__section">'
+  ];
+
+  $form['id'] = [
+    '#type' => 'hidden',
+    '#value' => $id,
+  ];
+
+  $form['activity_type_id'] = [
+    '#type' => 'select',
+    '#title' => t('Task type:'),
+    '#options' => $taskTypes['values'],
+    '#attributes' => $disabledAttr,
+    '#label_class' => 'col-sm-3 control-label',
+    '#field_prefix' => '<div class="col-sm-9">',
+    '#field_suffix' => '</div>',
+  ];
+
+  if ($id) {
+    $form['activity_type_id']['#default_value'] = $task['activity_type_id'];
+  }
+
+  $form['activity_date_time'] = [
+    '#type' => 'date_popup',
+    '#title' => t('Due:'),
+    '#date_format' => 'Y-m-d',
+    '#date_year_range' => '-10:+10',
+    '#default_value' => isset($task['activity_date_time']) ? strip_tags($task['activity_date_time']) : '',
+    '#attributes' => $disabledAttr,
+    '#label_class' => 'col-xs-12 col-sm-3 control-label',
+    '#prefix' => '<div class="civihr_container-inline-date--reset">',
+    '#field_prefix' => '<div class="col-xs-4 col-sm-4">',
+    '#field_suffix' => '</div>',
+    '#suffix' => '</div>'
+  ];
+
+  $form['subject'] = [
+    '#type' => 'textfield',
+    '#title' => t('Subject:'),
+    '#default_value' => isset($task['subject']) ? strip_tags($task['subject']) : '',
+    '#attributes' => $disabledAttr,
+    '#label_class' => 'col-sm-3 control-label',
+    '#field_prefix' => '<div class="col-sm-9">',
+    '#field_suffix' => '</div>',
+  ];
+
+  $form['assignee'] = [
+    '#type' => 'textfield',
+    '#title' => t('Assignee:'),
+    '#default_value' => '',
+    '#attributes' => $disabledAttr,
+    '#label_class' => 'col-sm-3 control-label',
+    '#field_prefix' => '<div class="col-sm-9">',
+    '#field_suffix' => '</div>',
+  ];
+
+  $form['target'] = [
+    '#type' => 'textfield',
+    '#title' => t('Target:'),
+    '#default_value' => '',
+    '#attributes' => $disabledAttr,
+    '#label_class' => 'col-sm-3 control-label',
+    '#field_prefix' => '<div class="col-sm-9">',
+    '#field_suffix' => '</div>',
+  ];
+
+  $form['status_id'] = [
+    '#type' => 'select',
+    '#title' => t('Status:'),
+    '#options' => $taskStatuses,
+    '#default_value' => isset($task['status_id']) ? $task['status_id'] : '',
+    '#attributes' => $disabledAttr,
+    '#label_class' => 'col-sm-3 control-label',
+    '#field_prefix' => '<div class="col-sm-9">',
+    '#field_suffix' => '</div>',
+  ];
+
+  $form['details'] = [
+    '#type' => 'textarea',
+    '#title' => t('Details:'),
+    '#rows' => 10,
+    '#cols' => 100,
+    '#default_value' => isset($task['details']) ? strip_tags($task['details']) : '',
+    '#attributes' => $disabledAttr,
+    '#label_class' => 'col-sm-3 control-label',
+    '#field_prefix' => '<div class="col-sm-9">',
+    '#field_suffix' => '</div>',
+  ];
+
+  $form['assignment'] = [
+    '#type' => 'textfield',
+    '#title' => t('Workflow:'),
+    '#default_value' => '',
+    '#attributes' => $disabledAttr,
+    '#label_class' => 'col-sm-3 control-label',
+    '#field_prefix' => '<div class="col-sm-9">',
+    '#field_suffix' => '</div>',
+  ];
+
+  $form['section_close'] = [
+    '#markup' => '</div>'
+  ];
+
+  if (_task_can_be_edited($id)) {
+    $form['save'] = [
+      '#type' => 'submit',
+      '#value' => t('Save'),
+      '#attributes' => ['class' => ['chr_action']],
+      '#prefix' => '<div class="modal-civihr-custom__footer"><div class="chr_actions-wrapper">',
+      '#suffix'=> '</div></div>'
+    ];
+  }
+
+  // Add the validation function
+  $form['#validate'][] = 'civihr_employee_portal_civi_tasks_form_validate';
+
+  // Add the submit function
+  $form['#submit'][] = 'civihr_employee_portal_civi_tasks_form_submit';
+
+  $form['javascript'] = [
+    '#markup' =>
+    '<script type="text/javascript">'
+    . 'Drupal.behaviors.civihr_employee_portal_tasks.buildAssigneeSelect(' . json_encode($assigneeSelected) . ');'
+    . 'Drupal.behaviors.civihr_employee_portal_tasks.buildTargetSelect(' . json_encode($targetSelected) . ');'
+    . 'Drupal.behaviors.civihr_employee_portal_tasks.buildAssignmentsSelect(' . json_encode($assignmentsSelectOptions) . ', ' . json_encode($assignmentSelected) . ');'
+    . '</script>',
+  ];
+
+  drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . '/js/tasks.js');
+
+  return $form;
 }
 
 function civihr_employee_portal_civi_tasks_form_validate($form, &$form_state) {
 }
 
 function civihr_employee_portal_civi_tasks_form_submit($form, &$form_state) {
+  global $user;
 
-    global $user;
-    $id = isset($form_state['values']['id']) ? $form_state['values']['id'] : null;
+  $id = isset($form_state['values']['id']) ? $form_state['values']['id'] : null;
 
-    if (_task_can_be_edited($id)) {
-        $result_output = array();
-        $extensions = CRM_Core_PseudoConstant::getExtensions();
-        if (empty($extensions['uk.co.compucorp.civicrm.tasksassignments'])) {
-            return false;
-        }
+  if (_task_can_be_edited($id)) {
+    $result_output = [];
+    $extensions = CRM_Core_PseudoConstant::getExtensions();
 
-        $params = array(
-            'sequential' => 1,
-            'debug' => false,
-            'assignee_contact_id' => $form_state['values']['assignee'],
-            'source_contact_id' => _get_civicrm_contact_id_by_drupal_uid($user->uid),
-            'target_contact_id' => $form_state['values']['target'],
-            'activity_type_id' => $form_state['values']['activity_type_id'],
-            'activity_date_time' => $form_state['values']['activity_date_time'],
-            'subject' => $form_state['values']['subject'],
-            'status_id' => $form_state['values']['status_id'],
-            'details' => $form_state['values']['details'],
-        );
-        if ($id) {
-            $params['id'] = $id;
-        }
-        if (!empty($form_state['values']['assignment'])) {
-            $params['case_id'] = (int)$form_state['values']['assignment'];
-        }
-
-        $result = civicrm_api3('Task', 'create', $params);
-
-        $folder_real_path = drupal_realpath('public://') . '/views_json_query/';
-        _remove_json_cache_files($folder_real_path);
-
-        if (!$result['is_error']) {
-            if ($id) {
-                drupal_set_message('Task has been updated.', 'success');
-            } else {
-                drupal_set_message('Task has been created.', 'success');
-            }
-        } else {
-            drupal_set_message('An error occured when saving the Task.', 'error');
-        }
-    } else {
-        drupal_set_message('You do not have permissions to create or edit Task.', 'error');
+    if (empty($extensions['uk.co.compucorp.civicrm.tasksassignments'])) {
+      return false;
     }
+
+    $params = [
+      'sequential' => 1,
+      'debug' => false,
+      'assignee_contact_id' => $form_state['values']['assignee'],
+      'source_contact_id' => _get_civicrm_contact_id_by_drupal_uid($user->uid),
+      'target_contact_id' => $form_state['values']['target'],
+      'activity_type_id' => $form_state['values']['activity_type_id'],
+      'activity_date_time' => $form_state['values']['activity_date_time'],
+      'subject' => $form_state['values']['subject'],
+      'status_id' => $form_state['values']['status_id'],
+      'details' => $form_state['values']['details'],
+    ];
+
+    if ($id) {
+      $params['id'] = $id;
+    }
+
+    if (!empty($form_state['values']['assignment'])) {
+      $params['case_id'] = (int)$form_state['values']['assignment'];
+    }
+
+    $result = civicrm_api3('Task', 'create', $params);
+
+    $folder_real_path = drupal_realpath('public://') . '/views_json_query/';
+    _remove_json_cache_files($folder_real_path);
+
+    if (!$result['is_error']) {
+      if ($id) {
+        drupal_set_message('Task has been updated.', 'success');
+      } else {
+        drupal_set_message('Task has been created.', 'success');
+      }
+    } else {
+      drupal_set_message('An error occured when saving the Task.', 'error');
+    }
+  } else {
+    drupal_set_message('You do not have permissions to create or edit Task.', 'error');
+  }
 }
 
 /**
@@ -2806,40 +2712,38 @@ function civihr_employee_portal_civi_tasks_form_submit($form, &$form_state) {
  * @return NULL
  */
 function civihr_employee_portal_civi_tasks_complete($taskId = null) {
+  $res = [
+    'success' => 0,
+    'message' => t("Error processing status change."),
+  ];
 
-    $res = array(
-        'success' => 0,
-        'message' => t("Error processing status change."),
-    );
+  try {
+    // check whether curent user is assignee of the task
+    if (_task_can_be_marked_as_complete($taskId)) {
+      $result = civicrm_api3('Task', 'create', [
+        'sequential' => 1,
+        'id' => $taskId,
+        'status_id' => 2,
+      ]);
 
-    try {
-        // check whether curent user is assignee of the task
-        if (_task_can_be_marked_as_complete($taskId)) {
-            $result = civicrm_api3('Task', 'create', array(
-                'sequential' => 1,
-                'id' => $taskId,
-                'status_id' => 2,
-            ));
-
-            if ($result['is_error'] !== 1) {
-                $res['success'] = 1;
-                $res['message'] = t("Task marked as complete.");
-            }
-        } else {
-            $res['message'] = t("You don't have permissions to mark the Task as complete.");
-        }
-    } catch (CiviCRM_API3_Exception $e) {
-        $error = $e->getMessage();
-        $res['message'] = t("Error communicating with API.");
+      if ($result['is_error'] !== 1) {
+        $res['success'] = 1;
+        $res['message'] = t("Task marked as complete.");
+      }
+    } else {
+      $res['message'] = t("You don't have permissions to mark the Task as complete.");
     }
+  } catch (CiviCRM_API3_Exception $e) {
+    $error = $e->getMessage();
+    $res['message'] = t("Error communicating with API.");
+  }
 
-    // clear views cache to reflect the changes
-    _clear_json_cache();
+  // clear views cache to reflect the changes
+  _clear_json_cache();
 
-    // Output json
-    drupal_json_output($res);
-    drupal_exit();
-
+  // Output json
+  drupal_json_output($res);
+  drupal_exit();
 }
 
 /**
@@ -2850,28 +2754,27 @@ function civihr_employee_portal_civi_tasks_complete($taskId = null) {
  * @return bool
  */
 function _task_can_be_marked_as_complete($taskId) {
+  global $user;
+  $result = false;
 
-    global $user;
-    $result = false;
+  try {
+    $apiResult = civicrm_api3('Task', 'get', [
+      'sequential' => 1,
+      'return' => "id,assignee_contact_id",
+      'id' => $taskId,
+    ]);
 
-    try {
-        $apiResult = civicrm_api3('Task', 'get', array(
-            'sequential' => 1,
-            'return' => "id,assignee_contact_id",
-            'id' => $taskId,
-        ));
+    $uf = get_civihr_uf_match_data($user->uid);
+    $apiResultValue = CRM_Utils_Array::first($apiResult['values']);
 
-        $uf = get_civihr_uf_match_data($user->uid);
-        $apiResultValue = CRM_Utils_Array::first($apiResult['values']);
-
-        if (in_array($uf['contact_id'], $apiResultValue['assignee_contact_id'])) {
-            $result = true;
-        }
-    } catch (CiviCRM_API3_Exception $e) {
-        $error = $e->getMessage();
+    if (in_array($uf['contact_id'], $apiResultValue['assignee_contact_id'])) {
+      $result = true;
     }
+  } catch (CiviCRM_API3_Exception $e) {
+    $error = $e->getMessage();
+  }
 
-    return $result;
+  return $result;
 }
 
 /**
@@ -2882,731 +2785,696 @@ function _task_can_be_marked_as_complete($taskId) {
  * @return bool
  */
 function _task_can_be_edited($taskId = null) {
+  global $user;
 
-    global $user;
-    $result = false;
+  $result = false;
 
-    if ($taskId) {
-        try {
-            $apiResult = civicrm_api3('Task', 'get', array(
-                'sequential' => 1,
-                'return' => "id,source_contact_id",
-                'id' => $taskId,
-            ));
+  if ($taskId) {
+    try {
+      $apiResult = civicrm_api3('Task', 'get', [
+        'sequential' => 1,
+        'return' => "id,source_contact_id",
+        'id' => $taskId,
+      ]);
 
-            $uf = get_civihr_uf_match_data($user->uid);
-            $apiResultValue = CRM_Utils_Array::first($apiResult['values']);
+      $uf = get_civihr_uf_match_data($user->uid);
+      $apiResultValue = CRM_Utils_Array::first($apiResult['values']);
 
-            if (in_array($uf['contact_id'], array($apiResultValue['source_contact_id']))) {
-                $result = true;
-            }
-        } catch (CiviCRM_API3_Exception $e) {
-            $error = $e->getMessage();
-        }
-    } else {
+      if (in_array($uf['contact_id'], [$apiResultValue['source_contact_id']])) {
         $result = true;
+      }
+    } catch (CiviCRM_API3_Exception $e) {
+      $error = $e->getMessage();
     }
+  } else {
+    $result = true;
+  }
 
-    if (!user_access('can create and edit tasks')) {
-        $result = false;
-    }
+  if (!user_access('can create and edit tasks')) {
+    $result = false;
+  }
 
-    return $result;
+  return $result;
 }
 
 /**
-* Ajax menu callback.
-*/
+ * Ajax menu callback.
+ */
 function civihr_employee_portal_appraisal_manager_upload($ajax, $id) {
+  if ($ajax) {
+    ctools_include('ajax');
+    ctools_include('modal');
 
-    if ($ajax) {
-        ctools_include('ajax');
-        ctools_include('modal');
+    $title = t('Appraisal Upload');
 
-        $title = t('Appraisal Upload');
+    $form_state = [
+      'ajax' => TRUE,
+      'is_ajax_update' => TRUE,
+      'title' => $title,
+      'id' => $id,
+    ];
 
-        $form_state = array(
-            'ajax' => TRUE,
-            'is_ajax_update' => TRUE,
-            'title' => $title,
-            'id' => $id,
-        );
-
-        // Since this will run again on form rebuild while still in the modal, prevent
-        // form IDs from being incremented.
-        // @todo https://drupal.org/node/1305882
-        if (!empty($_POST['ajax_html_ids'])) {
-            unset($_POST['ajax_html_ids']);
-        }
-
-        // Use ctools to generate ajax instructions for the browser to create
-        // a form in a modal popup.
-        $output = ctools_modal_form_wrapper('civihr_employee_portal_appraisal_manager_form', $form_state);
-
-        // If the form has been submitted, there may be additional instructions
-        // such as dismissing the modal popup.
-        if (!empty($form_state['executed'])) {
-
-            // Add the responder javascript, required by ctools
-            ctools_add_js('ajax-responder');
-
-            $output[] = ajax_command_replace('.messages', 'all good');
-            $output[] = ctools_modal_command_dismiss();
-            $output[] = ctools_ajax_command_redirect('hr-appraisals-manager');
-
-        }
-
-        // Return the ajax instructions to the browser via ajax_render().
-        print ajax_render($output);
-        drupal_exit();
-
+    // Since this will run again on form rebuild while still in the modal, prevent
+    // form IDs from being incremented.
+    // @todo https://drupal.org/node/1305882
+    if (!empty($_POST['ajax_html_ids'])) {
+      unset($_POST['ajax_html_ids']);
     }
 
-    else {
-        return drupal_get_form('civihr_employee_portal_appraisal_manager_form');
+    // Use ctools to generate ajax instructions for the browser to create
+    // a form in a modal popup.
+    $output = ctools_modal_form_wrapper('civihr_employee_portal_appraisal_manager_form', $form_state);
+
+    // If the form has been submitted, there may be additional instructions
+    // such as dismissing the modal popup.
+    if (!empty($form_state['executed'])) {
+      // Add the responder javascript, required by ctools
+      ctools_add_js('ajax-responder');
+
+      $output[] = ajax_command_replace('.messages', 'all good');
+      $output[] = ctools_modal_command_dismiss();
+      $output[] = ctools_ajax_command_redirect('hr-appraisals-manager');
     }
 
+    // Return the ajax instructions to the browser via ajax_render().
+    print ajax_render($output);
+    drupal_exit();
+  }
+  else {
+    return drupal_get_form('civihr_employee_portal_appraisal_manager_form');
+  }
 }
 
 /**
  * Custom Document dashboard block form.
  */
 function civihr_employee_portal_appraisal_manager_form($form, &$form_state) {
+  $extensions = CRM_Core_PseudoConstant::getExtensions();
 
-    $extensions = CRM_Core_PseudoConstant::getExtensions();
-    if (empty($extensions['uk.co.compucorp.civicrm.appraisals'])) {
-        return $form;
-    }
-
-    $result = civicrm_api3('Appraisal', 'get', array(
-        'sequential' => 1,
-        'id' => $form_state['id'],
-    ));
-    $appraisal = CRM_Utils_Array::first($result['values']);
-
-    $files = CRM_Appraisals_Page_Files::fileList(
-        array(
-            'entityTable' => 'civicrm_appraisal-manager',
-            'entityID' => $appraisal['id'],
-        )
-    );
-
-    $form['#prefix'] = '<article class="node node-webform contextual-links-region clearfix"><div class="content">';
-    $form['#suffix'] = '</div></article>';
-
-    $form['id'] = array(
-        '#type' => 'hidden',
-        '#value' => $appraisal['id'],
-    );
-
-    $form['files'] = array(
-        '#type' => 'plupload',
-        '#title' => 'Files',
-        '#prefix' => '<div class="row"><div class="col-md-12"><div class="well drop-zone" id="drop-target">Drop document here</div>',
-        '#suffix' => '<div id="notsupported">Your browser doesn\'t support multiupload feature.</div>
-            <div>
-                <table class="table table-condensed table-upload">
-                    <colgroup>
-                            <col class="col-index">
-                            <col class="col-name">
-                            <col class="col-size">
-                            <col class="col-status">
-                            <col class="col-action">
-                    </colgroup>
-                    <thead>
-                        <tr>
-                            <th>#</th>
-                            <th>Name</th>
-                            <th>Size</th>
-                            <th>Progress</th>
-                            <th></th>
-                        </tr>
-                    </thead>
-                    <tbody id="filelist">
-                    </tbody>
-                </table>
-            </div>
-            <br />
-            <div id="container">
-                <a href class="btn btn-primary" id="pickfiles">Select files</a>
-            </div>
-            <br />
-            <pre id="console"></pre>
-            <script>
-            CRM.$(document).trigger("uploaderFormReady", {id: ' . $appraisal['id'] . ', table: "civicrm_appraisal-manager", url: "/civicrm/appraisals/file/upload", formId: "civihr-employee-portal-appraisal-manager-form", title: "Appraisal file", files:' . json_encode($files) . '});
-            </script>
-        </div></div>',
-    );
-
-    $form['meeting_date'] = array(
-        '#type' => 'date_popup',
-        '#title' => t('Appraisal meeting date'),
-        '#prefix' => '<div class="row"><div class="col-md-12">',
-        '#suffix' => '</div></div>',
-        '#date_format' => 'Y-m-d',
-        '#date_year_range' => '-10:+10',
-        '#default_value' => isset($appraisal['meeting_date']) ? strip_tags($appraisal['meeting_date']) : '',
-    );
-
-    $form['checkboxes'] = array(
-        '#type' => 'checkboxes',
-        '#prefix' => '<div class="row"><div class="col-md-12">',
-        '#suffix' => '</div></div>',
-        '#options' => array(
-            1 => t('Appraisal meeting completed'),
-            2 => t('Discussed and approved with employee')
-        ),
-        '#default_value' => array(
-            $appraisal['meeting_completed'] ? 1 : 0,
-            $appraisal['approved_by_employee'] ? 2 : 0,
-        ),
-    );
-
-    $form['notes'] = array(
-        '#type' => 'textarea',
-        '#title' => t('Notes'),
-        '#prefix' => '<div class="row"><div class="col-md-12">',
-        '#suffix' => '</div></div>',
-        '#rows' => 5,
-        '#cols' => 100,
-        '#default_value' => isset($appraisal['notes']) ? strip_tags($appraisal['notes']) : '',
-    );
-
-    $form['grade'] = array(
-        '#type' => 'textfield',
-        '#title' => t('Grade'),
-        '#prefix' => '<div class="row"><div class="col-md-12">',
-        '#suffix' => '</div></div>',
-        '#default_value' => isset($appraisal['grade']) ? strip_tags($appraisal['grade']) : '0',
-    );
-
-    $form['delete_files'] = array(
-        '#type' => 'hidden',
-    );
-
-    $form['save'] = array(
-        '#type' => 'submit',
-        '#value' => t('Save and set to Awaiting Grade'),
-        '#attributes' => array(
-            'class' => array(
-                'btn',
-                'btn-primary'
-            ),
-        ),
-    );
-
-    // Add the validation function
-    $form['#validate'][] = 'civihr_employee_portal_appraisal_manager_form_validate';
-
-    // Add the submit function
-    $form['#submit'][] = 'civihr_employee_portal_appraisal_manager_form_submit';
-
+  if (empty($extensions['uk.co.compucorp.civicrm.appraisals'])) {
     return $form;
+  }
+
+  $result = civicrm_api3('Appraisal', 'get', [
+    'sequential' => 1,
+    'id' => $form_state['id'],
+  ]);
+  $appraisal = CRM_Utils_Array::first($result['values']);
+
+  $files = CRM_Appraisals_Page_Files::fileList([
+    'entityTable' => 'civicrm_appraisal-manager',
+    'entityID' => $appraisal['id'],
+  ]);
+
+  $form['#prefix'] = '<article class="node node-webform contextual-links-region clearfix"><div class="content">';
+  $form['#suffix'] = '</div></article>';
+
+  $form['id'] = [
+    '#type' => 'hidden',
+    '#value' => $appraisal['id'],
+  ];
+
+  $form['files'] = [
+    '#type' => 'plupload',
+    '#title' => 'Files',
+    '#prefix' => '<div class="row"><div class="col-md-12"><div class="well drop-zone" id="drop-target">Drop document here</div>',
+    '#suffix' => '<div id="notsupported">Your browser doesn\'t support multiupload feature.</div>
+      <div>
+        <table class="table table-condensed table-upload">
+          <colgroup>
+            <col class="col-index">
+            <col class="col-name">
+            <col class="col-size">
+            <col class="col-status">
+            <col class="col-action">
+          </colgroup>
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Name</th>
+              <th>Size</th>
+              <th>Progress</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody id="filelist">
+          </tbody>
+        </table>
+      </div>
+      <br />
+      <div id="container">
+        <a href class="btn btn-primary" id="pickfiles">Select files</a>
+      </div>
+      <br />
+      <pre id="console"></pre>
+      <script>
+        CRM.$(document).trigger("uploaderFormReady", {id: ' . $appraisal['id'] . ', table: "civicrm_appraisal-manager", url: "/civicrm/appraisals/file/upload", formId: "civihr-employee-portal-appraisal-manager-form", title: "Appraisal file", files:' . json_encode($files) . '});
+      </script>
+    </div></div>',
+  ];
+
+  $form['meeting_date'] = [
+    '#type' => 'date_popup',
+    '#title' => t('Appraisal meeting date'),
+    '#prefix' => '<div class="row"><div class="col-md-12">',
+    '#suffix' => '</div></div>',
+    '#date_format' => 'Y-m-d',
+    '#date_year_range' => '-10:+10',
+    '#default_value' => isset($appraisal['meeting_date']) ? strip_tags($appraisal['meeting_date']) : '',
+  ];
+
+  $form['checkboxes'] = [
+    '#type' => 'checkboxes',
+    '#prefix' => '<div class="row"><div class="col-md-12">',
+    '#suffix' => '</div></div>',
+    '#options' => [
+      1 => t('Appraisal meeting completed'),
+      2 => t('Discussed and approved with employee')
+    ],
+    '#default_value' => [
+      $appraisal['meeting_completed'] ? 1 : 0,
+      $appraisal['approved_by_employee'] ? 2 : 0,
+    ],
+  ];
+
+  $form['notes'] = [
+    '#type' => 'textarea',
+    '#title' => t('Notes'),
+    '#prefix' => '<div class="row"><div class="col-md-12">',
+    '#suffix' => '</div></div>',
+    '#rows' => 5,
+    '#cols' => 100,
+    '#default_value' => isset($appraisal['notes']) ? strip_tags($appraisal['notes']) : '',
+  ];
+
+  $form['grade'] = [
+    '#type' => 'textfield',
+    '#title' => t('Grade'),
+    '#prefix' => '<div class="row"><div class="col-md-12">',
+    '#suffix' => '</div></div>',
+    '#default_value' => isset($appraisal['grade']) ? strip_tags($appraisal['grade']) : '0',
+  ];
+
+  $form['delete_files'] = [
+    '#type' => 'hidden',
+  ];
+
+  $form['save'] = [
+    '#type' => 'submit',
+    '#value' => t('Save and set to Awaiting Grade'),
+    '#attributes' => [
+      'class' => [
+        'btn',
+        'btn-primary'
+      ],
+    ],
+  ];
+
+  // Add the validation function
+  $form['#validate'][] = 'civihr_employee_portal_appraisal_manager_form_validate';
+
+  // Add the submit function
+  $form['#submit'][] = 'civihr_employee_portal_appraisal_manager_form_submit';
+
+  return $form;
 }
 
 function civihr_employee_portal_appraisal_manager_form_validate($form, &$form_state) {
-    if (empty($form_state['values']['meeting_date'])) {
-        form_set_error('meeting_date', t('Please specify Appraisal meeting date.'));
-    }
+  if (empty($form_state['values']['meeting_date'])) {
+    form_set_error('meeting_date', t('Please specify Appraisal meeting date.'));
+  }
 }
 
 function civihr_employee_portal_appraisal_manager_form_submit($form, &$form_state) {
-    $result_output = array();
-    $extensions = CRM_Core_PseudoConstant::getExtensions();
-    if (empty($extensions['uk.co.compucorp.civicrm.appraisals'])) {
-        return false;
+  $result_output = [];
+  $extensions = CRM_Core_PseudoConstant::getExtensions();
+
+  if (empty($extensions['uk.co.compucorp.civicrm.appraisals'])) {
+    return false;
+  }
+
+  $id = (int)strip_tags($form_state['values']['id']);
+  $meetingDate = substr(strip_tags($form_state['values']['meeting_date']), 0, 10);
+  $meetingCompleted = strip_tags($form_state['values']['checkboxes'][1]) ? 1 : 0;
+  $meetingApproved = (int)strip_tags($form_state['values']['checkboxes'][2]) ? 1 : 0;
+  $notes = strip_tags($form_state['values']['notes']);
+  $grade = (int)strip_tags($form_state['values']['grade']);
+
+  $params = [
+    'sequential' => 1,
+    'id' => $id,
+    'meeting_date' => $meetingDate,
+    'meeting_completed' => $meetingCompleted,
+    'approved_by_employee' => $meetingApproved,
+    'notes' => $notes,
+  ];
+
+  //TODO: if (has_appraisal_permissions to grade) {
+  $params['grade'] = $grade;
+  //}
+
+  // setting appraisal status to Awaiting Grade:
+  $params['status_id'] = 3;
+
+  $result = civicrm_api3('Appraisal', 'create', $params);
+
+  $deleteFiles = json_decode($form_state['values']['delete_files'], true);
+  if (!empty($deleteFiles)) {
+    foreach ($deleteFiles as $deleteFile) {
+      $result = CRM_Appraisals_Page_Files::fileDelete([
+        'fileID' => (int)$deleteFile['id'],
+        'entityTable' => 'civicrm_appraisal-manager',
+        'entityID' => $form_state['values']['id'],
+      ]);
     }
+  }
 
-    $id = (int)strip_tags($form_state['values']['id']);
-    $meetingDate = substr(strip_tags($form_state['values']['meeting_date']), 0, 10);
-    $meetingCompleted = strip_tags($form_state['values']['checkboxes'][1]) ? 1 : 0;
-    $meetingApproved = (int)strip_tags($form_state['values']['checkboxes'][2]) ? 1 : 0;
-    $notes = strip_tags($form_state['values']['notes']);
-    $grade = (int)strip_tags($form_state['values']['grade']);
+  //clear views cache to reflect changes
+  _clear_json_cache();
 
-    $params = array(
-        'sequential' => 1,
-        'id' => $id,
-        'meeting_date' => $meetingDate,
-        'meeting_completed' => $meetingCompleted,
-        'approved_by_employee' => $meetingApproved,
-        'notes' => $notes,
-    );
-    //TODO: if (has_appraisal_permissions to grade) {
-    $params['grade'] = $grade;
-    //}
-
-    // setting appraisal status to Awaiting Grade:
-    $params['status_id'] = 3;
-
-    $result = civicrm_api3('Appraisal', 'create', $params);
-
-    $deleteFiles = json_decode($form_state['values']['delete_files'], true);
-    if (!empty($deleteFiles)) {
-        foreach ($deleteFiles as $deleteFile) {
-            $result = CRM_Appraisals_Page_Files::fileDelete(
-                array(
-                    'fileID' => (int)$deleteFile['id'],
-                    'entityTable' => 'civicrm_appraisal-manager',
-                    'entityID' => $form_state['values']['id'],
-                )
-            );
-        }
-    }
-
-    //clear views cache to reflect changes
-    _clear_json_cache();
-
-    drupal_set_message(t('Appraisal changes has been saved.'), 'success');
-    //drupal_goto('hr-appraisals-manager');
+  drupal_set_message(t('Appraisal changes has been saved.'), 'success');
 }
 
 function civihr_employee_portal_appraisal_manager_view($ajax, $id) {
+  $appraisal = civicrm_api3('Appraisal', 'getsingle', [
+    'sequential' => 1,
+    'id' => (int)$id,
+  ]);
+  $appraisal['meeting_date'] = substr($appraisal['meeting_date'], 0, 10);
+  $appraisalCycle = civicrm_api3('AppraisalCycle', 'getsingle', [
+    'sequential' => 1,
+    'id' => $appraisal['appraisal_cycle_id'],
+  ]);
+  $contact = get_civihr_contact_data($appraisal['contact_id']);
+  $manager = get_civihr_contact_data($appraisal['manager_id']);
+  $title = $contact['display_name'] . ' Appraisal';
+  $documents = civihr_employee_portal_get_appraisal_documents($appraisal['id']);
 
-    $appraisal = civicrm_api3('Appraisal', 'getsingle', array(
-        'sequential' => 1,
-        'id' => (int)$id,
-    ));
-    $appraisal['meeting_date'] = substr($appraisal['meeting_date'], 0, 10);
-    $appraisalCycle = civicrm_api3('AppraisalCycle', 'getsingle', array(
-        'sequential' => 1,
-        'id' => $appraisal['appraisal_cycle_id'],
-    ));
-    $contact = get_civihr_contact_data($appraisal['contact_id']);
-    $manager = get_civihr_contact_data($appraisal['manager_id']);
-    $title = $contact['display_name'] . ' Appraisal';
-    $documents = civihr_employee_portal_get_appraisal_documents($appraisal['id']);
+  $output = theme_render_template(
+    drupal_get_path('module', 'civihr_employee_portal') .
+    '/templates/civihr-employee-portal-appraisal-manager-view-modal.tpl.php',
+    [
+      'appraisal' => $appraisal,
+      'appraisalCycle' => $appraisalCycle,
+      'contact' => $contact,
+      'manager' => $manager,
+      'appraisalStatus' => get_appraisal_status($appraisal['status_id']),
+      'appraisalCycleType' => get_appraisal_cycle_type($appraisalCycle['type_id']),
+      'documents' => $documents,
+    ]
+  );
 
-    $output = theme_render_template(
-        drupal_get_path('module', 'civihr_employee_portal') .
-        '/templates/civihr-employee-portal-appraisal-manager-view-modal.tpl.php',
-        array(
-            'appraisal' => $appraisal,
-            'appraisalCycle' => $appraisalCycle,
-            'contact' => $contact,
-            'manager' => $manager,
-            'appraisalStatus' => get_appraisal_status($appraisal['status_id']),
-            'appraisalCycleType' => get_appraisal_cycle_type($appraisalCycle['type_id']),
-            'documents' => $documents,
-        )
-    );
+  if ($ajax) {
+    ctools_include('ajax');
+    ctools_include('modal');
 
-    if ($ajax) {
-        ctools_include('ajax');
-        ctools_include('modal');
-
-        ctools_modal_render($title, $output);
-        drupal_exit();
-    } else {
-        return $output;
-    }
-
+    ctools_modal_render($title, $output);
+    drupal_exit();
+  } else {
+    return $output;
+  }
 }
 
 function civihr_employee_portal_appraisal_employee_upload($ajax, $id) {
+  if ($ajax) {
+    ctools_include('ajax');
+    ctools_include('modal');
 
-    if ($ajax) {
-        ctools_include('ajax');
-        ctools_include('modal');
+    $title = t('Appraisal Upload');
 
-        $title = t('Appraisal Upload');
+    $form_state = [
+      'ajax' => TRUE,
+      'is_ajax_update' => TRUE,
+      'title' => $title,
+      'id' => $id,
+    ];
 
-        $form_state = array(
-            'ajax' => TRUE,
-            'is_ajax_update' => TRUE,
-            'title' => $title,
-            'id' => $id,
-        );
-
-        // Since this will run again on form rebuild while still in the modal, prevent
-        // form IDs from being incremented.
-        // @todo https://drupal.org/node/1305882
-        if (!empty($_POST['ajax_html_ids'])) {
-            unset($_POST['ajax_html_ids']);
-        }
-
-        // Use ctools to generate ajax instructions for the browser to create
-        // a form in a modal popup.
-        $output = ctools_modal_form_wrapper('civihr_employee_portal_appraisal_employee_form', $form_state);
-
-        // If the form has been submitted, there may be additional instructions
-        // such as dismissing the modal popup.
-        if (!empty($form_state['executed'])) {
-
-            // Add the responder javascript, required by ctools
-            ctools_add_js('ajax-responder');
-
-            $output[] = ajax_command_replace('.messages', 'all good');
-            $output[] = ctools_modal_command_dismiss();
-            $output[] = ctools_ajax_command_redirect('dashboard');
-
-        }
-
-        // Return the ajax instructions to the browser via ajax_render().
-        print ajax_render($output);
-        drupal_exit();
-
+    // Since this will run again on form rebuild while still in the modal, prevent
+    // form IDs from being incremented.
+    // @todo https://drupal.org/node/1305882
+    if (!empty($_POST['ajax_html_ids'])) {
+      unset($_POST['ajax_html_ids']);
     }
 
-    else {
-        return drupal_get_form('civihr_employee_portal_appraisal_employee_form');
+    // Use ctools to generate ajax instructions for the browser to create
+    // a form in a modal popup.
+    $output = ctools_modal_form_wrapper('civihr_employee_portal_appraisal_employee_form', $form_state);
+
+    // If the form has been submitted, there may be additional instructions
+    // such as dismissing the modal popup.
+    if (!empty($form_state['executed'])) {
+      // Add the responder javascript, required by ctools
+      ctools_add_js('ajax-responder');
+
+      $output[] = ajax_command_replace('.messages', 'all good');
+      $output[] = ctools_modal_command_dismiss();
+      $output[] = ctools_ajax_command_redirect('dashboard');
     }
 
+    // Return the ajax instructions to the browser via ajax_render().
+    print ajax_render($output);
+    drupal_exit();
+  }
+  else {
+    return drupal_get_form('civihr_employee_portal_appraisal_employee_form');
+  }
 }
 
 /**
  * Custom Document dashboard block form.
  */
 function civihr_employee_portal_appraisal_employee_form($form, &$form_state) {
+  $extensions = CRM_Core_PseudoConstant::getExtensions();
 
-    $extensions = CRM_Core_PseudoConstant::getExtensions();
-    if (empty($extensions['uk.co.compucorp.civicrm.appraisals'])) {
-        return $form;
-    }
-
-    $result = civicrm_api3('Appraisal', 'get', array(
-        'sequential' => 1,
-        'id' => $form_state['id'],
-    ));
-    $appraisal = CRM_Utils_Array::first($result['values']);
-
-    $files = CRM_Appraisals_Page_Files::fileList(
-        array(
-            'entityTable' => 'civicrm_appraisal-self',
-            'entityID' => $appraisal['id'],
-        )
-    );
-
-    $form['#prefix'] = '<article class="node node-webform contextual-links-region clearfix"><div class="content">';
-    $form['#suffix'] = '</div></article>';
-
-    $form['id'] = array(
-        '#type' => 'hidden',
-        '#value' => $appraisal['id'],
-    );
-
-    $form['files'] = array(
-        '#type' => 'plupload',
-        '#title' => 'Files',
-        '#prefix' => '<div class="row"><div class="col-md-12"><div class="well drop-zone" id="drop-target">Drop document here</div>',
-        '#suffix' => '<div id="notsupported">Your browser doesn\'t support multiupload feature.</div>
-            <div>
-                <table class="table table-condensed table-upload">
-                    <colgroup>
-                            <col class="col-index">
-                            <col class="col-name">
-                            <col class="col-size">
-                            <col class="col-status">
-                            <col class="col-action">
-                    </colgroup>
-                    <thead>
-                        <tr>
-                            <th>#</th>
-                            <th>Name</th>
-                            <th>Size</th>
-                            <th>Progress</th>
-                            <th></th>
-                        </tr>
-                    </thead>
-                    <tbody id="filelist">
-                    </tbody>
-                </table>
-            </div>
-            <br />
-            <div id="container">
-                <a href class="btn btn-primary" id="pickfiles">Select files</a>
-            </div>
-            <br />
-            <pre id="console"></pre>
-            <script>
-            CRM.$(document).trigger("uploaderFormReady", {id: ' . $appraisal['id'] . ', table: "civicrm_appraisal-self", url: "/civicrm/appraisals/file/upload", formId: "civihr-employee-portal-appraisal-employee-form", title: "Appraisal file", files:' . json_encode($files) . '});
-            </script>
-        </div></div>',
-    );
-
-    $form['delete_files'] = array(
-        '#type' => 'hidden',
-    );
-
-    $form['save'] = array(
-        '#type' => 'submit',
-        '#value' => t('Save and Assign to Manager'),
-        '#attributes' => array(
-            'class' => array(
-                'btn',
-                'btn-primary'
-            ),
-        ),
-    );
-
-    // Add the validation function
-    $form['#validate'][] = 'civihr_employee_portal_appraisal_employee_form_validate';
-
-    // Add the submit function
-    $form['#submit'][] = 'civihr_employee_portal_appraisal_employee_form_submit';
-
+  if (empty($extensions['uk.co.compucorp.civicrm.appraisals'])) {
     return $form;
+  }
+
+  $result = civicrm_api3('Appraisal', 'get', [
+    'sequential' => 1,
+    'id' => $form_state['id'],
+  ]);
+  $appraisal = CRM_Utils_Array::first($result['values']);
+
+  $files = CRM_Appraisals_Page_Files::fileList([
+    'entityTable' => 'civicrm_appraisal-self',
+    'entityID' => $appraisal['id'],
+  ]);
+
+  $form['#prefix'] = '<article class="node node-webform contextual-links-region clearfix"><div class="content">';
+  $form['#suffix'] = '</div></article>';
+
+  $form['id'] = [
+    '#type' => 'hidden',
+    '#value' => $appraisal['id'],
+  ];
+
+  $form['files'] = [
+    '#type' => 'plupload',
+    '#title' => 'Files',
+    '#prefix' => '<div class="row"><div class="col-md-12"><div class="well drop-zone" id="drop-target">Drop document here</div>',
+    '#suffix' => '<div id="notsupported">Your browser doesn\'t support multiupload feature.</div>
+      <div>
+        <table class="table table-condensed table-upload">
+          <colgroup>
+            <col class="col-index">
+            <col class="col-name">
+            <col class="col-size">
+            <col class="col-status">
+            <col class="col-action">
+          </colgroup>
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Name</th>
+              <th>Size</th>
+              <th>Progress</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody id="filelist">
+          </tbody>
+        </table>
+      </div>
+      <br />
+      <div id="container">
+        <a href class="btn btn-primary" id="pickfiles">Select files</a>
+      </div>
+      <br />
+      <pre id="console"></pre>
+      <script>
+        CRM.$(document).trigger("uploaderFormReady", {id: ' . $appraisal['id'] . ', table: "civicrm_appraisal-self", url: "/civicrm/appraisals/file/upload", formId: "civihr-employee-portal-appraisal-employee-form", title: "Appraisal file", files:' . json_encode($files) . '});
+      </script>
+    </div></div>',
+  ];
+
+  $form['delete_files'] = [
+    '#type' => 'hidden',
+  ];
+
+  $form['save'] = [
+    '#type' => 'submit',
+    '#value' => t('Save and Assign to Manager'),
+    '#attributes' => [
+      'class' => [
+        'btn',
+        'btn-primary'
+      ],
+    ],
+  ];
+
+  // Add the validation function
+  $form['#validate'][] = 'civihr_employee_portal_appraisal_employee_form_validate';
+
+  // Add the submit function
+  $form['#submit'][] = 'civihr_employee_portal_appraisal_employee_form_submit';
+
+  return $form;
 }
 
 function civihr_employee_portal_appraisal_employee_form_validate($form, &$form_state) {
-    return TRUE;
+  return TRUE;
 }
 
 function civihr_employee_portal_appraisal_employee_form_submit($form, &$form_state) {
-    $result_output = array();
-    $extensions = CRM_Core_PseudoConstant::getExtensions();
-    if (empty($extensions['uk.co.compucorp.civicrm.appraisals'])) {
-        return false;
+  $result_output = [];
+  $extensions = CRM_Core_PseudoConstant::getExtensions();
+
+  if (empty($extensions['uk.co.compucorp.civicrm.appraisals'])) {
+    return false;
+  }
+
+  $id = (int)strip_tags($form_state['values']['id']);
+
+  $params = [
+    'sequential' => 1,
+    'id' => $id,
+  ];
+
+  // setting appraisal status to Awaiting Manager Appraisal:
+  $params['status_id'] = 2;
+
+  $result = civicrm_api3('Appraisal', 'create', $params);
+  $deleteFiles = json_decode($form_state['values']['delete_files'], true);
+
+  if (!empty($deleteFiles)) {
+    foreach ($deleteFiles as $deleteFile) {
+      $result = CRM_Appraisals_Page_Files::fileDelete([
+        'fileID' => (int)$deleteFile['id'],
+        'entityTable' => 'civicrm_appraisal-self',
+        'entityID' => $form_state['values']['id'],
+      ]);
     }
+  }
 
-    $id = (int)strip_tags($form_state['values']['id']);
+  //clear views cache to reflect changes
+  _clear_json_cache();
 
-    $params = array(
-        'sequential' => 1,
-        'id' => $id,
-    );
-
-    // setting appraisal status to Awaiting Manager Appraisal:
-    $params['status_id'] = 2;
-
-    $result = civicrm_api3('Appraisal', 'create', $params);
-
-    $deleteFiles = json_decode($form_state['values']['delete_files'], true);
-    if (!empty($deleteFiles)) {
-        foreach ($deleteFiles as $deleteFile) {
-            $result = CRM_Appraisals_Page_Files::fileDelete(
-                array(
-                    'fileID' => (int)$deleteFile['id'],
-                    'entityTable' => 'civicrm_appraisal-self',
-                    'entityID' => $form_state['values']['id'],
-                )
-            );
-        }
-    }
-
-    //clear views cache to reflect changes
-    _clear_json_cache();
-
-    drupal_set_message(t('Appraisal changes has been saved.'), 'success');
-    //drupal_goto('hr-appraisals-manager');
+  drupal_set_message(t('Appraisal changes has been saved.'), 'success');
 }
 
 function civihr_employee_portal_get_appraisal_documents($appraisalId) {
+  $documents = [];
+  $selfAppraisalFiles = CRM_Appraisals_Page_Files::fileList([
+    'entityTable' => 'civicrm_appraisal-self',
+    'entityID' => $appraisalId,
+  ]);
 
-    $documents = array();
-    $selfAppraisalFiles = CRM_Appraisals_Page_Files::fileList(array(
-        'entityTable' => 'civicrm_appraisal-self',
-        'entityID' => $appraisalId,
-    ));
-    foreach ($selfAppraisalFiles as $file) {
-        $file['appraisalFileTypeLabel'] = 'Self Appraisal';
-        $documents['selfAppraisal'] = $file;
-    }
-    $managerAppraisalFiles = CRM_Appraisals_Page_Files::fileList(array(
-        'entityTable' => 'civicrm_appraisal-manager',
-        'entityID' => $appraisalId,
-    ));
-    foreach ($managerAppraisalFiles as $file) {
-        $file['appraisalFileTypeLabel'] = 'Manager Appraisal';
-        $documents['managerAppraisal'] = $file;
-    }
+  foreach ($selfAppraisalFiles as $file) {
+    $file['appraisalFileTypeLabel'] = 'Self Appraisal';
+    $documents['selfAppraisal'] = $file;
+  }
 
-    return $documents;
+  $managerAppraisalFiles = CRM_Appraisals_Page_Files::fileList([
+    'entityTable' => 'civicrm_appraisal-manager',
+    'entityID' => $appraisalId,
+  ]);
+
+  foreach ($managerAppraisalFiles as $file) {
+    $file['appraisalFileTypeLabel'] = 'Manager Appraisal';
+    $documents['managerAppraisal'] = $file;
+  }
+
+  return $documents;
 }
 
 ////////////////////////////// end of Appraisals functions.
 
 
 /**
-* Ajax menu callback.
-*/
+ * Ajax menu callback.
+ */
 function civihr_employee_portal_request_new_account($ajax) {
+  if ($ajax) {
+    ctools_include('ajax');
+    ctools_include('modal');
 
-    if ($ajax) {
-        ctools_include('ajax');
-        ctools_include('modal');
+    $title = t('Request Access');
 
-        $title = t('Request Access');
+    $form_state = [
+      'ajax' => TRUE,
+      'is_ajax_update' => TRUE,
+      'title' => $title,
+    ];
 
-        $form_state = array(
-            'ajax' => TRUE,
-            'is_ajax_update' => TRUE,
-            'title' => $title,
-        );
-
-        // Since this will run again on form rebuild while still in the modal, prevent
-        // form IDs from being incremented.
-        // @todo https://drupal.org/node/1305882
-        if (!empty($_POST['ajax_html_ids'])) {
-            unset($_POST['ajax_html_ids']);
-        }
-
-        // Use ctools to generate ajax instructions for the browser to create
-        // a form in a modal popup.
-        $output = ctools_modal_form_wrapper('civihr_employee_portal_request_new_account_form', $form_state);
-
-        // If the form has been submitted, there may be additional instructions
-        // such as dismissing the modal popup.
-        if (!empty($form_state['executed'])) {
-
-            // Add the responder javascript, required by ctools
-            ctools_add_js('ajax-responder');
-
-            $output[] = ajax_command_replace('.messages', 'all good');
-            $output[] = ctools_modal_command_dismiss();
-            $output[] = ctools_ajax_command_redirect('welcome-page');
-
-        }
-
-        // Return the ajax instructions to the browser via ajax_render().
-        print ajax_render($output);
-        drupal_exit();
-
+    // Since this will run again on form rebuild while still in the modal, prevent
+    // form IDs from being incremented.
+    // @todo https://drupal.org/node/1305882
+    if (!empty($_POST['ajax_html_ids'])) {
+      unset($_POST['ajax_html_ids']);
     }
 
-    else {
-        return drupal_get_form('civihr_employee_portal_request_new_account_form');
+    // Use ctools to generate ajax instructions for the browser to create
+    // a form in a modal popup.
+    $output = ctools_modal_form_wrapper('civihr_employee_portal_request_new_account_form', $form_state);
+
+    // If the form has been submitted, there may be additional instructions
+    // such as dismissing the modal popup.
+    if (!empty($form_state['executed'])) {
+      // Add the responder javascript, required by ctools
+      ctools_add_js('ajax-responder');
+
+      $output[] = ajax_command_replace('.messages', 'all good');
+      $output[] = ctools_modal_command_dismiss();
+      $output[] = ctools_ajax_command_redirect('welcome-page');
     }
+
+    // Return the ajax instructions to the browser via ajax_render().
+    print ajax_render($output);
+    drupal_exit();
+  }
+  else {
+    return drupal_get_form('civihr_employee_portal_request_new_account_form');
+  }
 }
 
 function civihr_employee_portal_request_new_account_form($form, &$form_state){
+  $form = [];
 
-    $form = array();
+  $form['#prefix'] = '<div id="request-new-account-form" class="col-md-12">';
+  $form['#suffix'] = '</div>';
 
-    //$form = drupal_get_form('user_register_form', $form);
+  $form['first_name'] = [
+    '#type' => 'textfield',
+    '#title' => t('First Name'),
+    '#prefix' => '<div class="row"><div class="col-md-6">',
+    '#suffix' => '</div>',
+    '#attributes' => [
+      'placeholder' => t('First Name'),
+    ],
+  ];
 
-    $form['#prefix'] = '<div id="request-new-account-form" class="col-md-12">';
-    $form['#suffix'] = '</div>';
+  $form['last_name'] = [
+    '#type' => 'textfield',
+    '#title' => t('Last Name'),
+    '#prefix' => '<div class="col-md-6">',
+    '#suffix' => '</div></div>',
+    '#attributes' => [
+      'placeholder' => t('Last Name'),
+    ],
+  ];
 
-    $form['first_name'] = array(
-        '#type' => 'textfield',
-        '#title' => t('First Name'),
-        '#prefix' => '<div class="row"><div class="col-md-6">',
-        '#suffix' => '</div>',
-        '#attributes' => array(
-            'placeholder' => t('First Name'),
-        ),
-    );
+  $form['mail'] = [
+    '#type' => 'textfield',
+    '#title' => t('Email'),
+    '#prefix' => '<div class="row"><div class="col-md-12">',
+    '#suffix' => '</div></div>',
+    '#attributes' => [
+      'placeholder' => t('Email'),
+    ],
+  ];
 
-    $form['last_name'] = array(
-        '#type' => 'textfield',
-        '#title' => t('Last Name'),
-        '#prefix' => '<div class="col-md-6">',
-        '#suffix' => '</div></div>',
-        '#attributes' => array(
-            'placeholder' => t('Last Name'),
-        ),
-    );
+  $form['name'] = [
+    '#type' => 'textfield',
+    '#title' => t('Username'),
+    '#prefix' => '<div class="row"><div class="col-md-12">',
+    '#suffix' => '</div></div>',
+    '#attributes' => [
+      'placeholder' => t('Username'),
+    ],
+  ];
 
-    $form['mail'] = array(
-        '#type' => 'textfield',
-        '#title' => t('Email'),
-        '#prefix' => '<div class="row"><div class="col-md-12">',
-        '#suffix' => '</div></div>',
-        '#attributes' => array(
-            'placeholder' => t('Email'),
-        ),
-    );
+  $form['submit'] = [
+    '#type' => 'submit',
+    '#value' => t('Request Access'),
+  ];
 
-    $form['name'] = array(
-        '#type' => 'textfield',
-        '#title' => t('Username'),
-        '#prefix' => '<div class="row"><div class="col-md-12">',
-        '#suffix' => '</div></div>',
-        '#attributes' => array(
-            'placeholder' => t('Username'),
-        ),
-    );
+  $form['#validate'] = ['civihr_employee_portal_request_new_account_validate'];
+  $form['#submit'] = ['civihr_employee_portal_request_new_account_submit'];
 
-    $form['submit'] = array(
-        '#type' => 'submit',
-        '#value' => t('Request Access'),
-    );
-
-    $form['#validate'] = array('civihr_employee_portal_request_new_account_validate');
-    $form['#submit'] = array('civihr_employee_portal_request_new_account_submit');
-
-    return $form;
+  return $form;
 }
 
 function civihr_employee_portal_request_new_account_validate($form, &$form_state) {
+  if ($form_state['values']['first_name'] == '') {
+    form_set_error('first_name', t('First Name field is required.'));
+  }
 
-    //$form['#user_category'] = 'account';
-    if ($form_state['values']['first_name'] == '') {
-        form_set_error('first_name', t('First Name field is required.'));
-    }
+  if ($form_state['values']['last_name'] == '') {
+    form_set_error('last_name', t('Last Name field is required.'));
+  }
 
-    if ($form_state['values']['last_name'] == '') {
-        form_set_error('last_name', t('Last Name field is required.'));
-    }
+  if ($form_state['values']['mail'] == '') {
+    form_set_error('mail', t('Email field is required.'));
+  }
 
-    if ($form_state['values']['mail'] == '') {
-        form_set_error('mail', t('Email field is required.'));
-    }
+  if ($form_state['values']['name'] == '') {
+    form_set_error('name', t('Employee ID field is required.'));
+  }
 
-    if ($form_state['values']['name'] == '') {
-        form_set_error('name', t('Employee ID field is required.'));
+  if (isset($form_state['values']['name'])) {
+    if ($error = user_validate_name($form_state['values']['name'])) {
+      form_set_error('name', $error);
     }
-
-    if (isset($form_state['values']['name'])) {
-      if ($error = user_validate_name($form_state['values']['name'])) {
-        form_set_error('name', $error);
-      }
-      elseif ((bool) db_select('users')->fields('users', array('uid'))->condition('uid', 0, '<>')->condition('name', db_like($form_state['values']['name']), 'LIKE')->range(0, 1)->execute()->fetchField()) {
-        form_set_error('name', t('The name %name is already taken.', array('%name' => $form_state['values']['name'])));
-      }
+    elseif ((bool) db_select('users')->fields('users', ['uid'])->condition('uid', 0, '<>')->condition('name', db_like($form_state['values']['name']), 'LIKE')->range(0, 1)->execute()->fetchField()) {
+      form_set_error('name', t('The name %name is already taken.', ['%name' => $form_state['values']['name']]));
     }
+  }
 
     // Validate the e-mail address, and check if it is taken by an existing user.
-    if ($error = user_validate_mail($form_state['values']['mail'])) {
-      form_set_error('mail', $error);
-    }
-    elseif ((bool) db_select('users')->fields('users', array('uid'))->condition('uid', 0, '<>')->condition('mail', db_like($form_state['values']['mail']), 'LIKE')->range(0, 1)->execute()->fetchField()) {
+  if ($error = user_validate_mail($form_state['values']['mail'])) {
+    form_set_error('mail', $error);
+  }
+  elseif ((bool) db_select('users')->fields('users', ['uid'])->condition('uid', 0, '<>')->condition('mail', db_like($form_state['values']['mail']), 'LIKE')->range(0, 1)->execute()->fetchField()) {
       // Format error message dependent on whether the user is logged in or not.
-      if ($GLOBALS['user']->uid) {
-        form_set_error('mail', t('The e-mail address %email is already taken.', array('%email' => $form_state['values']['mail'])));
-      }
-      else {
-        form_set_error('mail', t('The e-mail address %email is already registered. <a href="@password">Have you forgotten your password?</a>', array('%email' => $form_state['values']['mail'], '@password' => url('user/password'))));
-      }
+    if ($GLOBALS['user']->uid) {
+      form_set_error('mail', t('The e-mail address %email is already taken.', ['%email' => $form_state['values']['mail']]));
     }
-
-    //user_account_form_validate($form, $form_state);
-    //user_register_validate($form, $form_state);
-
-    /*user_account_form_validate($form, $form_state);
-    user_validate_picture($form, $form_state);
-    user_register_validate($form, $form_state);*/
+    else {
+      form_set_error('mail', t('The e-mail address %email is already registered. <a href="@password">Have you forgotten your password?</a>', ['%email' => $form_state['values']['mail'], '@password' => url('user/password')]));
+    }
+  }
 }
 
 function civihr_employee_portal_request_new_account_submit($form, &$form_state) {
-
-    $edit = array(
-        'name' => $form_state['values']['name'],
-        'pass' => user_password(),
-        'mail' => $form_state['values']['mail'],
+  $edit = [
+    'name' => $form_state['values']['name'],
+    'pass' => user_password(),
+    'mail' => $form_state['values']['mail'],
         //'init' => $form_state['values']['init'],
-        'status' => 0,
-        'access' => REQUEST_TIME,
-    );
+    'status' => 0,
+    'access' => REQUEST_TIME,
+  ];
 
-    $user = user_save(drupal_anonymous_user(), $edit);
-    if (!empty($user->uid)) {
-        $uf = get_civihr_uf_match_data($user->uid);
-        if (!empty($uf['contact_id'])) {
-            $result = civicrm_api3('Contact', 'create', array(
-                'sequential' => 1,
-                'id' => $uf['contact_id'],
-                'first_name' => $form_state['values']['first_name'],
-                'last_name' => $form_state['values']['last_name'],
-            ));
-        }
+  $user = user_save(drupal_anonymous_user(), $edit);
+
+  if (!empty($user->uid)) {
+    $uf = get_civihr_uf_match_data($user->uid);
+
+    if (!empty($uf['contact_id'])) {
+      $result = civicrm_api3('Contact', 'create', [
+        'sequential' => 1,
+        'id' => $uf['contact_id'],
+        'first_name' => $form_state['values']['first_name'],
+        'last_name' => $form_state['values']['last_name'],
+      ]);
     }
+  }
 
-    // Fire rules register events
-    rules_invoke_event('user_and_civi_contact_added', $user);
+  // Fire rules register events
+  rules_invoke_event('user_and_civi_contact_added', $user);
 
-    drupal_set_message(t('Request sent! You will receive email notificiation once your account is activated.'), 'success');
+  drupal_set_message(t('Request sent! You will receive email notificiation once your account is activated.'), 'success');
 }
 
 /**
@@ -3614,727 +3482,709 @@ function civihr_employee_portal_request_new_account_submit($form, &$form_state) 
  * The json response will be cached in local file when the VIEWS requests to load data from this endpoint
  */
 function civihr_employee_portal_get_contact_list() {
+  watchdog('not cached contact list', 'test1');
 
-    watchdog('not cached contact list', 'test1');
+  $result_contacts = civicrm_api3('Contact', 'get', [
+    'sequential' => 1,
+    'options' => [
+      'limit' => 10000000,
+    ],
 
-    $result_contacts = civicrm_api3('Contact', 'get', array(
-        'sequential' => 1,
-        'options' => array(
-            'limit' => 10000000,
-        ),
+    'return' => "contact_id,display_name,email,phone,contact_type",
+  ]);
 
-        'return' => "contact_id,display_name,email,phone,contact_type",
-    ));
+  $result_contracts = civicrm_api3('HRJobContract', 'get', [
+    'sequential' => 1,
+    'options' => [
+      'limit' => 10000000,
+    ],
+    'return' => 'is_primary,title,location,contract_type,period_type,contact_id'
+  ]);
 
-    $result_contracts = civicrm_api3('HRJobContract', 'get', array(
-        'sequential' => 1,
-        'options' => array(
-            'limit' => 10000000,
-        ),
-        'return' => 'is_primary,title,location,contract_type,period_type,contact_id'
-    ));
+  // Merge contacts with contracts (if contract doesn't exist still return the contact data)
+  $merged_output = HelperClass::array_merge_callback($result_contacts['values'], $result_contracts['values'], function ($contact_array, $job_contract_array) {
 
-    // Merge contacts with contracts (if contract doesn't exist still return the contact data)
-    $merged_output = HelperClass::array_merge_callback($result_contacts['values'], $result_contracts['values'], function ($contact_array, $job_contract_array) {
+    // Merge only for the primary contracts
+    if ($job_contract_array['is_primary'] == 1) {
+      return $contact_array['contact_id'] == $job_contract_array['contact_id'];
+    }
+  });
 
-        // Merge only for the primary contracts
-        if ($job_contract_array['is_primary'] == 1) {
-            return $contact_array['contact_id'] == $job_contract_array['contact_id'];
-        }
-    });
+  // Build the results
+  $result_output = [];
+  $result_output['values'] = $merged_output;
 
-    // Build the results
-    $result_output = Array();
-    $result_output['values'] = $merged_output;
-
-    // Output json results
-    drupal_json_output($result_output);
-    drupal_exit();
-
+  // Output json results
+  drupal_json_output($result_output);
+  drupal_exit();
 }
 
 /**
  * Implements hook_block_info().
  */
 function civihr_employee_portal_block_info() {
+  // Call the Base class
+  $blocks = new Base;
 
-    // Call the Base class
-    $blocks = new Base;
-
-    // Generate the block and return
-    return $blocks->generateBlockInfo();
-
+  // Generate the block and return
+  return $blocks->generateBlockInfo();
 }
 
 /**
  * Implements hook_block_view().
  */
 function civihr_employee_portal_block_view($delta = '') {
+  $blocktypes = Base::returnBlockTypes();
 
-    $blocktypes = Base::returnBlockTypes();
+  if (array_key_exists($delta, $blocktypes)) {
+    $block = [];
 
-    if (array_key_exists($delta, $blocktypes)) {
-        $block = array();
+    $block['subject'] = $blocktypes[$delta]['title'];
+    $block['content'] = _civihr_employee_portal_block_generate_content($blocktypes[$delta]['class_name']);
 
-        $block['subject'] = $blocktypes[$delta]['title'];
-        $block['content'] = _civihr_employee_portal_block_generate_content($blocktypes[$delta]['class_name']);
-
-        return $block;
-    }
-
+    return $block;
+  }
 }
 
 /**
  * Block content generated based on Block class
  */
 function _civihr_employee_portal_block_generate_content($class_name = '') {
+  $class_name = 'Drupal\civihr_employee_portal\Blocks' . '\\' . $class_name;
+  $block = new $class_name;
 
-    $class_name = 'Drupal\civihr_employee_portal\Blocks' . '\\' . $class_name;
-
-    $block = new $class_name;
-
-    return $block->generateBlock();
+  return $block->generateBlock();
 }
 
 /**
  * Implements hook_schema().
  */
 function civihr_employee_portal_schema() {
-    $schema = [];
+  $schema = [];
 
-    // Reports settings db table.
-    $schema['reports_settings_age_group'] = [
-        'description' => 'HR Reports Age Group settings',
-        'fields' => [
-            'id' => [
-                'type' => 'serial',
-                'unsigned' => TRUE,
-                'not null' => TRUE,
-            ],
-            'age_from' => [
-                'type' => 'int',
-                'not null' => FALSE,
-                'default' => NULL,
-            ],
-            'age_to' => [
-                'type' => 'int',
-                'not null' => FALSE,
-                'default' => NULL,
-            ],
-            'label' => [
-                'type' => 'varchar',
-                'length' => 32,
-                'not null' => TRUE,
-            ],
-        ],
-        'unique keys' => [],
-        'primary key' => ['id'],
-    ];
+  // Reports settings db table.
+  $schema['reports_settings_age_group'] = [
+    'description' => 'HR Reports Age Group settings',
+    'fields' => [
+      'id' => [
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'age_from' => [
+        'type' => 'int',
+        'not null' => FALSE,
+        'default' => NULL,
+      ],
+      'age_to' => [
+        'type' => 'int',
+        'not null' => FALSE,
+        'default' => NULL,
+      ],
+      'label' => [
+        'type' => 'varchar',
+        'length' => 32,
+        'not null' => TRUE,
+      ],
+    ],
+    'unique keys' => [],
+    'primary key' => ['id'],
+  ];
 
     // Reports configuration db table.
-    $schema['reports_configuration'] = [
-        'description' => 'HR Reports Configuration',
-        'fields' => [
-            'id' => [
-                'type' => 'serial',
-                'unsigned' => TRUE,
-                'not null' => TRUE,
-            ],
-            'report_name' => [
-                'type' => 'varchar',
-                'length' => 256,
-                'not null' => TRUE,
-            ],
-            'label' => [
-                'type' => 'varchar',
-                'length' => 256,
-                'not null' => TRUE,
-            ],
-            'json_config' => [
-                'type' => 'text',
-                'not null' => FALSE,
-            ],
-        ],
-        'unique keys' => [],
-        'primary key' => ['id'],
-    ];
+  $schema['reports_configuration'] = [
+    'description' => 'HR Reports Configuration',
+    'fields' => [
+      'id' => [
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'report_name' => [
+        'type' => 'varchar',
+        'length' => 256,
+        'not null' => TRUE,
+      ],
+      'label' => [
+        'type' => 'varchar',
+        'length' => 256,
+        'not null' => TRUE,
+      ],
+      'json_config' => [
+        'type' => 'text',
+        'not null' => FALSE,
+      ],
+    ],
+    'unique keys' => [],
+    'primary key' => ['id'],
+  ];
 
-    return $schema;
+  return $schema;
 }
 
 /**
  * Implements hook_schema_alter().
  */
 function civihr_employee_portal_schema_alter(&$schema) {
-    $schema['absence_activity']['description'] = 'Views data associated with Absence Activities';
-    $schema['absence_activity']['fields']['absence_activity_id'] = array(
-        'type' => 'serial',
-        'unsigned' => TRUE,
-        'not null' => FALSE,
-        'description' => 'Absence Activity ID.',
-    );
-    $schema['absence_activity']['fields']['absence_contact_id'] = array(
-        'type' => 'int',
-        'unsigned' => TRUE,
-        'not null' => FALSE,
-        'description' => 'Absence Contact ID.',
-    );
-    $schema['absence_activity']['fields']['absence_type'] = array(
-        'type' => 'varchar',
-        'length' => 256,
-        'not null' => FALSE,
-        'description' => 'Absence Type.',
-    );
-    $schema['absence_activity']['fields']['sickness_reason'] = array(
-        'type' => 'varchar',
-        'length' => 512,
-        'not null' => FALSE,
-        'description' => 'Sickness Reason.',
-    );
-    $schema['absence_activity']['fields']['absence_date'] = array(
-        'type' => 'varchar',
-        'length' => 10,
-        'mysql_type' => 'DATE',
-        'not null' => FALSE,
-        'description' => 'Absence Date.',
-    );
-    $schema['absence_activity']['fields']['absence_month'] = array(
-        'type' => 'varchar',
-        'length' => 7,
-        'mysql_type' => 'DATE',
-        'not null' => FALSE,
-        'description' => 'Absence Month.',
-    );
-    $schema['absence_activity']['fields']['absence_start_date'] = array(
-        'type' => 'varchar',
-        'length' => 10,
-        'mysql_type' => 'DATE',
-        'not null' => FALSE,
-        'description' => 'Absence Start Date.',
-    );
-    $schema['absence_activity']['fields']['absence_start_date_month'] = array(
-        'type' => 'varchar',
-        'length' => 7,
-        'mysql_type' => 'DATE',
-        'not null' => FALSE,
-        'description' => 'Absence Start Date Month.',
-    );
-    $schema['absence_activity']['fields']['absence_end_date'] = array(
-        'type' => 'varchar',
-        'length' => 10,
-        'mysql_type' => 'DATE',
-        'not null' => FALSE,
-        'description' => 'Absence End Date.',
-    );
-    $schema['absence_activity']['fields']['absence_end_date_month'] = array(
-        'type' => 'varchar',
-        'length' => 7,
-        'mysql_type' => 'DATE',
-        'not null' => FALSE,
-        'description' => 'Absence End Date Month.',
-    );
-    $schema['absence_activity']['fields']['absence_day_of_week'] = array(
-        'type' => 'varchar',
-        'not null' => FALSE,
-        'description' => 'Absence day of week.',
-    );
-    $schema['absence_activity']['fields']['absence_duration'] = array(
-        'type' => 'int',
-        'not null' => FALSE,
-        'description' => 'Absence duration.',
-    );
-/*    $schema['absence_activity']['fields']['absence_duration_in_days'] = array(
-        'type' => 'varchar',
-        'not null' => TRUE,
-        'description' => 'Absence duration in days.',
-    );*/
-/*    $schema['absence_activity']['fields']['absence_length'] = array(
-        'type' => 'int',
-        'not null' => TRUE,
-        'description' => 'Absence length.',
-    );*/
-    $schema['absence_activity']['fields']['absence_amount_taken'] = array(
-        'type' => 'varchar',
-        'not null' => FALSE,
-        'description' => 'Absence amount taken.',
-    );
-    $schema['absence_activity']['fields']['absence_amount_accrued'] = array(
-        'type' => 'varchar',
-        'not null' => FALSE,
-        'description' => 'Absence amount accrued.',
-    );
-    $schema['absence_activity']['fields']['absence_absolute_amount'] = array(
-        'type' => 'varchar',
-        'not null' => FALSE,
-        'description' => 'Absence absolute amount.',
-    );
-    $schema['absence_activity']['fields']['absence_status'] = array(
-        'type' => 'varchar',
-        'length' => 32,
-        'not null' => FALSE,
-        'description' => 'Absence Status.',
-    );
-    $schema['absence_activity']['fields']['absence_is_credit'] = array(
-        'type' => 'int',
-        'not null' => FALSE,
-        'description' => 'Absence is credit.',
-    );
+  $schema['absence_activity']['description'] = 'Views data associated with Absence Activities';
+  $schema['absence_activity']['fields']['absence_activity_id'] = [
+    'type' => 'serial',
+    'unsigned' => TRUE,
+    'not null' => FALSE,
+    'description' => 'Absence Activity ID.',
+  ];
+  $schema['absence_activity']['fields']['absence_contact_id'] = [
+    'type' => 'int',
+    'unsigned' => TRUE,
+    'not null' => FALSE,
+    'description' => 'Absence Contact ID.',
+  ];
+  $schema['absence_activity']['fields']['absence_type'] = [
+    'type' => 'varchar',
+    'length' => 256,
+    'not null' => FALSE,
+    'description' => 'Absence Type.',
+  ];
+  $schema['absence_activity']['fields']['sickness_reason'] = [
+    'type' => 'varchar',
+    'length' => 512,
+    'not null' => FALSE,
+    'description' => 'Sickness Reason.',
+  ];
+  $schema['absence_activity']['fields']['absence_date'] = [
+    'type' => 'varchar',
+    'length' => 10,
+    'mysql_type' => 'DATE',
+    'not null' => FALSE,
+    'description' => 'Absence Date.',
+  ];
+  $schema['absence_activity']['fields']['absence_month'] = [
+    'type' => 'varchar',
+    'length' => 7,
+    'mysql_type' => 'DATE',
+    'not null' => FALSE,
+    'description' => 'Absence Month.',
+  ];
+  $schema['absence_activity']['fields']['absence_start_date'] = [
+    'type' => 'varchar',
+    'length' => 10,
+    'mysql_type' => 'DATE',
+    'not null' => FALSE,
+    'description' => 'Absence Start Date.',
+  ];
+  $schema['absence_activity']['fields']['absence_start_date_month'] = [
+    'type' => 'varchar',
+    'length' => 7,
+    'mysql_type' => 'DATE',
+    'not null' => FALSE,
+    'description' => 'Absence Start Date Month.',
+  ];
+  $schema['absence_activity']['fields']['absence_end_date'] = [
+    'type' => 'varchar',
+    'length' => 10,
+    'mysql_type' => 'DATE',
+    'not null' => FALSE,
+    'description' => 'Absence End Date.',
+  ];
+  $schema['absence_activity']['fields']['absence_end_date_month'] = [
+    'type' => 'varchar',
+    'length' => 7,
+    'mysql_type' => 'DATE',
+    'not null' => FALSE,
+    'description' => 'Absence End Date Month.',
+  ];
+  $schema['absence_activity']['fields']['absence_day_of_week'] = [
+    'type' => 'varchar',
+    'not null' => FALSE,
+    'description' => 'Absence day of week.',
+  ];
+  $schema['absence_activity']['fields']['absence_duration'] = [
+    'type' => 'int',
+    'not null' => FALSE,
+    'description' => 'Absence duration.',
+  ];
+  $schema['absence_activity']['fields']['absence_amount_taken'] = [
+    'type' => 'varchar',
+    'not null' => FALSE,
+    'description' => 'Absence amount taken.',
+  ];
+  $schema['absence_activity']['fields']['absence_amount_accrued'] = [
+    'type' => 'varchar',
+    'not null' => FALSE,
+    'description' => 'Absence amount accrued.',
+  ];
+  $schema['absence_activity']['fields']['absence_absolute_amount'] = [
+    'type' => 'varchar',
+    'not null' => FALSE,
+    'description' => 'Absence absolute amount.',
+  ];
+  $schema['absence_activity']['fields']['absence_status'] = [
+    'type' => 'varchar',
+    'length' => 32,
+    'not null' => FALSE,
+    'description' => 'Absence Status.',
+  ];
+  $schema['absence_activity']['fields']['absence_is_credit'] = [
+    'type' => 'int',
+    'not null' => FALSE,
+    'description' => 'Absence is credit.',
+  ];
 
-    $schema['civicrm_value_length_of_service_11']['description'] = 'Views data associated with Contact Length of Service';
-    $schema['civicrm_value_length_of_service_11']['fields']['id'] = array(
-        'type' => 'serial',
-        'unsigned' => TRUE,
-        'not null' => FALSE,
-        'description' => 'Length of Service ID.',
-    );
-    $schema['civicrm_value_length_of_service_11']['fields']['entity_id'] = array(
-        'type' => 'int',
-        'unsigned' => TRUE,
-        'not null' => FALSE,
-        'description' => 'Contact ID.',
-    );
-    $schema['civicrm_value_length_of_service_11']['fields']['length_of_service'] = array(
-        'type' => 'int',
-        'unsigned' => TRUE,
-        'not null' => FALSE,
-        'description' => 'Length of Service.',
-    );
+  $schema['civicrm_value_length_of_service_11']['description'] = 'Views data associated with Contact Length of Service';
+  $schema['civicrm_value_length_of_service_11']['fields']['id'] = [
+    'type' => 'serial',
+    'unsigned' => TRUE,
+    'not null' => FALSE,
+    'description' => 'Length of Service ID.',
+  ];
+  $schema['civicrm_value_length_of_service_11']['fields']['entity_id'] = [
+    'type' => 'int',
+    'unsigned' => TRUE,
+    'not null' => FALSE,
+    'description' => 'Contact ID.',
+  ];
+  $schema['civicrm_value_length_of_service_11']['fields']['length_of_service'] = [
+    'type' => 'int',
+    'unsigned' => TRUE,
+    'not null' => FALSE,
+    'description' => 'Length of Service.',
+  ];
 
     // appraisal view:
-    $schema['appraisal']['description'] = 'Views data representation of CiviHR Appraisal';
-    $schema['appraisal']['fields']['id'] = array(
-        'type' => 'serial',
-        'unsigned' => TRUE,
-        'not null' => FALSE,
-        'description' => 'Appraisal ID',
-    );
-    $schema['appraisal']['fields']['contact_id'] = array(
-        'type' => 'int',
-        'not null' => FALSE,
-        'description' => 'Contact ID',
-    );
-    $schema['appraisal']['fields']['cycle_type_id'] = array(
-        'type' => 'int',
-        'not null' => TRUE,
-        'description' => 'Cycle type ID',
-    );
-    $schema['appraisal']['fields']['cycle_start_date'] = array(
-        'type' => 'varchar',
-        'length' => 10,
-        'mysql_type' => 'DATE',
-        'not null' => TRUE,
-        'description' => 'Cycle start date',
-    );
-    $schema['appraisal']['fields']['cycle_end_date'] = array(
-        'type' => 'varchar',
-        'length' => 10,
-        'mysql_type' => 'DATE',
-        'not null' => TRUE,
-        'description' => 'Cycle end date',
-    );
-    $schema['appraisal']['fields']['status_id'] = array(
-        'type' => 'int',
-        'not null' => TRUE,
-        'description' => 'Status ID',
-    );
-    $schema['appraisal']['fields']['manager_id'] = array(
-        'type' => 'int',
-        'not null' => FALSE,
-        'description' => 'Manager ID',
-    );
-    $schema['appraisal']['fields']['self_appraisal_due'] = array(
-        'type' => 'varchar',
-        'length' => 10,
-        'mysql_type' => 'DATE',
-        'not null' => TRUE,
-        'description' => 'Self appraisal due date',
-    );
-    $schema['appraisal']['fields']['manager_appraisal_due'] = array(
-        'type' => 'varchar',
-        'length' => 10,
-        'mysql_type' => 'DATE',
-        'not null' => TRUE,
-        'description' => 'Manager appraisal due date',
-    );
-    $schema['appraisal']['fields']['grade_due'] = array(
-        'type' => 'varchar',
-        'length' => 10,
-        'mysql_type' => 'DATE',
-        'not null' => TRUE,
-        'description' => 'Grade due date',
-    );
-    $schema['appraisal']['fields']['grade'] = array(
-        'type' => 'int',
-        'not null' => TRUE,
-        'description' => 'Grade',
-    );
+  $schema['appraisal']['description'] = 'Views data representation of CiviHR Appraisal';
+  $schema['appraisal']['fields']['id'] = [
+    'type' => 'serial',
+    'unsigned' => TRUE,
+    'not null' => FALSE,
+    'description' => 'Appraisal ID',
+  ];
+  $schema['appraisal']['fields']['contact_id'] = [
+    'type' => 'int',
+    'not null' => FALSE,
+    'description' => 'Contact ID',
+  ];
+  $schema['appraisal']['fields']['cycle_type_id'] = [
+    'type' => 'int',
+    'not null' => TRUE,
+    'description' => 'Cycle type ID',
+  ];
+  $schema['appraisal']['fields']['cycle_start_date'] = [
+    'type' => 'varchar',
+    'length' => 10,
+    'mysql_type' => 'DATE',
+    'not null' => TRUE,
+    'description' => 'Cycle start date',
+  ];
+  $schema['appraisal']['fields']['cycle_end_date'] = [
+    'type' => 'varchar',
+    'length' => 10,
+    'mysql_type' => 'DATE',
+    'not null' => TRUE,
+    'description' => 'Cycle end date',
+  ];
+  $schema['appraisal']['fields']['status_id'] = [
+    'type' => 'int',
+    'not null' => TRUE,
+    'description' => 'Status ID',
+  ];
+  $schema['appraisal']['fields']['manager_id'] = [
+    'type' => 'int',
+    'not null' => FALSE,
+    'description' => 'Manager ID',
+  ];
+  $schema['appraisal']['fields']['self_appraisal_due'] = [
+    'type' => 'varchar',
+    'length' => 10,
+    'mysql_type' => 'DATE',
+    'not null' => TRUE,
+    'description' => 'Self appraisal due date',
+  ];
+  $schema['appraisal']['fields']['manager_appraisal_due'] = [
+    'type' => 'varchar',
+    'length' => 10,
+    'mysql_type' => 'DATE',
+    'not null' => TRUE,
+    'description' => 'Manager appraisal due date',
+  ];
+  $schema['appraisal']['fields']['grade_due'] = [
+    'type' => 'varchar',
+    'length' => 10,
+    'mysql_type' => 'DATE',
+    'not null' => TRUE,
+    'description' => 'Grade due date',
+  ];
+  $schema['appraisal']['fields']['grade'] = [
+    'type' => 'int',
+    'not null' => TRUE,
+    'description' => 'Grade',
+  ];
 
-    // hrvacancy view:
-    $schema['hrvacancy']['description'] = 'Views data representation of HRVacancy';
-    $schema['hrvacancy']['fields']['id'] = array(
-        'type' => 'serial',
-        'unsigned' => TRUE,
-        'not null' => FALSE,
-        'description' => 'Vacancy ID',
-    );
-    $schema['hrvacancy']['fields']['start_date'] = array(
-        'type' => 'varchar',
-        'length' => 10,
-        'mysql_type' => 'DATE',
-        'not null' => FALSE,
-        'description' => 'Vacancy start date',
-    );
-    $schema['hrvacancy']['fields']['end_date'] = array(
-        'type' => 'varchar',
-        'length' => 10,
-        'mysql_type' => 'DATE',
-        'not null' => FALSE,
-        'description' => 'Vacancy end date',
-    );
-    $schema['hrvacancy']['fields']['status_id'] = array(
-        'type' => 'int',
-        'not null' => TRUE,
-        'description' => 'Vacancy status ID',
-    );
-    $schema['hrvacancy']['fields']['description'] = array(
-        'type' => 'text',
-        'not null' => TRUE,
-        'description' => 'Vacancy description',
-    );
-    $schema['hrvacancy']['fields']['position'] = array(
-        'type' => 'varchar',
-        'length' => 127,
-        'not null' => TRUE,
-        'description' => 'Vacancy position',
-    );
-    $schema['hrvacancy']['fields']['salary'] = array(
-        'type' => 'varchar',
-        'length' => 127,
-        'not null' => TRUE,
-        'description' => 'Vacancy salary',
-    );
-    $schema['hrvacancy']['fields']['location'] = array(
-        'type' => 'varchar',
-        'length' => 254,
-        'not null' => TRUE,
-        'description' => 'Vacancy location',
-    );
+  // hrvacancy view:
+  $schema['hrvacancy']['description'] = 'Views data representation of HRVacancy';
+  $schema['hrvacancy']['fields']['id'] = [
+    'type' => 'serial',
+    'unsigned' => TRUE,
+    'not null' => FALSE,
+    'description' => 'Vacancy ID',
+  ];
+  $schema['hrvacancy']['fields']['start_date'] = [
+    'type' => 'varchar',
+    'length' => 10,
+    'mysql_type' => 'DATE',
+    'not null' => FALSE,
+    'description' => 'Vacancy start date',
+  ];
+  $schema['hrvacancy']['fields']['end_date'] = [
+    'type' => 'varchar',
+    'length' => 10,
+    'mysql_type' => 'DATE',
+    'not null' => FALSE,
+    'description' => 'Vacancy end date',
+  ];
+  $schema['hrvacancy']['fields']['status_id'] = [
+    'type' => 'int',
+    'not null' => TRUE,
+    'description' => 'Vacancy status ID',
+  ];
+  $schema['hrvacancy']['fields']['description'] = [
+    'type' => 'text',
+    'not null' => TRUE,
+    'description' => 'Vacancy description',
+  ];
+  $schema['hrvacancy']['fields']['position'] = [
+    'type' => 'varchar',
+    'length' => 127,
+    'not null' => TRUE,
+    'description' => 'Vacancy position',
+  ];
+  $schema['hrvacancy']['fields']['salary'] = [
+    'type' => 'varchar',
+    'length' => 127,
+    'not null' => TRUE,
+    'description' => 'Vacancy salary',
+  ];
+  $schema['hrvacancy']['fields']['location'] = [
+    'type' => 'varchar',
+    'length' => 254,
+    'not null' => TRUE,
+    'description' => 'Vacancy location',
+  ];
 
-    // tasks view:
-    $schema['tasks']['description'] = 'Views data representation of CiviHR Tasks';
-    $schema['tasks']['fields']['id'] = array(
-        'type' => 'serial',
-        'unsigned' => TRUE,
-        'not null' => FALSE,
-        'description' => 'Task ID',
-    );
-    $schema['tasks']['fields']['activity_type_id'] = array(
-        'type' => 'int',
-        'not null' => TRUE,
-        'description' => 'Activity type ID',
-    );
-    $schema['tasks']['fields']['case_id'] = array(
-        'type' => 'int',
-        'not null' => TRUE,
-        'description' => 'Case ID',
-    );
-    $schema['tasks']['fields']['subject'] = array(
-        'type' => 'varchar',
-        'length' => 255,
-        'not null' => FALSE,
-        'description' => 'Task subject',
-    );
-    $schema['tasks']['fields']['activity_date_time'] = array(
-        'type' => 'varchar',
-        'length' => 10,
-        'mysql_type' => 'DATE',
-        'not null' => TRUE,
-        'description' => 'Task start date',
-    );
-    $schema['tasks']['fields']['details'] = array(
-        'type' => 'text',
-        'not null' => TRUE,
-        'description' => 'Task details',
-    );
-    $schema['tasks']['fields']['status_id'] = array(
-        'type' => 'int',
-        'not null' => TRUE,
-        'description' => 'Task status ID',
-    );
-    $schema['tasks']['fields']['is_deleted'] = array(
-        'type' => 'int',
-        'not null' => TRUE,
-        'description' => 'Is Task deleted?',
-    );
-    $schema['tasks']['fields']['source_contact_id'] = array(
-        'type' => 'int',
-        'not null' => FALSE,
-        'description' => 'Source Contact ID',
-    );
-    $schema['tasks']['fields']['source_contact_name'] = array(
-        'type' => 'varchar',
-        'length' => 255,
-        'not null' => FALSE,
-        'description' => 'Source Contact name',
-    );
-    $schema['tasks']['fields']['target_contact_id'] = array(
-        'type' => 'int',
-        'not null' => FALSE,
-        'description' => 'Target Contact ID',
-    );
-    $schema['tasks']['fields']['target_contact_name'] = array(
-        'type' => 'varchar',
-        'length' => 255,
-        'not null' => FALSE,
-        'description' => 'Target Contact name',
-    );
-    $schema['tasks']['fields']['assignee_contact_id'] = array(
-        'type' => 'int',
-        'not null' => FALSE,
-        'description' => 'Assignee Contact ID',
-    );
-    $schema['tasks']['fields']['assignee_contact_name'] = array(
-        'type' => 'varchar',
-        'length' => 255,
-        'not null' => FALSE,
-        'description' => 'Assignee Contact name',
-    );
+  // tasks view:
+  $schema['tasks']['description'] = 'Views data representation of CiviHR Tasks';
+  $schema['tasks']['fields']['id'] = [
+    'type' => 'serial',
+    'unsigned' => TRUE,
+    'not null' => FALSE,
+    'description' => 'Task ID',
+  ];
+  $schema['tasks']['fields']['activity_type_id'] = [
+    'type' => 'int',
+    'not null' => TRUE,
+    'description' => 'Activity type ID',
+  ];
+  $schema['tasks']['fields']['case_id'] = [
+    'type' => 'int',
+    'not null' => TRUE,
+    'description' => 'Case ID',
+  ];
+  $schema['tasks']['fields']['subject'] = [
+    'type' => 'varchar',
+    'length' => 255,
+    'not null' => FALSE,
+    'description' => 'Task subject',
+  ];
+  $schema['tasks']['fields']['activity_date_time'] = [
+    'type' => 'varchar',
+    'length' => 10,
+    'mysql_type' => 'DATE',
+    'not null' => TRUE,
+    'description' => 'Task start date',
+  ];
+  $schema['tasks']['fields']['details'] = [
+    'type' => 'text',
+    'not null' => TRUE,
+    'description' => 'Task details',
+  ];
+  $schema['tasks']['fields']['status_id'] = [
+    'type' => 'int',
+    'not null' => TRUE,
+    'description' => 'Task status ID',
+  ];
+  $schema['tasks']['fields']['is_deleted'] = [
+    'type' => 'int',
+    'not null' => TRUE,
+    'description' => 'Is Task deleted?',
+  ];
+  $schema['tasks']['fields']['source_contact_id'] = [
+    'type' => 'int',
+    'not null' => FALSE,
+    'description' => 'Source Contact ID',
+  ];
+  $schema['tasks']['fields']['source_contact_name'] = [
+    'type' => 'varchar',
+    'length' => 255,
+    'not null' => FALSE,
+    'description' => 'Source Contact name',
+  ];
+  $schema['tasks']['fields']['target_contact_id'] = [
+    'type' => 'int',
+    'not null' => FALSE,
+    'description' => 'Target Contact ID',
+  ];
+  $schema['tasks']['fields']['target_contact_name'] = [
+    'type' => 'varchar',
+    'length' => 255,
+    'not null' => FALSE,
+    'description' => 'Target Contact name',
+  ];
+  $schema['tasks']['fields']['assignee_contact_id'] = [
+    'type' => 'int',
+    'not null' => FALSE,
+    'description' => 'Assignee Contact ID',
+  ];
+  $schema['tasks']['fields']['assignee_contact_name'] = [
+    'type' => 'varchar',
+    'length' => 255,
+    'not null' => FALSE,
+    'description' => 'Assignee Contact name',
+  ];
 
-    // documents view:
-    $schema['documents']['description'] = 'Views data representation of CiviHR Documents';
-    $schema['documents']['fields']['id'] = array(
-        'type' => 'serial',
-        'unsigned' => TRUE,
-        'not null' => FALSE,
-        'description' => 'Document ID',
-    );
-    $schema['documents']['fields']['activity_type_id'] = array(
-        'type' => 'int',
-        'not null' => TRUE,
-        'description' => 'Activity type ID',
-    );
-    $schema['documents']['fields']['case_id'] = array(
-        'type' => 'int',
-        'not null' => TRUE,
-        'description' => 'Case ID',
-    );
-    $schema['documents']['fields']['subject'] = array(
-        'type' => 'varchar',
-        'length' => 255,
-        'not null' => FALSE,
-        'description' => 'Document subject',
-    );
-    $schema['documents']['fields']['activity_date_time'] = array(
-        'type' => 'varchar',
-        'length' => 10,
-        'mysql_type' => 'DATE',
-        'not null' => TRUE,
-        'description' => 'Document start date',
-    );
-    $schema['documents']['fields']['expire_date'] = array(
-        'type' => 'varchar',
-        'length' => 10,
-        'mysql_type' => 'DATE',
-        'not null' => TRUE,
-        'description' => 'Document end date',
-    );
-    $schema['documents']['fields']['details'] = array(
-        'type' => 'text',
-        'not null' => TRUE,
-        'description' => 'Document details',
-    );
-    $schema['documents']['fields']['file_count'] = array(
-        'type' => 'int',
-        'not null' => TRUE,
-        'description' => 'Document file count',
-    );
-    $schema['documents']['fields']['status_id'] = array(
-        'type' => 'int',
-        'not null' => TRUE,
-        'description' => 'Document status ID',
-    );
-    $schema['documents']['fields']['is_deleted'] = array(
-        'type' => 'int',
-        'not null' => TRUE,
-        'description' => 'Is Document deleted?',
-    );
-    $schema['documents']['fields']['source_contact_id'] = array(
-        'type' => 'int',
-        'not null' => FALSE,
-        'description' => 'Source Contact ID',
-    );
-    $schema['documents']['fields']['source_contact_name'] = array(
-        'type' => 'varchar',
-        'length' => 255,
-        'not null' => FALSE,
-        'description' => 'Source Contact name',
-    );
-    $schema['documents']['fields']['target_contact_id'] = array(
-        'type' => 'int',
-        'not null' => FALSE,
-        'description' => 'Target Contact ID',
-    );
-    $schema['documents']['fields']['target_contact_name'] = array(
-        'type' => 'varchar',
-        'length' => 255,
-        'not null' => FALSE,
-        'description' => 'Target Contact name',
-    );
-    $schema['documents']['fields']['assignee_contact_id'] = array(
-        'type' => 'int',
-        'not null' => FALSE,
-        'description' => 'Assignee Contact ID',
-    );
-    $schema['documents']['fields']['assignee_contact_name'] = array(
-        'type' => 'varchar',
-        'length' => 255,
-        'not null' => FALSE,
-        'description' => 'Assignee Contact name',
-    );
+  // documents view:
+  $schema['documents']['description'] = 'Views data representation of CiviHR Documents';
+  $schema['documents']['fields']['id'] = [
+    'type' => 'serial',
+    'unsigned' => TRUE,
+    'not null' => FALSE,
+    'description' => 'Document ID',
+  ];
+  $schema['documents']['fields']['activity_type_id'] = [
+    'type' => 'int',
+    'not null' => TRUE,
+    'description' => 'Activity type ID',
+  ];
+  $schema['documents']['fields']['case_id'] = [
+    'type' => 'int',
+    'not null' => TRUE,
+    'description' => 'Case ID',
+  ];
+  $schema['documents']['fields']['subject'] = [
+    'type' => 'varchar',
+    'length' => 255,
+    'not null' => FALSE,
+    'description' => 'Document subject',
+  ];
+  $schema['documents']['fields']['activity_date_time'] = [
+    'type' => 'varchar',
+    'length' => 10,
+    'mysql_type' => 'DATE',
+    'not null' => TRUE,
+    'description' => 'Document start date',
+  ];
+  $schema['documents']['fields']['expire_date'] = [
+    'type' => 'varchar',
+    'length' => 10,
+    'mysql_type' => 'DATE',
+    'not null' => TRUE,
+    'description' => 'Document end date',
+  ];
+  $schema['documents']['fields']['details'] = [
+    'type' => 'text',
+    'not null' => TRUE,
+    'description' => 'Document details',
+  ];
+  $schema['documents']['fields']['file_count'] = [
+    'type' => 'int',
+    'not null' => TRUE,
+    'description' => 'Document file count',
+  ];
+  $schema['documents']['fields']['status_id'] = [
+    'type' => 'int',
+    'not null' => TRUE,
+    'description' => 'Document status ID',
+  ];
+  $schema['documents']['fields']['is_deleted'] = [
+    'type' => 'int',
+    'not null' => TRUE,
+    'description' => 'Is Document deleted?',
+  ];
+  $schema['documents']['fields']['source_contact_id'] = [
+    'type' => 'int',
+    'not null' => FALSE,
+    'description' => 'Source Contact ID',
+  ];
+  $schema['documents']['fields']['source_contact_name'] = [
+    'type' => 'varchar',
+    'length' => 255,
+    'not null' => FALSE,
+    'description' => 'Source Contact name',
+  ];
+  $schema['documents']['fields']['target_contact_id'] = [
+    'type' => 'int',
+    'not null' => FALSE,
+    'description' => 'Target Contact ID',
+  ];
+  $schema['documents']['fields']['target_contact_name'] = [
+    'type' => 'varchar',
+    'length' => 255,
+    'not null' => FALSE,
+    'description' => 'Target Contact name',
+  ];
+  $schema['documents']['fields']['assignee_contact_id'] = [
+    'type' => 'int',
+    'not null' => FALSE,
+    'description' => 'Assignee Contact ID',
+  ];
+  $schema['documents']['fields']['assignee_contact_name'] = [
+    'type' => 'varchar',
+    'length' => 255,
+    'not null' => FALSE,
+    'description' => 'Assignee Contact name',
+  ];
 }
 
 /**
  * Implements hook_entity_info().
  */
 function civihr_employee_portal_entity_info() {
-    $info = array();
+  $info = [];
 
-    $info['civihr_absence_activity'] = array(
-        'label' => t('Absence Activity entity'),
-        'plural label' => t('Absence Activity entity'),
-        'description' => t('Absence Activity.'),
-        'entity class' => 'Entity',
-        'controller class' => 'EntityAPIController',
-        'views controller class' => 'EntityDefaultViewsController',
-        'base table' => 'absence_activity',
-        'fieldable' => TRUE,
-        'entity keys' => array(
-            'id' => 'absence_activity_id',
-            'label' => 'Activity ID'
-        ),
-        'bundles' => array(),
+  $info['civihr_absence_activity'] = [
+    'label' => t('Absence Activity entity'),
+    'plural label' => t('Absence Activity entity'),
+    'description' => t('Absence Activity.'),
+    'entity class' => 'Entity',
+    'controller class' => 'EntityAPIController',
+    'views controller class' => 'EntityDefaultViewsController',
+    'base table' => 'absence_activity',
+    'fieldable' => TRUE,
+    'entity keys' => [
+      'id' => 'absence_activity_id',
+      'label' => 'Activity ID'
+    ],
+    'bundles' => [],
         // Use the default label() and uri() functions
-        'label callback' => 'entity_class_label',
-        'uri callback' => 'entity_class_uri',
+    'label callback' => 'entity_class_label',
+    'uri callback' => 'entity_class_uri',
         // Entity API needs to know about your module for the views integration to work
-        'module' => 'civihr_employee_portal',
-    );
+    'module' => 'civihr_employee_portal',
+  ];
 
-    $info['civihr_length_of_service'] = array(
-        'label' => t('Length of service entity'),
-        'plural label' => t('Length of service entity'),
-        'description' => t('Length of service.'),
-        'entity class' => 'Entity',
-        'controller class' => 'EntityAPIController',
-        'views controller class' => 'EntityDefaultViewsController',
-        'base table' => 'civicrm_value_length_of_service_11',
-        'fieldable' => TRUE,
-        'entity keys' => array(
-            'id' => 'entity_id',
-            'label' => 'Employee ID'
-        ),
-        'bundles' => array(),
+  $info['civihr_length_of_service'] = [
+    'label' => t('Length of service entity'),
+    'plural label' => t('Length of service entity'),
+    'description' => t('Length of service.'),
+    'entity class' => 'Entity',
+    'controller class' => 'EntityAPIController',
+    'views controller class' => 'EntityDefaultViewsController',
+    'base table' => 'civicrm_value_length_of_service_11',
+    'fieldable' => TRUE,
+    'entity keys' => [
+      'id' => 'entity_id',
+      'label' => 'Employee ID'
+    ],
+    'bundles' => [],
         // Use the default label() and uri() functions
-        'label callback' => 'entity_class_label',
-        'uri callback' => 'entity_class_uri',
+    'label callback' => 'entity_class_label',
+    'uri callback' => 'entity_class_uri',
         // Entity API needs to know about your module for the views integration to work
-        'module' => 'civihr_employee_portal',
-    );
+    'module' => 'civihr_employee_portal',
+  ];
 
     // appraisal entity:
-    $info['civihr_appraisal'] = array(
-        'label' => t('Appraisal entity'),
-        'plural label' => t('Appraisal entity'),
-        'description' => t('Appraisal entity definition.'),
-        'entity class' => 'Entity',
-        'controller class' => 'EntityAPIController',
-        'views controller class' => 'EntityDefaultViewsController',
-        'base table' => 'appraisal',
-        'fieldable' => TRUE,
-        'entity keys' => array(
-            'id' => 'id',
-            'label' => 'Entity Appraisal ID'
-        ),
-        'bundles' => array(),
+  $info['civihr_appraisal'] = [
+    'label' => t('Appraisal entity'),
+    'plural label' => t('Appraisal entity'),
+    'description' => t('Appraisal entity definition.'),
+    'entity class' => 'Entity',
+    'controller class' => 'EntityAPIController',
+    'views controller class' => 'EntityDefaultViewsController',
+    'base table' => 'appraisal',
+    'fieldable' => TRUE,
+    'entity keys' => [
+      'id' => 'id',
+      'label' => 'Entity Appraisal ID'
+    ],
+    'bundles' => [],
         // Use the default label() and uri() functions
-        'label callback' => 'entity_class_label',
-        'uri callback' => 'entity_class_uri',
+    'label callback' => 'entity_class_label',
+    'uri callback' => 'entity_class_uri',
         // Entity API needs to know about your module for the views integration to work
-        'module' => 'civihr_employee_portal',
-    );
+    'module' => 'civihr_employee_portal',
+  ];
 
     // hrvacancy entity:
-    $info['civihr_hrvacancy'] = array(
-        'label' => t('HRVacancy entity'),
-        'plural label' => t('HRVacancy entity'),
-        'description' => t('HRVacancy'),
-        'entity class' => 'Entity',
-        'controller class' => 'EntityAPIController',
-        'views controller class' => 'EntityDefaultViewsController',
-        'base table' => 'hrvacancy',
-        'fieldable' => TRUE,
-        'entity keys' => array(
-            'id' => 'id',
-            'label' => 'Vacancy ID',
-        ),
-        'bundles' => array(),
-        'label callback' => 'entity_class_label',
-        'uri callback' => 'entity_class_uri',
-        'module' => 'civihr_employee_portal',
-    );
+  $info['civihr_hrvacancy'] = [
+    'label' => t('HRVacancy entity'),
+    'plural label' => t('HRVacancy entity'),
+    'description' => t('HRVacancy'),
+    'entity class' => 'Entity',
+    'controller class' => 'EntityAPIController',
+    'views controller class' => 'EntityDefaultViewsController',
+    'base table' => 'hrvacancy',
+    'fieldable' => TRUE,
+    'entity keys' => [
+      'id' => 'id',
+      'label' => 'Vacancy ID',
+    ],
+    'bundles' => [],
+    'label callback' => 'entity_class_label',
+    'uri callback' => 'entity_class_uri',
+    'module' => 'civihr_employee_portal',
+  ];
 
     // task entity:
-    $info['civihr_task'] = array(
-        'label' => t('Task entity'),
-        'plural label' => t('Task entity'),
-        'description' => t('Task'),
-        'entity class' => 'Entity',
-        'controller class' => 'EntityAPIController',
-        'views controller class' => 'EntityDefaultViewsController',
-        'base table' => 'tasks',
-        'fieldable' => TRUE,
-        'entity keys' => array(
-            'id' => 'id',
-            'label' => 'Task ID',
-        ),
-        'bundles' => array(),
-        'label callback' => 'entity_class_label',
-        'uri callback' => 'entity_class_uri',
-        'module' => 'civihr_employee_portal',
-    );
+  $info['civihr_task'] = [
+    'label' => t('Task entity'),
+    'plural label' => t('Task entity'),
+    'description' => t('Task'),
+    'entity class' => 'Entity',
+    'controller class' => 'EntityAPIController',
+    'views controller class' => 'EntityDefaultViewsController',
+    'base table' => 'tasks',
+    'fieldable' => TRUE,
+    'entity keys' => [
+      'id' => 'id',
+      'label' => 'Task ID',
+    ],
+    'bundles' => [],
+    'label callback' => 'entity_class_label',
+    'uri callback' => 'entity_class_uri',
+    'module' => 'civihr_employee_portal',
+  ];
 
     // document entity:
-    $info['civihr_document'] = array(
-        'label' => t('Document entity'),
-        'plural label' => t('Document entity'),
-        'description' => t('Document'),
-        'entity class' => 'Entity',
-        'controller class' => 'EntityAPIController',
-        'views controller class' => 'EntityDefaultViewsController',
-        'base table' => 'documents',
-        'fieldable' => TRUE,
-        'entity keys' => array(
-            'id' => 'id',
-            'label' => 'Document ID',
-        ),
-        'bundles' => array(),
-        'label callback' => 'entity_class_label',
-        'uri callback' => 'entity_class_uri',
-        'module' => 'civihr_employee_portal',
-    );
+  $info['civihr_document'] = [
+    'label' => t('Document entity'),
+    'plural label' => t('Document entity'),
+    'description' => t('Document'),
+    'entity class' => 'Entity',
+    'controller class' => 'EntityAPIController',
+    'views controller class' => 'EntityDefaultViewsController',
+    'base table' => 'documents',
+    'fieldable' => TRUE,
+    'entity keys' => [
+      'id' => 'id',
+      'label' => 'Document ID',
+    ],
+    'bundles' => [],
+    'label callback' => 'entity_class_label',
+    'uri callback' => 'entity_class_uri',
+    'module' => 'civihr_employee_portal',
+  ];
 
-    return $info;
+  return $info;
 }
 
 /**
  * Implements hook_views_api().
  */
 function civihr_employee_portal_views_api() {
-    return array(
-        'api' => 3,
-        'path' => drupal_get_path('module', 'civihr_employee_portal') . '/views',
-        'template path' => drupal_get_path('module', 'civihr_employee_portal') . '/views/templates',
-    );
+  return [
+    'api' => 3,
+    'path' => drupal_get_path('module', 'civihr_employee_portal') . '/views',
+    'template path' => drupal_get_path('module', 'civihr_employee_portal') . '/views/templates',
+  ];
 }
 
 /**
@@ -4342,81 +4192,79 @@ function civihr_employee_portal_views_api() {
  * Custom CSV export actions for CiviHR reports
  */
 function civihr_employee_portal_action_info() {
-    return array(
-        'views_data_export_action_csv_export' => array(
-            'type' => 'entity',
-            'label' => t('Export to CSV'),
-            'configurable' => FALSE,
-            'aggregate' => TRUE,
-            'behavior' => array('views_data_export_export_csv'),
-        ),
-    );
+  return [
+    'views_data_export_action_csv_export' => [
+      'type' => 'entity',
+      'label' => t('Export to CSV'),
+      'configurable' => FALSE,
+      'aggregate' => TRUE,
+      'behavior' => ['views_data_export_export_csv'],
+    ],
+  ];
 }
 
 /**
  * CSV export action callback.
  */
 function views_data_export_action_csv_export($entity, &$context) {
+  watchdog('context new', print_r($context, TRUE));
 
-    watchdog('context new', print_r($context, TRUE));
+  if (isset($context['view_info'])) {
+    $view = views_get_view($context['view_info']['name']);
+    $display_id = FALSE;
 
-    if (isset($context['view_info'])) {
-        $view = views_get_view($context['view_info']['name']);
-        $display_id = FALSE;
-
-        foreach ($view->display as $display) {
-            if ($display->display_plugin == 'views_data_export') {
-                $display_id = $display->id;
-                break;
-            }
-        }
-
-        if ($display_id) {
-            $args = $context['view_info']['arguments'];
-
-            // If a subset of the available entities was selected, provide the list
-            // of selected IDs to the view as a contrived argument, which we'll
-            // use later to alter the query.
-            // Extra code for backward/forward compatibility.
-            // @see https://www.drupal.org/node/2488146.
-            if (isset($context['view_info']['total_rows'])) {
-                $total_rows = $context['view_info']['total_rows'];
-            }
-            else {
-                $countView = clone $view;
-                $countView->execute($context['view_info']['display']);
-                $total_rows = $countView->total_rows;
-            }
-
-            // Store the selected count
-            $total_selected = count(array_keys($entity));
-
-            $entity_ids = implode("+", array_keys($entity));
-
-            watchdog('entity', print_r($entity_ids, TRUE));
-            watchdog('total rows', print_r($total_rows, TRUE));
-
-            // @ TODO if all rows selected don't pass this optional parameter as it will slow down everything
-            //if (count($total_selected) < $total_rows) {
-
-            // As third paremeter pass the optional entity IDs / otherwise everything should be exported
-            $args[] = $entity_ids;
-            //}
-
-            watchdog('args final', print_r($args, TRUE));
-
-            $view->execute_display($display_id, $args);
-            // If the export is configured to run as a batch job, it will handle the
-            // display of progress & result/download pages, deliver the generated
-            // file, and never return here. Otherwise, executing the display here
-            // won't cause the file to be delivered to the browser for download.
-            // Dying here ensures that it does, but there must be a better way.
-            die();
-        }
-        else {
-            drupal_set_message(t("Can't export data, because the !view view does not have a !display display.", array('!view' => $view->name, '!display' => 'views_data_export')), 'error');
-        }
+    foreach ($view->display as $display) {
+      if ($display->display_plugin == 'views_data_export') {
+        $display_id = $display->id;
+        break;
+      }
     }
+
+    if ($display_id) {
+      $args = $context['view_info']['arguments'];
+
+      // If a subset of the available entities was selected, provide the list
+      // of selected IDs to the view as a contrived argument, which we'll
+      // use later to alter the query.
+      // Extra code for backward/forward compatibility.
+      // @see https://www.drupal.org/node/2488146.
+      if (isset($context['view_info']['total_rows'])) {
+        $total_rows = $context['view_info']['total_rows'];
+      }
+      else {
+        $countView = clone $view;
+        $countView->execute($context['view_info']['display']);
+        $total_rows = $countView->total_rows;
+      }
+
+      // Store the selected count
+      $total_selected = count(array_keys($entity));
+      $entity_ids = implode("+", array_keys($entity));
+
+      watchdog('entity', print_r($entity_ids, TRUE));
+      watchdog('total rows', print_r($total_rows, TRUE));
+
+      // @ TODO if all rows selected don't pass this optional parameter as it will slow down everything
+      //if (count($total_selected) < $total_rows) {
+
+      // As third paremeter pass the optional entity IDs / otherwise everything should be exported
+      $args[] = $entity_ids;
+      //}
+
+      watchdog('args final', print_r($args, TRUE));
+
+      $view->execute_display($display_id, $args);
+      // If the export is configured to run as a batch job, it will handle the
+      // display of progress & result/download pages, deliver the generated
+      // file, and never return here. Otherwise, executing the display here
+      // won't cause the file to be delivered to the browser for download.
+      // Dying here ensures that it does, but there must be a better way.
+      die();
+    }
+    else {
+      drupal_set_message(t("Can't export data, because the !view view does not have a !display display.", ['!view' => $view->name, '!display' => 'views_data_export']), 'error');
+    }
+  }
 }
 
 /**
@@ -4425,93 +4273,90 @@ function views_data_export_action_csv_export($entity, &$context) {
  * Replace default views template for views-exposed-form.tpl.php.
  */
 function civihr_employee_portal_theme_registry_alter(&$theme_registry) {
-    $module_path = drupal_get_path('module', 'civihr_employee_portal');
-    $views_path = drupal_get_path('module', 'views');
-    if ($theme_registry['views_exposed_form']['path'] == $views_path . '/theme') {
-        $theme_registry['views_exposed_form']['path'] = $module_path . '/templates';
-    }
-    $theme_registry['views_view_table']['path'] = $module_path . '/templates';
+  $module_path = drupal_get_path('module', 'civihr_employee_portal');
+  $views_path = drupal_get_path('module', 'views');
+
+  if ($theme_registry['views_exposed_form']['path'] == $views_path . '/theme') {
+    $theme_registry['views_exposed_form']['path'] = $module_path . '/templates';
+  }
+
+  $theme_registry['views_view_table']['path'] = $module_path . '/templates';
 }
 
 /**
  * Custom Staff Directory dashboard block form.
  */
 function civihr_employee_portal_directory_block_form($form, &$form_state) {
+  $form['display_name'] = [
+    '#type' => 'textfield',
+    '#title' => t('Name'),
+    '#attributes' => ['placeholder' => t('Enter name')],
+    '#prefix' => '<div class="row"><div class="col-md-12">',
+    '#suffix' => '</div>'
+  ];
 
-    $form['display_name'] = array(
-        '#type' => 'textfield',
-        '#title' => t('Name'),
-        '#attributes' => array('placeholder' => t('Enter name')),
-        '#prefix' => '<div class="row"><div class="col-md-12">',
-        '#suffix' => '</div>'
-    );
+  $form['job_title'] = [
+    '#type' => 'textfield',
+    '#title' => t('Job title'),
+    '#attributes' => ['placeholder' => t('Job title')],
+    '#prefix' => '<div class="col-md-6">',
+    '#suffix' => '</div>'
+  ];
 
-    $form['job_title'] = array(
-        '#type' => 'textfield',
-        '#title' => t('Job title'),
-        '#attributes' => array('placeholder' => t('Job title')),
-        '#prefix' => '<div class="col-md-6">',
-        '#suffix' => '</div>'
-    );
+  $form['phone'] = [
+    '#type' => 'textfield',
+    '#title' => t('Phone'),
+    '#attributes' => ['placeholder' => t('Phone')],
+    '#prefix' => '<div class="col-md-6">',
+    '#suffix' => '</div>'
+  ];
 
-    $form['phone'] = array(
-        '#type' => 'textfield',
-        '#title' => t('Phone'),
-        '#attributes' => array('placeholder' => t('Phone')),
-        '#prefix' => '<div class="col-md-6">',
-        '#suffix' => '</div>'
-    );
+  $form['email_value'] = [
+    '#type' => 'textfield',
+    '#title' => t('Email'),
+    '#attributes' => ['placeholder' => t('Email')],
+    '#prefix' => '<div class="col-md-12">',
+    '#suffix' => '</div></div>'
+  ];
 
-    $form['email_value'] = array(
-        '#type' => 'textfield',
-        '#title' => t('Email'),
-        '#attributes' => array('placeholder' => t('Email')),
-        '#prefix' => '<div class="col-md-12">',
-        '#suffix' => '</div></div>'
-    );
+  $form['submit'] = [
+    '#attributes' => ['class' => ['chr_action']],
+    '#type' => 'submit',
+    '#value' => t('Go!'),
+    '#prefix' => '<div class="chr_panel__footer"><div class="chr_actions-wrapper">',
+    '#suffix' => '</div></div>'
+  ];
 
-    $form['submit'] = array(
-        '#attributes' => array('class' => array('chr_action')),
-        '#type' => 'submit',
-        '#value' => t('Go!'),
-        '#prefix' => '<div class="chr_panel__footer"><div class="chr_actions-wrapper">',
-        '#suffix' => '</div></div>'
-    );
+  // Add the validation function
+  $form['#validate'][] = 'civihr_employee_portal_directory_block_form_validate';
 
-    // Add the validation function
-    $form['#validate'][] = 'civihr_employee_portal_directory_block_form_validate';
+  // Add the submit function
+  $form['#submit'][] = 'civihr_employee_portal_directory_block_form_submit';
 
-    // Add the submit function
-    $form['#submit'][] = 'civihr_employee_portal_directory_block_form_submit';
-
-    return $form;
+  return $form;
 }
 
 /**
  * Custom Staff Directory dashboard block form validate function.
  */
 function civihr_employee_portal_directory_block_form_validate($form, &$form_state) {
-
-    // No name selected, throw an error
-    if ($form_state['values']['display_name'] == '') {
-        form_set_error('display_name', 'Name cannot be blank!');
-    }
+  // No name selected, throw an error
+  if ($form_state['values']['display_name'] == '') {
+    form_set_error('display_name', 'Name cannot be blank!');
+  }
 }
 
 /**
  * Custom Staff Directory dashboard block form submit function.
  */
 function civihr_employee_portal_directory_block_form_submit($form, &$form_state) {
-
-    // Redirect to the staff directory views list page passing parameters to filter the viewß
-    drupal_goto('staff-directory', array('query'=>
-    array(
-        'display_name' => $form_state['values']['display_name'],
-        'title' => $form_state['values']['job_title'],
-        'phone' => $form_state['values']['phone'],
-        'email' => $form_state['values']['email_value'],
-
-    )));
+  // Redirect to the staff directory views list page passing parameters to filter the viewß
+  drupal_goto('staff-directory', ['query' => [
+    'display_name' => $form_state['values']['display_name'],
+    'title' => $form_state['values']['job_title'],
+    'phone' => $form_state['values']['phone'],
+    'email' => $form_state['values']['email_value'],
+  ]]);
 }
 
 /**
@@ -4522,156 +4367,157 @@ function civihr_employee_portal_directory_block_form_submit($form, &$form_state)
  * @param string $langcode
  */
 function civihr_employee_portal_node_view($node, $view_mode, $langcode) {
-    // Set up default State/Province values for Emergency Contact webform.
-    if ($node->nid === variable_get('emergency_contact_webform_nid')) {
-        $fieldset = _get_emergency_contact_fieldset_list();
-        for ($contact = 1; $contact < 3; $contact++) {
-            $country_id = null;
-            if (isset($node->content['webform']['#form']['submitted'][$fieldset[$contact]]['civicrm_1_contact_' . $contact . '_cg99999_custom_100008']['#default_value'])) {
-                $country_id = $node->content['webform']['#form']['submitted'][$fieldset[$contact]]['civicrm_1_contact_' . $contact . '_cg99999_custom_100008']['#default_value'];
-            }
-            $state_province_options = _get_state_province_list_by_country_id($country_id);
-            $node->content['webform']['#form']['submitted'][$fieldset[$contact]]['civicrm_1_contact_' . $contact . '_cg99999_custom_100009']['#options'] = $state_province_options;
-        }
+  // Set up default State/Province values for Emergency Contact webform.
+  if ($node->nid === variable_get('emergency_contact_webform_nid')) {
+    $fieldset = _get_emergency_contact_fieldset_list();
+
+    for ($contact = 1; $contact < 3; $contact++) {
+      $country_id = null;
+
+      if (isset($node->content['webform']['#form']['submitted'][$fieldset[$contact]]['civicrm_1_contact_' . $contact . '_cg99999_custom_100008']['#default_value'])) {
+        $country_id = $node->content['webform']['#form']['submitted'][$fieldset[$contact]]['civicrm_1_contact_' . $contact . '_cg99999_custom_100008']['#default_value'];
+      }
+
+      $state_province_options = _get_state_province_list_by_country_id($country_id);
+      $node->content['webform']['#form']['submitted'][$fieldset[$contact]]['civicrm_1_contact_' . $contact . '_cg99999_custom_100009']['#options'] = $state_province_options;
     }
+  }
 }
 
-// Note: Under "Redirection location" NO redirect option should be select to get the confirmation message with ajax.
-// We can use this trick to make it generic for all webforms those have No redirect settings enabled under "Redirection location" setting.
+// Note: Under "Redirection location" NO redirect option should be select to get
+// the confirmation message with ajax.
+// We can use this trick to make it generic for all webforms those have
+// No redirect settings enabled under "Redirection location" setting.
 function civihr_employee_portal_form_alter(&$form, &$form_state, $form_id) {
+  if ($form_id == 'webform_client_form_' . variable_get('my_details_webform_nid') ||
+    $form_id == 'webform_client_form_' . variable_get('emergency_contact_webform_nid')) {
+    $form['#attributes']['class'][] = 'civihr_form civihr_form--reset form-horizontal';
+  }
 
-    if ($form_id == 'webform_client_form_' . variable_get('my_details_webform_nid') ||
-        $form_id == 'webform_client_form_' . variable_get('emergency_contact_webform_nid')) {
-        $form['#attributes']['class'][] = 'civihr_form civihr_form--reset form-horizontal';
-    }
+  // Form become outdated fix
+  if ($form_id == 'views_exposed_form') {
+    // https://www.drupal.org/node/2557327
+    unset($form['#token']);
+  }
 
-    // Form become outdated fix
-    if ($form_id == 'views_exposed_form') {
-        // https://www.drupal.org/node/2557327
-        unset($form['#token']);
-    }
+  // Alter HR documents node creation page
+  if ($form_id == 'hr_documents_node_form') {
+    // Make the fields hidden -> https://compucorp.atlassian.net/browse/PCHR-358
+    $form['field_download']['#attributes'] = ['style' => 'display:none'];
+  }
 
-    // Alter HR documents node creation page
-    if ($form_id == 'hr_documents_node_form') {
-        // Make the fields hidden -> https://compucorp.atlassian.net/browse/PCHR-358
-        $form['field_download']['#attributes'] = array('style' => 'display:none');
-    }
+  // Alter system settings form and add CiviHR specific settings
+  if ($form_id == 'system_site_information_settings') {
+    $form['civihr_settings'] = [
+      '#type' => 'fieldset',
+      '#title' => t('CiviHR settings')
+    ];
 
-    // Alter system settings form and add CiviHR specific settings
-    if ($form_id == 'system_site_information_settings') {
+    $form['civihr_settings']['my_details_webform_nid'] = [
+      '#type' => 'textfield',
+      '#title' => t('Node ID for the My details Webform page'),
+      '#default_value' => variable_get('my_details_webform_nid', '')
+    ];
 
-        $form['civihr_settings'] = array(
-            '#type' => 'fieldset',
-            '#title' => t('CiviHR settings')
-        );
+    $form['civihr_settings']['emergency_contact_webform_nid'] = [
+      '#type' => 'textfield',
+      '#title' => t('Node ID for the Emergency Contact Webform page'),
+      '#default_value' => variable_get('emergency_contact_webform_nid', '')
+    ];
 
-        $form['civihr_settings']['my_details_webform_nid'] = array(
-            '#type' => 'textfield',
-            '#title' => t('Node ID for the My details Webform page'),
-            '#default_value' => variable_get('my_details_webform_nid', '')
-        );
+    $form['civihr_settings']['relationship_name_to_use'] = [
+      '#type' => 'textfield',
+      '#title' => t('Relationship Name to use for Leave Approval'),
+      '#description' => t('eg. "has Leave Approved by"'),
+      '#default_value' => variable_get('relationship_name_to_use', 'has Leave Approved by')
+    ];
 
-        $form['civihr_settings']['emergency_contact_webform_nid'] = array(
-            '#type' => 'textfield',
-            '#title' => t('Node ID for the Emergency Contact Webform page'),
-            '#default_value' => variable_get('emergency_contact_webform_nid', '')
-        );
+    $form['civihr_settings']['default_date_period_id'] = [
+      '#type' => 'textfield',
+      '#title' => t('Default Date period ID'),
+      '#description' => t('Default Date period ID from CiviCRM'),
+      '#default_value' => variable_get('default_date_period_id', '1')
+    ];
+  }
 
-        $form['civihr_settings']['relationship_name_to_use'] = array(
-            '#type' => 'textfield',
-            '#title' => t('Relationship Name to use for Leave Approval'),
-            '#description' => t('eg. "has Leave Approved by"'),
-            '#default_value' => variable_get('relationship_name_to_use', 'has Leave Approved by')
-        );
+  if ($form_id == 'user_login_block') {
+    array_unshift($form['#submit'], 'civihr_employee_portal_user_login_submit');
 
-        $form['civihr_settings']['default_date_period_id'] = array(
-            '#type' => 'textfield',
-            '#title' => t('Default Date period ID'),
-            '#description' => t('Default Date period ID from CiviCRM'),
-            '#default_value' => variable_get('default_date_period_id', '1')
-        );
-    }
+    $form['#validate'] = ['civihr_employee_portal_user_login_validate'];
+    $form['name']['#required'] = false;
+    $form['pass']['#required'] = false;
 
-    if ($form_id == 'user_login_block') {
-        array_unshift($form['#submit'], 'civihr_employee_portal_user_login_submit');
-
-        $form['#validate'] = array('civihr_employee_portal_user_login_validate');
-        $form['name']['#required'] = false;
-        $form['pass']['#required'] = false;
-
-        $form['forgot-password'] = array(
-            '#type' => 'textfield',
-            '#title' => t('Email'),
-            '#title_display' => 'invisible',
-            '#attributes' => array('placeholder' => t('Email')),
-        );
-    }
+    $form['forgot-password'] = [
+      '#type' => 'textfield',
+      '#title' => t('Email'),
+      '#title_display' => 'invisible',
+      '#attributes' => ['placeholder' => t('Email')],
+    ];
+  }
 
     // Do ajax submit generic for all the webform those have no redirect option enabled.
-    if(isset($form['#node']) && isset($form['#node']->webform) && $form['#node']->webform['redirect_url'] == "<none>") {
-        $matches = array();
+  if(isset($form['#node']) && isset($form['#node']->webform) && $form['#node']->webform['redirect_url'] == "<none>") {
+    $matches = [];
 
-        // Check whether the form id have nid at the end like _nid
-        preg_match('/[\d]+$/', $form_id, $matches);
-        $nid_match = !empty($matches[0]) ? $matches[0] : null;
+    // Check whether the form id have nid at the end like _nid
+    preg_match('/[\d]+$/', $form_id, $matches);
+    $nid_match = !empty($matches[0]) ? $matches[0] : null;
 
-        if(strpos($form_id, 'webform_client_form_') !== false && !empty($nid_match)) {
-
-            $form['actions']['submit'] = array(
-                '#type' => 'submit',
-                '#ajax' => array(
-                    'callback' => 'webform_client_form_ajax_callback',
-                    'wrapper' => str_replace('_','-',$form['#form_id']),
-                    'effect' => 'fade',
-                ),
-                '#value' => t('Submit'),
-            );
-        }
+    if(strpos($form_id, 'webform_client_form_') !== false && !empty($nid_match)) {
+      $form['actions']['submit'] = [
+        '#type' => 'submit',
+        '#ajax' => [
+          'callback' => 'webform_client_form_ajax_callback',
+          'wrapper' => str_replace('_','-',$form['#form_id']),
+          'effect' => 'fade',
+        ],
+        '#value' => t('Submit'),
+      ];
     }
+  }
 
-    // Set up Emergency Contact webform ajax fields and callbacks.
-    if (!empty($form['#node']) && $form['#node']->nid === variable_get('emergency_contact_webform_nid')) {
-        $fieldset = _get_emergency_contact_fieldset_list();
-        for ($contact = 1; $contact < 3; $contact++) {
-            $form['submitted'][$fieldset[$contact]]['civicrm_1_contact_' . $contact . '_cg99999_custom_100008']['#ajax'] = array(
-                'event' => 'change',
-                'wrapper' => 'emergency-contact' . $contact . '-state-province',
-                'callback' => 'civihr_employee_portal_state_province_contact' . $contact . '_callback',
-                'method' => 'replace',
-            );
-            $form['submitted'][$fieldset[$contact]]['civicrm_1_contact_' . $contact . '_cg99999_custom_100009']['#prefix'] = '<div id="emergency-contact' . $contact . '-state-province">';
-            $form['submitted'][$fieldset[$contact]]['civicrm_1_contact_' . $contact . '_cg99999_custom_100009']['#suffix'] = '</div>';
-        }
+  // Set up Emergency Contact webform ajax fields and callbacks.
+  if (!empty($form['#node']) && $form['#node']->nid === variable_get('emergency_contact_webform_nid')) {
+    $fieldset = _get_emergency_contact_fieldset_list();
+
+    for ($contact = 1; $contact < 3; $contact++) {
+      $form['submitted'][$fieldset[$contact]]['civicrm_1_contact_' . $contact . '_cg99999_custom_100008']['#ajax'] = [
+        'event' => 'change',
+        'wrapper' => 'emergency-contact' . $contact . '-state-province',
+        'callback' => 'civihr_employee_portal_state_province_contact' . $contact . '_callback',
+        'method' => 'replace',
+      ];
+      $form['submitted'][$fieldset[$contact]]['civicrm_1_contact_' . $contact . '_cg99999_custom_100009']['#prefix'] = '<div id="emergency-contact' . $contact . '-state-province">';
+      $form['submitted'][$fieldset[$contact]]['civicrm_1_contact_' . $contact . '_cg99999_custom_100009']['#suffix'] = '</div>';
     }
+  }
 }
 
 /**
  * Implements hook_form_FORM_ID_alter().
  */
 function civihr_employee_portal_form_user_profile_form_alter(&$form, &$form_state, $form_id) {
-
   // Adding Yoti Login fieldset with button.
   if (module_exists('yoti')) {
-
     // Fetching block id from block description.
     $query = db_select('block_custom', 'b')
-              ->fields('b', array('bid'))
+              ->fields('b', ['bid'])
               ->condition('b.info', 'User Profile Yoti Login');
     $block_id = $query->execute()->fetchField();
 
     if ($block_id) {
-      $form['login_with_yoti'] = array(
+      $form['login_with_yoti'] = [
         '#type' => 'fieldset',
         '#title' => t('Login with Yoti'),
         '#weight' => 10,
         '#collapsible' => TRUE,
         '#collapsed' => FALSE,
-      );
+      ];
       $yoti_block_view = module_invoke('block', 'block_view', $block_id);
-      $form['login_with_yoti']['login_with_yoti_button'] = array(
+      $form['login_with_yoti']['login_with_yoti_button'] = [
         '#type' => 'item',
         '#markup' => render($yoti_block_view['content']),
-      );
+      ];
     }
   }
 }
@@ -4700,7 +4546,6 @@ function civihr_employee_portal_civicrm_postProcess($formName, &$form) {
     case 'CRM_Contact_Form_Contact':
       ContactForm::postProcess($form);
       break;
-
   }
 }
 
@@ -4709,10 +4554,11 @@ function civihr_employee_portal_civicrm_postProcess($formName, &$form) {
  *
  * @param array $form
  * @param array $form_state
+ *
  * @return array
  */
 function civihr_employee_portal_state_province_contact1_callback($form, $form_state) {
-    return _get_emergency_contact_state_province_webform_field($form, 1);
+  return _get_emergency_contact_state_province_webform_field($form, 1);
 }
 
 /**
@@ -4720,10 +4566,11 @@ function civihr_employee_portal_state_province_contact1_callback($form, $form_st
  *
  * @param array $form
  * @param array $form_state
+ *
  * @return array
  */
 function civihr_employee_portal_state_province_contact2_callback($form, $form_state) {
-    return _get_emergency_contact_state_province_webform_field($form, 2);
+  return _get_emergency_contact_state_province_webform_field($form, 2);
 }
 
 /**
@@ -4732,15 +4579,16 @@ function civihr_employee_portal_state_province_contact2_callback($form, $form_st
  *
  * @param array $form
  * @param int $emergency_contact
+ *
  * @return array
  */
 function _get_emergency_contact_state_province_webform_field($form, $emergency_contact) {
-    $fieldset = _get_emergency_contact_fieldset_list();
-    $country_id = $form['submitted'][$fieldset[$emergency_contact]]['civicrm_1_contact_' . $emergency_contact . '_cg99999_custom_100008']['#value'];
-    $form['submitted'][$fieldset[$emergency_contact]]['civicrm_1_contact_' . $emergency_contact . '_cg99999_custom_100009']['#options'] = _get_state_province_list_by_country_id($country_id);
+  $fieldset = _get_emergency_contact_fieldset_list();
+  $country_id = $form['submitted'][$fieldset[$emergency_contact]]['civicrm_1_contact_' . $emergency_contact . '_cg99999_custom_100008']['#value'];
+  $form['submitted'][$fieldset[$emergency_contact]]['civicrm_1_contact_' . $emergency_contact . '_cg99999_custom_100009']['#options'] = _get_state_province_list_by_country_id($country_id);
 
-    $bootstrap_form = civihr_default_theme_form_apply_bootstrap($form['submitted']);
-    return $bootstrap_form[$fieldset[$emergency_contact]]['civicrm_1_contact_' . $emergency_contact . '_cg99999_custom_100009'];
+  $bootstrap_form = civihr_default_theme_form_apply_bootstrap($form['submitted']);
+  return $bootstrap_form[$fieldset[$emergency_contact]]['civicrm_1_contact_' . $emergency_contact . '_cg99999_custom_100009'];
 }
 
 /**
@@ -4749,10 +4597,10 @@ function _get_emergency_contact_state_province_webform_field($form, $emergency_c
  * @return array
  */
 function _get_emergency_contact_fieldset_list() {
-    return array(
-        1 => 'civicrm_1_contact_1_fieldset_fieldset',
-        2 => 'secondary_emergency_contact',
-    );
+  return [
+    1 => 'civicrm_1_contact_1_fieldset_fieldset',
+    2 => 'secondary_emergency_contact',
+  ];
 }
 
 /**
@@ -4760,99 +4608,109 @@ function _get_emergency_contact_fieldset_list() {
  * and labels of State/Province as values.
  *
  * @param int $country_id
+ *
  * @return array
  */
 function _get_state_province_list_by_country_id($country_id) {
-    if (!$country_id) {
-        return array();
-    }
-    civicrm_initialize();
-    $civi_settings = parse_url(CIVICRM_DSN);
-    $civi_db_name = trim($civi_settings['path'], '/');
-    $state_province_list = array();
-    $result = db_select($civi_db_name . '.civicrm_state_province', 'sp')
-        ->fields('sp', array('id', 'name'))
-        ->condition('country_id', $country_id, '=')
-        ->execute();
-    while ($row = $result->fetchAssoc()) {
-        $state_province_list[$row['id']] = $row['name'];
-    }
-    return $state_province_list;
+  if (!$country_id) {
+    return [];
+  }
+
+  civicrm_initialize();
+
+  $civi_settings = parse_url(CIVICRM_DSN);
+  $civi_db_name = trim($civi_settings['path'], '/');
+  $state_province_list = [];
+  $result = db_select($civi_db_name . '.civicrm_state_province', 'sp')
+      ->fields('sp', ['id', 'name'])
+      ->condition('country_id', $country_id, '=')
+      ->execute();
+
+  while ($row = $result->fetchAssoc()) {
+    $state_province_list[$row['id']] = $row['name'];
+  }
+
+  return $state_province_list;
 }
 
 function civihr_employee_portal_preprocess_user_login(&$vars) {
+  ctools_include('ajax');
+  ctools_include('modal');
 
-    ctools_include('ajax');
-    ctools_include('modal');
+  ctools_add_js('modal');
+  ctools_add_js('ajax-responder');
 
-    ctools_add_js('modal');
-    ctools_add_js('ajax-responder');
+  if (!empty($vars['form']['#block'])) {
+    $vars['form']['#block']->subject = null;
+  }
 
-    if (!empty($vars['form']['#block'])) {
-        $vars['form']['#block']->subject = null;
-    }
-    $vars['form']['name']['#attributes']['placeholder'] = 'Username or email';
-    $vars['form']['name']['#required'] = false;
-    $vars['form']['pass']['#attributes']['placeholder'] = 'Password';
-    $vars['form']['pass']['#required'] = false;
-    $vars['form']['actions']['forgot_password'] = array(
-        '#markup' => l('Forgot password?', '/user/password',  array(
-            'attributes' =>
-                array(
-                    'class' => 'btn btn-link pull-left',
-                    'id' => 'link-forgot-password',
-                    'title' => 'Request new password via e-mail.'
-                )
-        ))
-    );
-
-    $vars['classes_array'] = array();
-    $vars['content_attributes_array'] = array();
-    $vars['title_attributes_array'] = array();
-    $vars['content_attributes_array'] = array();
-    $vars['attributes_array'] = array();
+  $vars['form']['name']['#attributes']['placeholder'] = 'Username or email';
+  $vars['form']['name']['#required'] = false;
+  $vars['form']['pass']['#attributes']['placeholder'] = 'Password';
+  $vars['form']['pass']['#required'] = false;
+  $vars['form']['actions']['forgot_password'] = [
+    '#markup' => l('Forgot password?', '/user/password',  [
+      'attributes' =>
+      [
+        'class' => 'btn btn-link pull-left',
+        'id' => 'link-forgot-password',
+        'title' => 'Request new password via e-mail.'
+      ]
+    ])
+  ];
+  $vars['classes_array'] = [];
+  $vars['content_attributes_array'] = [];
+  $vars['title_attributes_array'] = [];
+  $vars['content_attributes_array'] = [];
+  $vars['attributes_array'] = [];
 }
 
 function civihr_employee_portal_user_login_validate(&$form, &$form_state) {
+  if ($form_state['values']['forgot-password']) {
+    $form_state['values']['name'] = $form_state['values']['forgot-password'];
+    require_once('modules/user/user.pages.inc');
+    user_pass_validate($form, $form_state);
 
-    if ($form_state['values']['forgot-password']) {
-        $form_state['values']['name'] = $form_state['values']['forgot-password'];
-        require_once('modules/user/user.pages.inc');
-        user_pass_validate($form, $form_state);
+    $errors = form_get_errors();
 
-        $errors = form_get_errors();
-        if (isset($errors['name'])) {
-            form_clear_error();
-            form_set_error('forgot-password', $errors['name']);
-        }
-        return true;
-    }
-
-    $requiredValidate = true;
-    if (!$form_state['values']['name']) {
-        form_set_error('name', t('Username or email field is required.'));
-        $requiredValidate = false;
-    }
-    if (!$form_state['values']['pass']) {
-        form_set_error('pass', t('Password field is required.'));
-        $requiredValidate = false;
-    }
-    if (!$requiredValidate) {
-        return;
-    }
-
-    user_login_name_validate($form, $form_state);
-    user_login_authenticate_validate($form, $form_state);
-    user_login_final_validate($form, $form_state);
-
-    $nameError = form_get_error($form['name']);
-    if ($nameError) {
-      $nameError = str_replace('username', 'username, email', $nameError);
+    if (isset($errors['name'])) {
       form_clear_error();
-      form_set_error('name', $nameError);
-      drupal_get_messages('error'); // clear existing
-      drupal_set_message($nameError, 'error');
+      form_set_error('forgot-password', $errors['name']);
     }
+
+    return true;
+  }
+
+  $requiredValidate = true;
+
+  if (!$form_state['values']['name']) {
+    form_set_error('name', t('Username or email field is required.'));
+    $requiredValidate = false;
+  }
+
+  if (!$form_state['values']['pass']) {
+    form_set_error('pass', t('Password field is required.'));
+    $requiredValidate = false;
+  }
+
+  if (!$requiredValidate) {
+    return;
+  }
+
+  user_login_name_validate($form, $form_state);
+  user_login_authenticate_validate($form, $form_state);
+  user_login_final_validate($form, $form_state);
+
+  $nameError = form_get_error($form['name']);
+
+  if ($nameError) {
+    $nameError = str_replace('username', 'username, email', $nameError);
+
+    form_clear_error();
+    form_set_error('name', $nameError);
+    drupal_get_messages('error'); // clear existing
+    drupal_set_message($nameError, 'error');
+  }
 }
 
 function civihr_employee_portal_user_login_submit(&$form, &$form_state) {
@@ -4862,7 +4720,8 @@ function civihr_employee_portal_user_login_submit(&$form, &$form_state) {
     user_pass_submit($form, $form_state);
     _drupal_session_write('custom_login_success_message', t('Details sent!'));
     drupal_goto($destination);
-    return true;
+
+    return TRUE;
   }
 }
 
@@ -4870,7 +4729,6 @@ function civihr_employee_portal_user_login_submit(&$form, &$form_state) {
  * Implements hook_user_login().
  */
 function civihr_employee_portal_user_login(&$edit, $account) {
-
   if (!isset($_POST['form_id']) || $_POST['form_id'] != 'user_pass_reset') {
     $sspEntryPath = 'dashboard';
     $civicrmEntryPath = 'civicrm/tasksassignments/dashboard#/tasks';
@@ -4882,92 +4740,83 @@ function civihr_employee_portal_user_login(&$edit, $account) {
 }
 
 function webform_client_form_ajax_callback($form, &$form_state) {
+  if (form_get_errors()) {
+    return $form;
+  }
+  else {
+    ctools_include('ajax');
+    ctools_include('modal');
+    ctools_add_js('ajax-responder');
 
-    if (form_get_errors()) {
-        return $form;
-    }
-    else {
+    // Get the contact ID and create the cache identifier value
+    $contact_value = 'civihr_contact_data_' . $_SESSION['CiviCRM']['userID'];
 
-        ctools_include('ajax');
-        ctools_include('modal');
-        ctools_add_js('ajax-responder');
+    $commands = [];
 
-        // Get the contact ID and create the cache identifier value
-        $contact_value = 'civihr_contact_data_' . $_SESSION['CiviCRM']['userID'];
+    $commands[] = ctools_modal_command_dismiss();
+    $commands[] = ctools_ajax_command_redirect('dashboard');
+    $commands[] = ajax_command_remove('#messages');
+    $commands[] = ajax_command_after('#breadcrumb', '<div id="messages">' . theme('status_messages') . '</div>');
 
-        $commands = array();
+    // Try to remove the cached data for this contact as the values were updated
+    cache_clear_all($contact_value, 'cache');
 
-        $commands[] = ctools_modal_command_dismiss();
-        $commands[] = ctools_ajax_command_redirect('dashboard');
-        $commands[] = ajax_command_remove('#messages');
-        $commands[] = ajax_command_after('#breadcrumb', '<div id="messages">' . theme('status_messages') . '</div>');
+    print ajax_render($commands);
 
-        // Try to remove the cached data for this contact as the values were updated
-        cache_clear_all($contact_value, 'cache');
-
-        print ajax_render($commands);
-
-        exit;
-
-    }
-
+    exit;
+  }
 }
 
 /**
  * Implement custom my details page, which loads the my details block, to edit the employee data
  */
 function civihr_employee_portal_my_details() {
+  ctools_include('modal');
+  ctools_modal_add_js();
 
-    ctools_include('modal');
-    ctools_modal_add_js();
+  // This will render the same block as on the dashboard page
+  $block = module_invoke('civihr_employee_portal', 'block_view', 'my_details');
 
-    // This will render the same block as on the dashboard page
-    $block = module_invoke('civihr_employee_portal', 'block_view', 'my_details');
-
-    return render($block['content']);
+  return render($block['content']);
 }
 
 /**
  * CiviHR Report - Landing page
  */
 function civihr_employee_portal_hrreport_landing_page() {
-    $jsOptions = array('type' => 'file', 'scope' => 'footer');
+  $jsOptions = ['type' => 'file', 'scope' => 'footer'];
 
-    if (CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Extension', 'org.civicrm.reqangular', 'is_active', 'full_name')) {
-      drupal_add_js(CRM_Core_Resources::singleton()->getUrl('org.civicrm.reqangular') . "dist/reqangular.min.js", $jsOptions);
-    }
+  if (CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Extension', 'org.civicrm.reqangular', 'is_active', 'full_name')) {
+    drupal_add_js(CRM_Core_Resources::singleton()->getUrl('org.civicrm.reqangular') . "dist/reqangular.min.js", $jsOptions);
+  }
 
-    // Base reports.js script
-    drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . '/js/reports.js', $jsOptions);
+  // Base reports.js script
+  drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . '/js/reports.js', $jsOptions);
 
-    //$menu = civihr_employee_portal_get_drupal_menu_items('main-menu', 'reports');
-    $menu = civihr_employee_portal_get_drupal_menu_items('hr-reports');
-    return theme('civihr_employee_portal_civihr_report_landing_page',
-        array(
-            'title' => t('Reports'),
-            'menu' => $menu,
-        )
-    );
+  $menu = civihr_employee_portal_get_drupal_menu_items('hr-reports');
+
+  return theme('civihr_employee_portal_civihr_report_landing_page', [
+    'title' => t('Reports'),
+    'menu' => $menu,
+  ]);
 }
 
 /**
  * CiviHR Report - Settings - Age group page
  */
 function civihr_employee_portal_hrreport_settings_age_group() {
-    $canEdit = user_access('manage hrreports settings');
-    $canDelete = user_access('manage hrreports settings');
+  $canEdit = user_access('manage hrreports settings');
+  $canDelete = user_access('manage hrreports settings');
 
-    ctools_include('modal');
-    ctools_modal_add_js();
+  ctools_include('modal');
+  ctools_modal_add_js();
 
-    return theme('civihr_employee_portal_civihr_report_settings_age_group',
-        array(
-            'header' => array('Age from', 'Age to', 'Label'),
-            'rows' => _get_reports_settings_age_group(),
-            'canEdit' => $canEdit,
-            'canDelete' => $canDelete,
-        )
-    );
+  return theme('civihr_employee_portal_civihr_report_settings_age_group', [
+    'header' => ['Age from', 'Age to', 'Label'],
+    'rows' => _get_reports_settings_age_group(),
+    'canEdit' => $canEdit,
+    'canDelete' => $canDelete,
+  ]);
 }
 
 /**
@@ -4976,378 +4825,395 @@ function civihr_employee_portal_hrreport_settings_age_group() {
  * @return array
  */
 function _get_reports_settings_age_group() {
-    $data = array();
-    $query = db_select('reports_settings_age_group', 't');
-    $result = $query->fields('t', array('id', 'age_from', 'age_to', 'label'))->execute();
-    foreach ($result as $row) {
-        $data[] = array(
-            'id' => $row->id,
-            'age_from' => $row->age_from,
-            'age_to' => $row->age_to,
-            'label' => $row->label,
-        );
-    }
-    return $data;
+  $data = [];
+  $query = db_select('reports_settings_age_group', 't');
+  $result = $query->fields('t', ['id', 'age_from', 'age_to', 'label'])->execute();
+
+  foreach ($result as $row) {
+    $data[] = [
+      'id' => $row->id,
+      'age_from' => $row->age_from,
+      'age_to' => $row->age_to,
+      'label' => $row->label,
+    ];
+  }
+
+  return $data;
 }
 
 /**
  * Return Age Group label for given age.
  *
  * @param int $age
+ *
  * @return string
  */
 function get_contact_age_group_label_by_age($age) {
-    $label = '';
-    $query = "SELECT label FROM reports_settings_age_group
-            WHERE (age_from <= :age AND age_to >= :age)
-            OR (age_from <= :age AND age_to = 0)
-            OR (age_from = 0 and age_to >= NULL)
-            LIMIT 1";
-    $params = array(':age' => $age);
-    $result = db_query($query, $params);
-    if ($result) {
-        $label = $result->fetchField();
-    }
-    return $label;
+  $label = '';
+  $query = "SELECT label FROM reports_settings_age_group
+          WHERE (age_from <= :age AND age_to >= :age)
+          OR (age_from <= :age AND age_to = 0)
+          OR (age_from = 0 and age_to >= NULL)
+          LIMIT 1";
+  $params = [':age' => $age];
+  $result = db_query($query, $params);
+
+  if ($result) {
+    $label = $result->fetchField();
+  }
+
+  return $label;
 }
 
 /**
-* Ajax menu callback.
-*/
+ * Ajax menu callback.
+ */
 function civihr_employee_portal_hrreport_settings_age_group_create($ajax, $id = null) {
-    if ($ajax) {
-        ctools_include('ajax');
-        ctools_include('modal');
-        $title = t('Create new Age Group');
-        if ($id) {
-            $title = t('Edit Age Group');
-        }
-        $form_state = array(
-            'ajax' => TRUE,
-            'is_ajax_update' => TRUE,
-            'title' => $title,
-            'id' => $id,
-        );
-        // Since this will run again on form rebuild while still in the modal, prevent
-        // form IDs from being incremented.
-        // @todo https://drupal.org/node/1305882
-        if (!empty($_POST['ajax_html_ids'])) {
-            unset($_POST['ajax_html_ids']);
-        }
-        // Use ctools to generate ajax instructions for the browser to create
-        // a form in a modal popup.
-        $output = ctools_modal_form_wrapper('civihr_employee_portal_hrreport_settings_age_group_form', $form_state);
-        // If the form has been submitted, there may be additional instructions
-        // such as dismissing the modal popup.
-        if (!empty($form_state['executed'])) {
-            // Add the responder javascript, required by ctools
-            ctools_add_js('ajax-responder');
-            $output[] = ajax_command_replace('.messages', 'all good');
-            $output[] = ctools_modal_command_dismiss();
-            $output[] = ctools_ajax_command_redirect('reports/settings/age_group');
+  if ($ajax) {
+    ctools_include('ajax');
+    ctools_include('modal');
 
-        }
-        // Return the ajax instructions to the browser via ajax_render().
-        print ajax_render($output);
-        drupal_exit();
+    $title = t('Create new Age Group');
 
+    if ($id) {
+      $title = t('Edit Age Group');
     }
-    else {
-        return drupal_get_form('civihr_employee_portal_hrreport_settings_age_group_form');
+
+    $form_state = [
+      'ajax' => TRUE,
+      'is_ajax_update' => TRUE,
+      'title' => $title,
+      'id' => $id,
+    ];
+
+    // Since this will run again on form rebuild while still in the modal, prevent
+    // form IDs from being incremented.
+    // @todo https://drupal.org/node/1305882
+    if (!empty($_POST['ajax_html_ids'])) {
+      unset($_POST['ajax_html_ids']);
     }
+
+    // Use ctools to generate ajax instructions for the browser to create
+    // a form in a modal popup.
+    $output = ctools_modal_form_wrapper('civihr_employee_portal_hrreport_settings_age_group_form', $form_state);
+
+    // If the form has been submitted, there may be additional instructions
+    // such as dismissing the modal popup.
+    if (!empty($form_state['executed'])) {
+      // Add the responder javascript, required by ctools
+      ctools_add_js('ajax-responder');
+      $output[] = ajax_command_replace('.messages', 'all good');
+      $output[] = ctools_modal_command_dismiss();
+      $output[] = ctools_ajax_command_redirect('reports/settings/age_group');
+    }
+
+    // Return the ajax instructions to the browser via ajax_render().
+    print ajax_render($output);
+    drupal_exit();
+  }
+  else {
+    return drupal_get_form('civihr_employee_portal_hrreport_settings_age_group_form');
+  }
 }
 
 /**
  * Reports settings - Age Group form.
  */
 function civihr_employee_portal_hrreport_settings_age_group_form($form, &$form_state) {
-    global $user;
-    $row = array(
-        'id' => null,
-        'age_from' => '',
-        'age_to' => '',
-        'label' => '',
-    );
-    $canEdit = user_access('manage hrreports settings');
-    $id = $form_state['id'];
-    // If $id is defined, load the setting row from db table.
-    if ($id) {
-        $query = db_select('reports_settings_age_group', 't');
-        $result = $query
-            ->fields('t')
-            ->condition('id', $id)
-            ->execute()
-            ->fetchObject();
-        if ($result) {
-            $row = array(
-                'id' => $id,
-                'age_from' => $result->age_from,
-                'age_to' => $result->age_to,
-                'label' => $result->label,
-            );
-        }
-    }
+  global $user;
 
-    // Create form elements
-    $form['#attributes']['class'][] = 'form-horizontal civihr_form';
-    $form['id'] = array(
-        '#type' => 'hidden',
-        '#value' => $id,
-    );
-    $form['age_from'] = array(
-        '#type' => 'textfield',
-        '#title' => t('Age From'),
-        '#default_value' => $row['age_from'],
-        '#label_class' => 'col-sm-3 control-label',
-        '#field_prefix' => '<div class="col-sm-9">',
-        '#field_suffix' => '</div>',
-    );
-    $form['age_to'] = array(
-        '#type' => 'textfield',
-        '#title' => t('Age To'),
-        '#default_value' => $row['age_to'],
-        '#label_class' => 'col-sm-3 control-label',
-        '#field_prefix' => '<div class="col-sm-9">',
-        '#field_suffix' => '</div>',
-    );
-    $form['label'] = array(
-        '#type' => 'textfield',
-        '#title' => t('Label'),
-        '#default_value' => $row['label'],
-        '#label_class' => 'col-sm-3 control-label',
-        '#field_prefix' => '<div class="col-sm-9">',
-        '#field_suffix' => '</div>',
-    );
-    if ($canEdit) {
-        $form['save'] = array(
-            '#type' => 'submit',
-            '#value' => t('Save'),
-            '#attributes' => array('class' => array('chr_action')),
-            '#prefix' => '<div class="modal-civihr-custom__footer"><div class="chr_actions-wrapper">',
-            '#suffix'=> '</div></div>'
-        );
-    }
-    // Add the validation function
-    $form['#validate'][] = 'civihr_employee_portal_hrreport_settings_age_group_form_validate';
-    // Add the submit function
-    $form['#submit'][] = 'civihr_employee_portal_hrreport_settings_age_group_form_submit';
+  $row = [
+    'id' => null,
+    'age_from' => '',
+    'age_to' => '',
+    'label' => '',
+  ];
+  $canEdit = user_access('manage hrreports settings');
+  $id = $form_state['id'];
 
-    return $form;
+  // If $id is defined, load the setting row from db table.
+  if ($id) {
+    $query = db_select('reports_settings_age_group', 't');
+    $result = $query
+      ->fields('t')
+      ->condition('id', $id)
+      ->execute()
+      ->fetchObject();
+
+    if ($result) {
+      $row = [
+        'id' => $id,
+        'age_from' => $result->age_from,
+        'age_to' => $result->age_to,
+        'label' => $result->label,
+      ];
+    }
+  }
+
+  // Create form elements
+  $form['#attributes']['class'][] = 'form-horizontal civihr_form';
+  $form['id'] = [
+    '#type' => 'hidden',
+    '#value' => $id,
+  ];
+  $form['age_from'] = [
+    '#type' => 'textfield',
+    '#title' => t('Age From'),
+    '#default_value' => $row['age_from'],
+    '#label_class' => 'col-sm-3 control-label',
+    '#field_prefix' => '<div class="col-sm-9">',
+    '#field_suffix' => '</div>',
+  ];
+  $form['age_to'] = [
+    '#type' => 'textfield',
+    '#title' => t('Age To'),
+    '#default_value' => $row['age_to'],
+    '#label_class' => 'col-sm-3 control-label',
+    '#field_prefix' => '<div class="col-sm-9">',
+    '#field_suffix' => '</div>',
+  ];
+  $form['label'] = [
+    '#type' => 'textfield',
+    '#title' => t('Label'),
+    '#default_value' => $row['label'],
+    '#label_class' => 'col-sm-3 control-label',
+    '#field_prefix' => '<div class="col-sm-9">',
+    '#field_suffix' => '</div>',
+  ];
+  if ($canEdit) {
+    $form['save'] = [
+      '#type' => 'submit',
+      '#value' => t('Save'),
+      '#attributes' => ['class' => ['chr_action']],
+      '#prefix' => '<div class="modal-civihr-custom__footer"><div class="chr_actions-wrapper">',
+      '#suffix'=> '</div></div>'
+    ];
+  }
+
+  // Add the validation function
+  $form['#validate'][] = 'civihr_employee_portal_hrreport_settings_age_group_form_validate';
+  // Add the submit function
+  $form['#submit'][] = 'civihr_employee_portal_hrreport_settings_age_group_form_submit';
+
+  return $form;
 }
 
 function civihr_employee_portal_hrreport_settings_age_group_form_validate($form, &$form_state) {
 }
 
 function civihr_employee_portal_hrreport_settings_age_group_form_submit($form, &$form_state) {
-    global $user;
-    $canEdit = user_access('manage hrreports settings');
+  global $user;
 
-    $id = !empty($form_state['values']['id']) ? (int)$form_state['values']['id'] : null;
-    if ($canEdit) {
-        $result = null;
-        if ($id) {
-            $result = db_update('reports_settings_age_group')
-                ->fields(array(
-                    'age_from' => (int)$form_state['values']['age_from'],
-                    'age_to' => (int)$form_state['values']['age_to'],
-                    'label' => $form_state['values']['label'],
-                ))
-                ->condition('id', $id)
-                ->execute();
-        } else {
-            $result = db_insert('reports_settings_age_group')
-                ->fields(array(
-                    'age_from' => (int)$form_state['values']['age_from'],
-                    'age_to' => (int)$form_state['values']['age_to'],
-                    'label' => $form_state['values']['label'],
-                ))
-                ->execute();
-        }
-        if ($result) {
-            if ($id) {
-                drupal_set_message('Age Group has been updated.', 'success');
-            } else {
-                drupal_set_message('Age Group has been created.', 'success');
-            }
-        } else {
-            drupal_set_message('An error occured when saving Age Group.', 'error');
-        }
+  $canEdit = user_access('manage hrreports settings');
+  $id = !empty($form_state['values']['id']) ? (int)$form_state['values']['id'] : null;
+
+  if ($canEdit) {
+    $result = null;
+
+    if ($id) {
+      $result = db_update('reports_settings_age_group')
+        ->fields([
+          'age_from' => (int)$form_state['values']['age_from'],
+          'age_to' => (int)$form_state['values']['age_to'],
+          'label' => $form_state['values']['label'],
+        ])
+        ->condition('id', $id)
+        ->execute();
     } else {
-        drupal_set_message('You do not have permissions to create or edit Reports settings.', 'error');
+      $result = db_insert('reports_settings_age_group')
+        ->fields([
+          'age_from' => (int)$form_state['values']['age_from'],
+          'age_to' => (int)$form_state['values']['age_to'],
+          'label' => $form_state['values']['label'],
+        ])
+        ->execute();
     }
+    if ($result) {
+      if ($id) {
+        drupal_set_message('Age Group has been updated.', 'success');
+      } else {
+        drupal_set_message('Age Group has been created.', 'success');
+      }
+    } else {
+      drupal_set_message('An error occured when saving Age Group.', 'error');
+    }
+  } else {
+    drupal_set_message('You do not have permissions to create or edit Reports settings.', 'error');
+  }
 }
 
 /**
-* Ajax menu callback.
-*/
+ * Ajax menu callback.
+ */
 function civihr_employee_portal_hrreport_settings_age_group_delete($ajax, $id) {
+  if ($ajax) {
+    ctools_include('ajax');
+    ctools_include('modal');
 
-    if ($ajax) {
-        ctools_include('ajax');
-        ctools_include('modal');
+    $title = t('Are you sure you want to delete this Age Group?');
 
-        $title = t('Are you sure you want to delete this Age Group?');
+    $form_state = [
+      'ajax' => TRUE,
+      'is_ajax_update' => TRUE,
+      'title' => $title,
+      'id' => $id,
+    ];
 
-        $form_state = array(
-            'ajax' => TRUE,
-            'is_ajax_update' => TRUE,
-            'title' => $title,
-            'id' => $id,
-        );
-
-        // Since this will run again on form rebuild while still in the modal, prevent
-        // form IDs from being incremented.
-        // @todo https://drupal.org/node/1305882
-        if (!empty($_POST['ajax_html_ids'])) {
-            unset($_POST['ajax_html_ids']);
-        }
-
-        // Use ctools to generate ajax instructions for the browser to create
-        // a form in a modal popup.
-        $output = ctools_modal_form_wrapper('civihr_employee_portal_hrreport_settings_age_group_form_delete_confirm', $form_state);
-
-        // If the form has been submitted, there may be additional instructions
-        // such as dismissing the modal popup.
-        if (!empty($form_state['executed'])) {
-
-            // Add the responder javascript, required by ctools
-            ctools_add_js('ajax-responder');
-
-            $output[] = ajax_command_replace('.messages', 'all good');
-            $output[] = ctools_modal_command_dismiss();
-            $output[] = ctools_ajax_command_redirect('reports/settings/age_group');
-
-        }
-
-        // Return the ajax instructions to the browser via ajax_render().
-        print ajax_render($output);
-        drupal_exit();
-
+    // Since this will run again on form rebuild while still in the modal, prevent
+    // form IDs from being incremented.
+    // @todo https://drupal.org/node/1305882
+    if (!empty($_POST['ajax_html_ids'])) {
+      unset($_POST['ajax_html_ids']);
     }
 
-    else {
-        return drupal_get_form('civihr_employee_portal_hrreport_settings_age_group_form_delete_confirm');
+    // Use ctools to generate ajax instructions for the browser to create
+    // a form in a modal popup.
+    $output = ctools_modal_form_wrapper('civihr_employee_portal_hrreport_settings_age_group_form_delete_confirm', $form_state);
+
+    // If the form has been submitted, there may be additional instructions
+    // such as dismissing the modal popup.
+    if (!empty($form_state['executed'])) {
+      // Add the responder javascript, required by ctools
+      ctools_add_js('ajax-responder');
+
+      $output[] = ajax_command_replace('.messages', 'all good');
+      $output[] = ctools_modal_command_dismiss();
+      $output[] = ctools_ajax_command_redirect('reports/settings/age_group');
     }
 
+    // Return the ajax instructions to the browser via ajax_render().
+    print ajax_render($output);
+    drupal_exit();
+  }
+  else {
+    return drupal_get_form('civihr_employee_portal_hrreport_settings_age_group_form_delete_confirm');
+  }
 }
 
 function civihr_employee_portal_hrreport_settings_age_group_form_delete_confirm($form, &$form_state){
+  $form['id'] = [
+    '#type' => 'hidden',
+    '#value' =>  $form_state['id'],
+    '#suffix' => "<script>CRM.$('#edit-cancel').bind('click', function() { Drupal.CTools.Modal.dismiss(); return false; });</script>",
+  ];
 
-    $form['id'] = array(
-        '#type' => 'hidden',
-        '#value' =>  $form_state['id'],
-        '#suffix' => "<script>CRM.$('#edit-cancel').bind('click', function() { Drupal.CTools.Modal.dismiss(); return false; });</script>",
-    );
+  $form['#submit'][] = 'civihr_employee_portal_hrreport_settings_age_group_form_delete_submit';
 
-    $form['#submit'][] = 'civihr_employee_portal_hrreport_settings_age_group_form_delete_submit';
-
-    return confirm_form($form,
-        t('Are you sure you want to delete this Age Group?'),
-        'dashboard',
-        t('This action cannot be undone.'),
-        t('Delete'),
-        t('Cancel'));
+  return confirm_form($form,
+    t('Are you sure you want to delete this Age Group?'),
+    'dashboard',
+    t('This action cannot be undone.'),
+    t('Delete'),
+    t('Cancel')
+  );
 }
 
 function civihr_employee_portal_hrreport_settings_age_group_form_delete_submit($form, &$form_state) {
-    $canDelete = user_access('manage hrreports settings');
-    if ($canDelete) {
-        $id = (int)$form_state['values']['id'];
-        $result = db_delete('reports_settings_age_group')
-            ->condition('id', $id)
-            ->execute();
-        if ($result) {
-            drupal_set_message(t('Age Group has been deleted.'), 'success');
-        } else {
-            drupal_set_message(t('An error occured when trying to delete Age Group.'), 'error');
-        }
+  $canDelete = user_access('manage hrreports settings');
+
+  if ($canDelete) {
+    $id = (int)$form_state['values']['id'];
+    $result = db_delete('reports_settings_age_group')
+      ->condition('id', $id)
+      ->execute();
+
+    if ($result) {
+      drupal_set_message(t('Age Group has been deleted.'), 'success');
     } else {
-        drupal_set_message(t('You do not have permissions to delete Reports settings.'), 'error');
+      drupal_set_message(t('An error occured when trying to delete Age Group.'), 'error');
     }
+  } else {
+    drupal_set_message(t('You do not have permissions to delete Reports settings.'), 'error');
+  }
 }
 
 /**
  * Add CSS and JavaScript files required for Report pages.
  */
 function _civihr_employee_portal_add_report_scripts() {
-    $jsOptions = array('type' => 'file', 'scope' => 'footer');
+  $jsOptions = ['type' => 'file', 'scope' => 'footer'];
 
     // PivotTable JavaScript library
-    drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/js/pivottable/pivot.css");
-    drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/js/pivottable/c3.min.css");
-    drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/js/perfect-scrollbar/perfect-scrollbar.min.css");
-    drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . '/js/jquery-2.1.1.min.js', $jsOptions);
-    drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . '/js/pivot.min.js', $jsOptions);
-    drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . '/js/perfect-scrollbar/perfect-scrollbar.min.js', $jsOptions);
-    drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . '/js/pivottable/c3.min.js', $jsOptions);
-    drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . '/js/pivottable/d3.min.js', $jsOptions);
-    drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . '/js/pivottable/c3_renderers.js', $jsOptions);
-    drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . '/js/pivottable/export_renderers.js', $jsOptions);
-    drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . '/js/pivottable-nreco/jquery-ui-1.9.2.custom.min.js', $jsOptions);
-    drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . '/js/pivottable-nreco/nrecopivot.js', $jsOptions);
-    drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . '/lib/moment/moment.min.js', $jsOptions);
+  drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/js/pivottable/pivot.css");
+  drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/js/pivottable/c3.min.css");
+  drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . "/js/perfect-scrollbar/perfect-scrollbar.min.css");
+  drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . '/js/jquery-2.1.1.min.js', $jsOptions);
+  drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . '/js/pivot.min.js', $jsOptions);
+  drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . '/js/perfect-scrollbar/perfect-scrollbar.min.js', $jsOptions);
+  drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . '/js/pivottable/c3.min.js', $jsOptions);
+  drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . '/js/pivottable/d3.min.js', $jsOptions);
+  drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . '/js/pivottable/c3_renderers.js', $jsOptions);
+  drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . '/js/pivottable/export_renderers.js', $jsOptions);
+  drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . '/js/pivottable-nreco/jquery-ui-1.9.2.custom.min.js', $jsOptions);
+  drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . '/js/pivottable-nreco/nrecopivot.js', $jsOptions);
+  drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . '/lib/moment/moment.min.js', $jsOptions);
 
-    if (CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Extension', 'org.civicrm.reqangular', 'is_active', 'full_name')) {
-      drupal_add_js(CRM_Core_Resources::singleton()->getUrl('org.civicrm.reqangular') . "dist/reqangular.min.js", $jsOptions);
-    }
+  if (CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Extension', 'org.civicrm.reqangular', 'is_active', 'full_name')) {
+    drupal_add_js(CRM_Core_Resources::singleton()->getUrl('org.civicrm.reqangular') . "dist/reqangular.min.js", $jsOptions);
+  }
 
-    // Base reports.js script
-    drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . '/js/reports.js', $jsOptions);
+  // Base reports.js script
+  drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . '/js/reports.js', $jsOptions);
 }
 
 function civihr_employee_portal_hrreport_gettable($viewName) {
-    $view = views_get_view('civihr_report_' . $viewName);
-    if (empty($view)) {
-        return null;
-    }
-    return views_embed_view('civihr_report_' . $viewName, 'civihr_report_table_' . $viewName);
+  $view = views_get_view('civihr_report_' . $viewName);
+
+  if (empty($view)) {
+    return null;
+  }
+
+  return views_embed_view('civihr_report_' . $viewName, 'civihr_report_table_' . $viewName);
 }
 
 function civihr_employee_portal_hrreport_printtable($viewName) {
-    print civihr_employee_portal_hrreport_gettable($viewName);
+  print civihr_employee_portal_hrreport_gettable($viewName);
 }
 
 /**
  * CiviHR Report - Custom Report page.
  *
  * @param string $reportName
+ *
  * @return array
  */
 function civihr_employee_portal_hrreport_custom($reportName) {
   _rebuild_reports_views();
 
   $view = views_get_view('civihr_report_' . $reportName);
+
   if (!$view) {
     return drupal_not_found();
   }
+
   ctools_include('modal');
   ctools_modal_add_js();
   _civihr_employee_portal_add_report_scripts();
+
   $table = civihr_employee_portal_hrreport_gettable($reportName);
   $exportPaths = _civihr_employee_portal_get_view_csv_export_paths($view);
   $view->set_display('default');
   $view->init_handlers();
-  $form_state = array(
+
+  $form_state = [
     'view' => $view,
     'display' => $view->display_handler->display,
     'exposed_form_plugin' => $view->display_handler->get_plugin('exposed_form'),
     'method' => 'get',
     'rerender' => TRUE,
     'no_redirect' => TRUE,
-  );
+  ];
   $filters = drupal_build_form('views_exposed_form', $form_state);
 
-  return theme('civihr_employee_portal_civihr_report_custom',
-    array(
-      'reportName' => $reportName,
-      'configurationList' => civihr_employee_portal_get_report_configuration_list($reportName),
-      'table' => $table,
-      'tableUrl' => !empty($table) ? '/reports/' . $reportName . '/table' : null,
-      'jsonUrl' => '/reports/' . $reportName . '/json',
-      'exportUrl' => '/' . array_shift($exportPaths),
-      'filters' => $filters,
-    )
-  );
+  return theme('civihr_employee_portal_civihr_report_custom', [
+    'reportName' => $reportName,
+    'configurationList' => civihr_employee_portal_get_report_configuration_list($reportName),
+    'table' => $table,
+    'tableUrl' => !empty($table) ? '/reports/' . $reportName . '/table' : null,
+    'jsonUrl' => '/reports/' . $reportName . '/json',
+    'exportUrl' => '/' . array_shift($exportPaths),
+    'filters' => $filters,
+  ]);
 }
 
 /**
@@ -5364,6 +5230,7 @@ function civihr_employee_portal_hrreport_get_json($reportName) {
   $view->set_display('page');
   $view->execute();
   $view->style_plugin->options['using_views_api_mode'] = FALSE;
+
   return $view->render('page');
 }
 
@@ -5383,6 +5250,7 @@ function civihr_employee_portal_hrreport_get_exposed_filter_default_values($view
   }
 
   $dateFilter = $view->display['default']->display_options['filters']['date_filter'];
+
   if (!empty($dateFilter['expose']['identifier'])) {
     $identifier = $dateFilter['expose']['identifier'];
 
@@ -5420,77 +5288,81 @@ function civihr_employee_portal_get_date_filter_default_value(array $params, $da
 }
 
 function civihr_employee_portal_hrreport_custom_printtable($reportName, $dateFilterValue = null) {
-    return civihr_employee_portal_hrreport_printtable($reportName, $dateFilterValue);
+  return civihr_employee_portal_hrreport_printtable($reportName, $dateFilterValue);
 }
 
 /**
+ * Implement form_views_exposed_form_alter()
+ *
  * @param $form
  * @param $form_state
- * Implement form_views_exposed_form_alter()
  */
 function civihr_employee_portal_form_views_exposed_form_alter(&$form, &$form_state, $form_id) {
-    /**
-     *  Staff Directory filters form, HR Documents filters form
-     */
-    $exposed_filters_forms = array('views-exposed-form-civihr-staff-directory-page', 'views-exposed-form-hr-documents-hr-resources');
+  /**
+   *  Staff Directory filters form, HR Documents filters form
+   */
+  $exposed_filters_forms = ['views-exposed-form-civihr-staff-directory-page', 'views-exposed-form-hr-documents-hr-resources'];
 
-    if (isset($form['#id']) && in_array($form['#id'], $exposed_filters_forms)) {
-        $form['#attributes']['class'][] = 'row';
+  if (isset($form['#id']) && in_array($form['#id'], $exposed_filters_forms)) {
+    $form['#attributes']['class'][] = 'row';
 
-        $form['submit']['#attributes'] = array('class' => array('chr_action'));
-        $form['submit']['#prefix'] = '<div class="col-sm-12"><div class="chr_panel__footer"><div class="chr_actions-wrapper">';
-        $form['submit']['#suffix'] = '</div></div></div>';
+    $form['submit']['#attributes'] = ['class' => ['chr_action']];
+    $form['submit']['#prefix'] = '<div class="col-sm-12"><div class="chr_panel__footer"><div class="chr_actions-wrapper">';
+    $form['submit']['#suffix'] = '</div></div></div>';
 
-        foreach ($form as $key => $value) {
-            if (isset($form['#info']["filter-$key"])) {
-                $form[$key]['#prefix'] = '<div class="col-sm-6">';
-                $form[$key]['#suffix'] = '</div>';
+    foreach ($form as $key => $value) {
+      if (isset($form['#info']["filter-$key"])) {
+        $form[$key]['#prefix'] = '<div class="col-sm-6">';
+        $form[$key]['#suffix'] = '</div>';
 
-                // Take the <label> value and use it as placeholder instead
-                if ($value['#type'] == 'textfield') {
-                    $form[$key]['#attributes'] = array('placeholder' => $form['#info']["filter-$key"]['label']);
-                }
-
-                $form['#info']["filter-$key"]['label'] = '';
-            }
+        // Take the <label> value and use it as placeholder instead
+        if ($value['#type'] == 'textfield') {
+          $form[$key]['#attributes'] = ['placeholder' => $form['#info']["filter-$key"]['label']];
         }
+
+        $form['#info']["filter-$key"]['label'] = '';
+      }
     }
+  }
 
-    if(strpos($form['#id'], 'views-exposed-form-civihr-report-') !== false) {
-        foreach ($form as $key => $value) {
-          if (isset($form[$key]['value'])) {
-            $form[$key]['value'] = setInputDatepickerForm($form['#info']["filter-$key"]['label']);
-          }
+  if(strpos($form['#id'], 'views-exposed-form-civihr-report-') !== false) {
+    foreach ($form as $key => $value) {
+      if (isset($form[$key]['value'])) {
+        $form[$key]['value'] = setInputDatepickerForm($form['#info']["filter-$key"]['label']);
+      }
 
-          if (isset($form[$key]['min'])) {
-            $form[$key]['min'] = setInputDatepickerForm($form[$key]['min']['#title']);
-          }
+      if (isset($form[$key]['min'])) {
+        $form[$key]['min'] = setInputDatepickerForm($form[$key]['min']['#title']);
+      }
 
-          if (isset($form[$key]['max'])) {
-            $form[$key]['max'] = setInputDatepickerForm($form[$key]['max']['#title']);
-          }
-        }
+      if (isset($form[$key]['max'])) {
+        $form[$key]['max'] = setInputDatepickerForm($form[$key]['max']['#title']);
+      }
     }
+  }
 
-    $form['submit']['#value'] = 'Filter';
+  $form['submit']['#value'] = 'Filter';
 }
 
 /**
  * Return an array containing a set of paths to any CSV export display of given View.
  *
  * @param object $view
+ *
  * @return array
  */
 function _civihr_employee_portal_get_view_csv_export_paths($view) {
-    $result = array();
-    foreach ($view->display as $display) {
-        if (!empty($display->display_options['style_plugin']) &&
-            $display->display_options['style_plugin'] === 'views_data_export_csv' &&
-            !empty($display->display_options['path'])) {
-            $result[] = $display->display_options['path'];
-        }
+  $result = [];
+
+  foreach ($view->display as $display) {
+    if (!empty($display->display_options['style_plugin']) &&
+      $display->display_options['style_plugin'] === 'views_data_export_csv' &&
+      !empty($display->display_options['path'])) {
+      $result[] = $display->display_options['path'];
     }
-    return $result;
+  }
+
+  return $result;
 }
 
 /**
@@ -5498,27 +5370,28 @@ function _civihr_employee_portal_get_view_csv_export_paths($view) {
  * datepicker filter markup.
  *
  * @param  string $title <Label title>
+ *
  * @return array
  */
 function setInputDatepickerForm($title) {
   $idxKey = 'id_' . uniqid();
 
-  return array(
-      '#title' => $title,
-      '#type' => 'textfield',
-      '#size' => '10',
-      '#description' => getCalendarButtonMarkup($idxKey),
-      '#date_label_position' => 'within',
-      '#attributes' => array(
-          'ng-init' => "$idxKey = false; filters.dt$idxKey=filters.date",
-          'placeholder' => '{{filters.placeholderFormat}}',
-          'uib-datepicker-popup' => '{{filters.format}}',
-          'close-text' => 'Close',
-          'ng-model' => "filters.dt$idxKey",
-          'is-open' => "filters.$idxKey",
-          'ng-click' => "filters.$idxKey = !filters.$idxKey"
-      ),
-  );
+  return [
+    '#title' => $title,
+    '#type' => 'textfield',
+    '#size' => '10',
+    '#description' => getCalendarButtonMarkup($idxKey),
+    '#date_label_position' => 'within',
+    '#attributes' => [
+      'ng-init' => "$idxKey = false; filters.dt$idxKey=filters.date",
+      'placeholder' => '{{filters.placeholderFormat}}',
+      'uib-datepicker-popup' => '{{filters.format}}',
+      'close-text' => 'Close',
+      'ng-model' => "filters.dt$idxKey",
+      'is-open' => "filters.$idxKey",
+      'ng-click' => "filters.$idxKey = !filters.$idxKey"
+    ],
+  ];
 }
 
 /**
@@ -5537,37 +5410,34 @@ function getCalendarButtonMarkup($idxKey) {
  * Implements hook_token_info().
  */
 function civihr_employee_portal_token_info() {
+  $info = [];
 
-    $info = array();
+  // Define any custom tokens.
+  $info['tokens']['user']['contact_display_name'] = [
+    'name' => t('CiviCRM Contact Display Name'),
+    'description' => t('CiviCRM Display Name from the contact record.'),
+  ];
 
-    // Define any custom tokens.
-    $info['tokens']['user']['contact_display_name'] = array(
-        'name' => t('CiviCRM Contact Display Name'),
-        'description' => t('CiviCRM Display Name from the contact record.'),
-    );
+  $info['tokens']['user']['contact_phone'] = [
+    'name' => t('CiviCRM Contact Phone'),
+    'description' => t('CiviCRM Contact Phone from the contact record.'),
+  ];
 
-    $info['tokens']['user']['contact_phone'] = array(
-        'name' => t('CiviCRM Contact Phone'),
-        'description' => t('CiviCRM Contact Phone from the contact record.'),
-    );
+  $info['tokens']['user']['assigned_manager_email'] = [
+    'name' => t('Assigned managers email addresses'),
+    'description' => t('Comma separated list of email addresses for the contact\'s assigned managers.'),
+  ];
 
-
-    $info['tokens']['user']['assigned_manager_email'] = array(
-        'name' => t('Assigned managers email addresses'),
-        'description' => t('Comma separated list of email addresses for the contact\'s assigned managers.'),
-    );
-
-    return $info;
+  return $info;
 }
 
 /**
  * Implements hook_tokens().
  */
-function civihr_employee_portal_tokens($type, $tokens, array $data = array(), array $options = array()) {
-  $replacements = array();
+function civihr_employee_portal_tokens($type, $tokens, array $data = [], array $options = []) {
+  $replacements = [];
 
   if ($type == 'user') {
-
     // Get the assigned manager contact IDs for the passed USER object
     if (isset($data['user']) && $data['user']->uid != '') {
       $user_contact_data = get_civihr_contact_data(NULL, $data['user']->uid);
@@ -5581,9 +5451,7 @@ function civihr_employee_portal_tokens($type, $tokens, array $data = array(), ar
     foreach ($tokens as $name => $original) {
       // Find our custom tokens by name.
       switch ($name) {
-
         case 'contact_display_name':
-
           // Find the contact display name.
           $value = '';
 
@@ -5596,7 +5464,6 @@ function civihr_employee_portal_tokens($type, $tokens, array $data = array(), ar
           break;
 
         case 'contact_phone':
-
           // Find the contact phone number.
           $value = '';
 
@@ -5609,7 +5476,6 @@ function civihr_employee_portal_tokens($type, $tokens, array $data = array(), ar
           break;
 
         case 'assigned_manager_name':
-
           // Find the assigned manager name.
           $value = '';
 
@@ -5622,7 +5488,6 @@ function civihr_employee_portal_tokens($type, $tokens, array $data = array(), ar
           break;
 
         case 'assigned_manager_phone':
-
           // Find the assigned manager phone.
           $value = '';
 
@@ -5635,7 +5500,6 @@ function civihr_employee_portal_tokens($type, $tokens, array $data = array(), ar
           break;
 
         case 'assigned_manager_email':
-
           // Build list of assigned managers e-mails
           $managerEmails = [];
 
@@ -5661,40 +5525,39 @@ function civihr_employee_portal_tokens($type, $tokens, array $data = array(), ar
  * Implements hook_module_implements_alter()
  */
 function civihr_employee_portal_module_implements_alter(&$implementations, $hook) {
+  if ($hook != 'views_data_alter') {
+    return;
+  }
 
-    if ($hook != 'views_data_alter') {
-        return;
-    }
+  watchdog('alter default order', print_r($implementations, TRUE));
 
-    watchdog('alter default order', print_r($implementations, TRUE));
-
-    $group = [];
+  $group = [];
 
     // Check if the module exists and it's installed
-    if (module_exists('views_autocomplete_filters')) {
-        // Put the views autocomplete filters after civicrm
-        $module = 'views_autocomplete_filters';
-        $group += array($module => $implementations[$module]);
-        unset($implementations[$module]);
-    }
+  if (module_exists('views_autocomplete_filters')) {
+    // Put the views autocomplete filters after civicrm
+    $module = 'views_autocomplete_filters';
+    $group += [$module => $implementations[$module]];
+    unset($implementations[$module]);
+  }
 
-    // Put the civihr employee portal module after civicrm module (breaks the Calendar view)
-    // $module = 'civihr_employee_portal';
-    // $group += array($module => $implementations[$module]);
-    // unset($implementations[$module]);
+  // Put the civihr employee portal module after civicrm module (breaks the Calendar view)
+  // $module = 'civihr_employee_portal';
+  // $group += array($module => $implementations[$module]);
+  // unset($implementations[$module]);
 
-    // Make sure some modules are after civicrm to avoid error with autocomplete search or drush cc all
-    $implementations = $implementations + $group;
+  // Make sure some modules are after civicrm to avoid error with autocomplete search or drush cc all
+  $implementations = $implementations + $group;
 
-    watchdog('alter modified order', print_r($implementations, TRUE));
+  watchdog('alter modified order', print_r($implementations, TRUE));
 }
 
 function civihr_employee_portal_civicrm_post($op, $objectName, $objectId, &$objectRef) {
-    if ($op === 'create' || $op === 'edit') {
-        if (in_array($objectName, array('Document', 'Task'))) {
-            _clear_json_cache();
-        }
+  if ($op === 'create' || $op === 'edit') {
+    if (in_array($objectName, ['Document', 'Task'])) {
+      _clear_json_cache();
     }
+  }
 }
 
 /**
@@ -5702,75 +5565,75 @@ function civihr_employee_portal_civicrm_post($op, $objectName, $objectId, &$obje
  *
  * @param string $menuName
  * @param string $parentLink
+ *
  * @return array
  */
 function civihr_employee_portal_get_drupal_menu_items($menuName) {
-    $menu = array();
-    $query = db_select('menu_links', 'ml')
-        ->fields('ml', array('link_path', 'router_path', 'link_title', 'options'))
-        ->condition('menu_name', $menuName)
-        ->condition('hidden', 0)
-        ->orderBy('weight');
-    $result = $query->execute()->fetchAll();
-    foreach ($result as $menuItem) {
-        $menu[] = array(
-            'link_path' => $menuItem->link_path,
-            'router_path' => $menuItem->router_path,
-            'link_title' => $menuItem->link_title,
-            'options' => unserialize($menuItem->options),
-        );
-    }
-    return $menu;
+  $menu = [];
+  $query = db_select('menu_links', 'ml')
+    ->fields('ml', ['link_path', 'router_path', 'link_title', 'options'])
+    ->condition('menu_name', $menuName)
+    ->condition('hidden', 0)
+    ->orderBy('weight');
+  $result = $query->execute()->fetchAll();
+
+  foreach ($result as $menuItem) {
+    $menu[] = [
+      'link_path' => $menuItem->link_path,
+      'router_path' => $menuItem->router_path,
+      'link_title' => $menuItem->link_title,
+      'options' => unserialize($menuItem->options),
+    ];
+  }
+
+  return $menu;
 }
 
 /**
  * Pass the contact ID and this function will return array of assigned ACTIVE manager contact IDs
+ *
  * @param $contact_id
  */
 function _getManagerContacts($contact_id) {
+  // @TODO -> cache the relationships if we need to!
+  // Get the relationships for the Contact
+  $res = civicrm_api3('Relationship', 'get', ['contact_id' => $contact_id, 'return' => "is_active"]);
+  $contactRelationships = $res['values'];
 
-    // @TODO -> cache the relationships if we need to!
-    // Get the relationships for the Contact
-    $res = civicrm_api3('Relationship', 'get', array('contact_id' => $contact_id, 'return' => "is_active"));
-    $contactRelationships = $res['values'];
+  $assigned_manager_contact_ids = [];
+  $manager_found = 0;
 
-    $assigned_manager_contact_ids = [];
-    $manager_found = 0;
-
-    // If Leave approver is find, assign him as the manager (add contact ID to $assigned_manager_contact_ids array)
-    foreach ($contactRelationships as $key => $relation) {
-      if ($relation['relation'] == variable_get('relationship_name_to_use', 'has Leave Approved by')) {
-        if(relationActiveAndCurrent($relation))
-        {
-          $assigned_manager_contact_ids[] = $relation['contact_id_b'];
-          $manager_found++;
-        }
+  // If Leave approver is find, assign him as the manager (add contact ID to $assigned_manager_contact_ids array)
+  foreach ($contactRelationships as $key => $relation) {
+    if ($relation['relation'] == variable_get('relationship_name_to_use', 'has Leave Approved by')) {
+      if(relationActiveAndCurrent($relation)) {
+        $assigned_manager_contact_ids[] = $relation['contact_id_b'];
+        $manager_found++;
       }
     }
+  }
 
-    // If no assigned managers found
-    if ($manager_found <= 0) {
+  // If no assigned managers found
+  if ($manager_found <= 0) {
+    // Get the main admin contact (this will be the default approver -> as no other leave approver is found)
+    $main_admin_contact = civicrm_api('uf_match', 'get', [
+      'version' => 3,
+      'uf_id' => 1,
+    ]);
+    $main_admin_contact = array_shift($main_admin_contact['values']);
 
-        // Get the main admin contact (this will be the default approver -> as no other leave approver is found)
-        $main_admin_contact = civicrm_api('uf_match', 'get', array(
-            'version' => 3,
-            'uf_id' => 1,
-        ));
+    // Set default manager ID
+    $assigned_manager_contact_ids[] = $main_admin_contact['contact_id'];
+  }
 
-        $main_admin_contact = array_shift($main_admin_contact['values']);
-
-        // Set default manager ID
-        $assigned_manager_contact_ids[] = $main_admin_contact['contact_id'];
-
-    }
-
-    return $assigned_manager_contact_ids;
+  return $assigned_manager_contact_ids;
 }
 
 /**
  * Function to determine if given manager-contact relationship is inactive or active
  *
  * @param array $relation
+ *
  * @return boolean
  */
 function relationActiveAndCurrent($relation){
@@ -5784,22 +5647,21 @@ function relationActiveAndCurrent($relation){
  * Implements hook_views_data()
  */
 function civihr_employee_portal_views_data() {
-  $data = array();
-
+  $data = [];
   $tables = date_views_base_tables();
 
   foreach ($tables as $base_table => $entity) {
     // The flexible date filter.
-    $data[$base_table]['between_date_filter'] = array(
+    $data[$base_table]['between_date_filter'] = [
       'group' => t('Date'),
-      'title' => t('Between Dates (!base_table)', array('!base_table' => $base_table)),
-      'help' => t('Filter between two Views !base_table date fields.', array('!base_table' => $base_table)),
-      'filter' => array(
+      'title' => t('Between Dates (!base_table)', ['!base_table' => $base_table]),
+      'help' => t('Filter between two Views !base_table date fields.', ['!base_table' => $base_table]),
+      'filter' => [
         'handler' => 'views_between_dates_filter_handler',
         'empty field name' => t('Undated'),
         'is date' => TRUE,
-      ),
-    );
+      ],
+    ];
   }
 
   return $data;
@@ -5809,22 +5671,23 @@ function civihr_employee_portal_views_data() {
  * Implements hook_date_views_fields()
  *
  * @param string $field
+ *
  * @return array
  */
 function civihr_employee_portal_date_views_fields($field) {
-  $values = array();
-  $sqlTypes = array(
-      'date' => array(
-        'hrjc_details.period_end_date',
-        'hrjc_details.period_start_date',
-        'absence_activity.absence_date',
-      ),
-  );
+  $values = [];
+  $sqlTypes = [
+    'date' => [
+      'hrjc_details.period_end_date',
+      'hrjc_details.period_start_date',
+      'absence_activity.absence_date',
+    ],
+  ];
+
   if (in_array($field, $sqlTypes['date'])) {
-    $values = array(
-      'sql_type' => DATE_ISO,
-    );
+    $values = ['sql_type' => DATE_ISO];
   }
+
   return $values;
 }
 
@@ -5832,26 +5695,30 @@ function civihr_employee_portal_date_views_fields($field) {
  * Check if given $form contains exposed filters of HR Report View.
  *
  * @param array $form
+ *
  * @return boolean
  */
 function _is_hrreports_exposed_filters_form($form) {
-    if (substr($form['#action'], 0, 20) === '/civihr_report_json_') {
-        return TRUE;
-    }
-    return FALSE;
+  if (substr($form['#action'], 0, 20) === '/civihr_report_json_') {
+    return TRUE;
+  }
+
+  return FALSE;
 }
 
 /**
  * Check if given $viewName matches HR Report View Table.
  *
  * @param string $viewName
+ *
  * @return boolean
  */
 function _is_hrreports_data_table_view($viewName) {
-    if (substr($viewName, 0, 14) === 'civihr_report_') {
-        return TRUE;
-    }
-    return FALSE;
+  if (substr($viewName, 0, 14) === 'civihr_report_') {
+    return TRUE;
+  }
+
+  return FALSE;
 }
 
 /**
@@ -5861,13 +5728,16 @@ function _is_hrreports_data_table_view($viewName) {
  * @param string $selfAppraisalDue
  * @param string $managerAppraisalDue
  * @param string $gradeDue
+ *
  * @return int
  */
 function _get_appraisal_employee_filter_type($status, $selfAppraisalDue, $managerAppraisalDue, $gradeDue) {
   $today = date('Y-m-d');
+
   if ($gradeDue < $today) {
     return 2;
   }
+
   return 1;
 }
 
@@ -5878,23 +5748,26 @@ function _get_appraisal_employee_filter_type($status, $selfAppraisalDue, $manage
  * @param string $selfAppraisalDue
  * @param string $managerAppraisalDue
  * @param string $gradeDue
+ *
  * @return int
  */
 function _get_appraisal_manager_filter_type($status, $selfAppraisalDue, $managerAppraisalDue, $gradeDue) {
-    $today = date('Y-m-d');
-    if ($status === 5) {
-        return 3;
-    }
-    if ($status === 1 && $selfAppraisalDue < $today) {
-        return 1;
-    }
-    if ($status === 2 && $managerAppraisalDue < $today) {
-        return 1;
-    }
-    if ($status === 3 && $gradeDue < $today) {
-        return 1;
-    }
-    return 2;
+  $today = date('Y-m-d');
+
+  if ($status === 5) {
+    return 3;
+  }
+  if ($status === 1 && $selfAppraisalDue < $today) {
+    return 1;
+  }
+  if ($status === 2 && $managerAppraisalDue < $today) {
+    return 1;
+  }
+  if ($status === 3 && $gradeDue < $today) {
+    return 1;
+  }
+
+  return 2;
 }
 
 /**
@@ -5905,6 +5778,7 @@ function _get_appraisal_manager_filter_type($status, $selfAppraisalDue, $manager
  * @param boolean $normalize
  *   normalize the filter to match the list of filters offered
  *   in the UI ('tomorrow' and 'week' are grouped together)
+ *
  * @return string
  */
 function _get_task_filter_by_date($date, $normalize = false) {
@@ -5934,7 +5808,6 @@ function _get_task_filter_by_date($date, $normalize = false) {
 
   return $normalize ? ($filter == 'tomorrow' ? 'week' : $filter) : $filter;
 }
-
 
 /**
  * This method handle user redirection for special use cases
@@ -5977,18 +5850,21 @@ function _user_redirection() {
  * Get an array containing existing configuration labels for specified Report.
  *
  * @param string $reportName
+ *
  * @return array
  */
 function civihr_employee_portal_get_report_configuration_list($reportName) {
-  $list = array();
+  $list = [];
   $result = db_select('reports_configuration', 'rc')
-    ->fields('rc', array('id', 'label'))
+    ->fields('rc', ['id', 'label'])
     ->condition('report_name', $reportName)
     ->orderBy('label')
     ->execute();
+
   while ($row = $result->fetchAssoc()) {
     $list[$row['id']] = $row['label'];
   }
+
   return $list;
 }
 
@@ -6000,24 +5876,25 @@ function civihr_employee_portal_get_report_configuration_list($reportName) {
  */
 function civihr_employee_portal_get_report_configuration_json($reportName, $configId) {
   if (empty($reportName) || empty($configId)) {
-    print drupal_json_output(array('status' => 'error'));
+    print drupal_json_output(['status' => 'error']);
     drupal_exit();
   }
+
   $result = db_select('reports_configuration', 'rc')
-    ->fields('rc', array('json_config'))
+    ->fields('rc', ['json_config'])
     ->condition('id', (int)$configId)
     ->condition('report_name', $reportName)
     ->range(0, 1)
     ->execute();
+
   if ($row = $result->fetchAssoc()) {
-    print drupal_json_output(
-      array(
-        'config' => json_decode($row['json_config']),
-        'status' => 'success',
-      )
-    );
-  } else {
-    print drupal_json_output(array('status' => 'error'));
+    print drupal_json_output([
+      'config' => json_decode($row['json_config']),
+      'status' => 'success',
+    ]);
+  }
+  else {
+    print drupal_json_output(['status' => 'error']);
   }
 
   drupal_exit();
@@ -6031,53 +5908,59 @@ function civihr_employee_portal_get_report_configuration_json($reportName, $conf
  */
 function civihr_employee_portal_save_report_configuration_json($reportName, $configId) {
   $jsonConfig = json_encode($_POST['json_config']);
+
   if ((empty($configId) && empty($_POST['label'])) || !$jsonConfig) {
-    print drupal_json_output(array('status' => 'error'));
+    print drupal_json_output(['status' => 'error']);
     drupal_exit();
   }
+
   $label = $_POST['label'];
-  $responseData = array(
+  $responseData = [
     'status' => 'success',
-  );
+  ];
+
   try {
     if (!empty($configId)) {
       $result = db_update('reports_configuration')
         ->condition('report_name', $reportName)
         ->condition('id', (int)$configId)
-        ->fields(array(
+        ->fields([
           'json_config' => $jsonConfig,
-        ))
+        ])
         ->execute();
-    } else {
+    }
+    else {
       $result = db_select('reports_configuration', 'rc')
-        ->fields('rc', array('id'))
+        ->fields('rc', ['id'])
         ->condition('report_name', $reportName)
         ->condition('label', $label)
         ->range(0, 1)
         ->execute();
+
       if ($row = $result->fetchAssoc()) {
-        $responseData = array(
+        $responseData = [
           'status' => 'already_exists',
           'id' => $row['id'],
-        );
+        ];
         print drupal_json_output($responseData);
         drupal_exit();
       }
       $result = db_insert('reports_configuration')
-        ->fields(array(
+        ->fields([
           'report_name' => $reportName,
           'label' => $label,
           'json_config' => $jsonConfig,
-        ))
+        ])
       ->execute();
       $responseData['id'] = $result;
       $responseData['label'] = $label;
     }
   } catch (Exception $e) {
-    $responseData = array(
+    $responseData = [
       'status' => 'error',
-    );
+    ];
   }
+
   print drupal_json_output($responseData);
   drupal_exit();
 }
@@ -6094,12 +5977,14 @@ function civihr_employee_portal_delete_report_configuration_json($reportName, $c
       ->condition('report_name', $reportName)
       ->condition('id', (int)$configId)
       ->execute();
+
     if ($result) {
-      print drupal_json_output(array('status' => 'success'));
+      print drupal_json_output(['status' => 'success']);
       drupal_exit();
     }
   }
-  print drupal_json_output(array('status' => 'error'));
+
+  print drupal_json_output(['status' => 'error']);
   drupal_exit();
 }
 
@@ -6127,9 +6012,9 @@ function get_civihr_version() {
       $civihrVersion = $cache->data;
     } else {
       try {
-        // Civi init
         civicrm_initialize();
-        $result = civicrm_api3('HRCoreInfo', 'getversion', array('sequential' => 1));
+
+        $result = civicrm_api3('HRCoreInfo', 'getversion', ['sequential' => 1]);
         $civihrVersion = $result['values'];
       } catch (CiviCRM_API3_Exception $e) {
         $error = $e->getMessage();

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -23,7 +23,9 @@ function civihr_employee_portal_css_alter(&$css) {
       ['module_name' => 'tipsy', 'file_name' => '/stylesheets/tipsy.css'],
     ];
 
-   _remove_resources($css, $removeFiles);
+    _remove_resources($css, $removeFiles);
+  } else {
+    _remove_shoreditch_resources($css);
   }
 }
 
@@ -57,6 +59,8 @@ function civihr_employee_portal_js_alter(&$javascript) {
     ];
 
     _remove_resources($javascript, $removeFiles);
+  } else {
+    _remove_shoreditch_resources($javascript);
   }
 }
 
@@ -73,6 +77,20 @@ function _remove_resources(&$resourcesList, $blacklist = []) {
   if ($resourcesList) {
     foreach ($blacklist as $key => $value) {
       unset($resourcesList[drupal_get_path('module', $value['module_name']) . $value['file_name']]);
+    }
+  }
+}
+
+/**
+ * Removes any resource related to the shoreditch extension
+ *
+ * @param array &$resourcesList variable contains all the references to loaded
+ *   js/css array from alter.
+ */
+function _remove_shoreditch_resources(&$resourcesList) {
+  foreach ($resourcesList as $path => $resource) {
+    if (strpos($path, 'org.civicrm.shoreditch')) {
+      unset($resourcesList[$path]);
     }
   }
 }

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -67,9 +67,11 @@ function civihr_employee_portal_js_alter(&$javascript) {
 /**
  * Removes javascript/css from civicrm pages.
  *
- * @param array &$resourcesList variable contains all the references to loaded
+ * @param array
+ *   &$resourcesList variable contains all the references to loaded
  *   js/css array from alter.
- * @param array $blacklist contains multi-dimensional array : module_name key
+ * @param array
+ *   $blacklist contains multi-dimensional array : module_name key
  *   as name of the contrib module from which we need to remove corresponding
  *   file using file_name key.
  */
@@ -84,7 +86,8 @@ function _remove_resources(&$resourcesList, $blacklist = []) {
 /**
  * Removes any resource related to the shoreditch extension
  *
- * @param array &$resourcesList variable contains all the references to loaded
+ * @param array
+ *   &$resourcesList variable contains all the references to loaded
  *   js/css array from alter.
  */
 function _remove_shoreditch_resources(&$resourcesList) {

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -415,30 +415,18 @@ function _rebuild_view($viewName) {
 }
 
 /**
- * Implements hook_coreResourceList
+ * Implements hook_civicrm_coreResourceList().
+ * Moves the notify jQuery plugin before CiviCRM common script file
  *
  * @param array $list
  * @param string $region
  */
 function civihr_employee_portal_civicrm_coreResourceList(&$list, $region) {
-  // To maintain the dependency remove the js files that are dependent on
-  // jquery.notify.js
-  $jsToRemove[] = array_search('js/Common.js', $list);
-  $jsToRemove[] = array_search('js/crm.ajax.js', $list);
-  $jsToRemove[] = array_search('js/wysiwyg/crm.wysiwyg.js', $list);
-  $jsToRemove[] = array_search('js/crm.drupal.js', $list);
+  $commonPos = array_search('js/Common.js', $list);
+  $notifyPos = array_search('packages/jquery/plugins/jquery.notify.min.js', $list);
 
-  foreach ($jsToRemove as $filepath) {
-    unset($list[$filepath]);
-  }
-
-  // Add the previously unlisted files to the list once the
-  // jquery.notify.js is added
-  $list[] = "packages/jquery/plugins/jquery.notify.js";
-  $list[] = "js/Common.js";
-  $list[] = "js/crm.ajax.js";
-  $list[] = "js/wysiwyg/crm.wysiwyg.js";
-  $list[] = "js/crm.drupal.js";
+  $notifyFile = array_splice($list, $notifyPos, 1);
+  array_splice($list, $commonPos, 0, $notifyFile);
 }
 
 /**

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -437,17 +437,19 @@ function _rebuild_view($viewName) {
 
 /**
  * Implements hook_civicrm_coreResourceList().
- * Moves the notify jQuery plugin before CiviCRM common script file
+ * Injects the notify jQuery plugin if not present
  *
  * @param array $list
  * @param string $region
  */
 function civihr_employee_portal_civicrm_coreResourceList(&$list, $region) {
-  $commonPos = array_search('js/Common.js', $list);
-  $notifyPos = array_search('packages/jquery/plugins/jquery.notify.min.js', $list);
+  if (!_isCiviCRM()) {
+    $notifyPath = 'packages/jquery/plugins/jquery.notify.min.js';
 
-  $notifyFile = array_splice($list, $notifyPos, 1);
-  array_splice($list, $commonPos, 0, $notifyFile);
+    if (!array_search($notifyPath, $list)) {
+      $list[] = $notifyPath;
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## Overview
The assets of the `org.civicrm.shoreditch` extensions were leaking into the SSP, causing visual issues and also adding resources that the browser had to fetch for no reason

## Before
You can see the shoreditch style affecting the style of the SSP in the admin toolbar and in the header, for example
<img width="700" alt="leak-before" src="https://user-images.githubusercontent.com/6400898/33070604-dbc328ae-ceb8-11e7-846a-9f6848bbbefc.png">

Network tab:
<img width="600" alt="ssp-assets-before" src="https://user-images.githubusercontent.com/6400898/33070419-3ccef368-ceb8-11e7-9b19-2149a3258ef6.png">


## After
Now the SSP style is not affected, because the shoreditch style is not included in the ssp anymore
<img width="700" alt="leak-after" src="https://user-images.githubusercontent.com/6400898/33070623-f358602e-ceb8-11e7-8373-288af524e92e.png">


Network tab:
<img width="600" alt="ssp-assets-after" src="https://user-images.githubusercontent.com/6400898/33070418-3cb4ac2e-ceb8-11e7-95f0-e75cd0779683.png">

## Technical Details
### Fixed .module file style
The entire `civihr_employee_portal.module` was fixed style-wise. This includes:
* Indentation
* Following proper phpdoc style for function documentations
* Using `[]` instead of `array()`

There were more fixes that could have been done (for example grouping related functions together), but at least it's a start

### Remove original inclusion of pre-shoreditch theme
As part of [this PR](https://github.com/compucorp/civihr-employee-portal/pull/124), the pre-shoreditch theme `org.civicrm.bootstrapcivicrm` was included in the SSP just to style the datepickers in the Reports page.

```php
function civihr_employee_portal_init() {
  drupal_add_css(getModuleUrl('org.civicrm.bootstrapcivicrm') . 'css/bootstrap-civicrm-style.css');
}
```

Fortunately we don't need to do that anymore, so the inclusion was removed

### Refactor hook_civicrm_coreResourceList()
This hook was introduced in [this PR](https://github.com/compucorp/civihr-employee-portal/pull/327/files) and it definitely need some improvement

1. The code was not optimal
2. It would run also when the browser would load a civicrm page
3. The entire dependency-swapping was unnecessary
4. The notify plugin needed to be added only for users without access to CiviCRM, otherwise the plugin is [already served](https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/Resources.php#L748)

*Before*
```php
function civihr_employee_portal_civicrm_coreResourceList(&$list, $region) {
  $jsToRemove[] = array_search('js/Common.js', $list);
  $jsToRemove[] = array_search('js/crm.ajax.js', $list);
  $jsToRemove[] = array_search('js/wysiwyg/crm.wysiwyg.js', $list);
  $jsToRemove[] = array_search('js/crm.drupal.js', $list);

  foreach ($jsToRemove as $filepath) {
    unset($list[$filepath]);
  }

  $list[] = "packages/jquery/plugins/jquery.notify.js";
  $list[] = "js/Common.js";
  $list[] = "js/crm.ajax.js";
  $list[] = "js/wysiwyg/crm.wysiwyg.js";
  $list[] = "js/crm.drupal.js";
}
```

*After*
```php
function civihr_employee_portal_civicrm_coreResourceList(&$list, $region) {
  if (!_isCiviCRM()) {
    $notifyPath = 'packages/jquery/plugins/jquery.notify.min.js';

    if (!array_search($notifyPath, $list)) {
      $list[] = $notifyPath;
    }
  }
}
```

### Remove Shoreditch assets
A simple `_remove_shoreditch_resources` function was introduced, that was then used in the `hook_css_alter()` and `hook_js_alter()` hooks, nothing fancy and i'm not sure if there is a more elegant way to tackle this

```php
function civihr_employee_portal_css_alter(&$css) {
  if (_isCiviCRM()) {
    // ...
  } else {
    _remove_shoreditch_resources($css);
  }
}

function civihr_employee_portal_js_alter(&$javascript) {
  if (_isCiviCRM()) {
    // ...
  } else {
    _remove_shoreditch_resources($javascript);
  }
}

function _remove_shoreditch_resources(&$resourcesList) {
  foreach ($resourcesList as $path => $resource) {
    if (strpos($path, 'org.civicrm.shoreditch')) {
      unset($resourcesList[$path]);
    }
  }
}
```