### PR TITLE
PCHR-2953: Fix Redirection from AJAX Webform Submissions

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5110,19 +5110,9 @@ function webform_client_form_ajax_callback($form, &$form_state) {
   ctools_include('modal');
   ctools_add_js('ajax-responder');
 
-  $redirectPath = 'dashboard';
-  $action = CRM_Utils_Array::value('#action', $form);
-  $hrDetailsForms = [
-    '/create-emergency-contact/js/view',
-    '/create-dependant/js/view',
-  ];
-  if (in_array($action, $hrDetailsForms)) {
-    $redirectPath = 'hr-details';
-  }
-
   $commands = [];
   $commands[] = ctools_modal_command_dismiss();
-  $commands[] = ctools_ajax_command_redirect($redirectPath);
+  $commands[] = ctools_ajax_command_reload();
   $commands[] = ajax_command_remove('#messages');
   $commands[] = ajax_command_after('#breadcrumb', '<div id="messages">' . theme('status_messages') . '</div>');
 


### PR DESCRIPTION
## Overview

When submitting a webform via AJAX (using a modal popup) the results will not be updated on the main page. Until now this was handled by redirecting the user to a page, however the redirect location was hardcoded to `/dashboard` which causes problems when submitting any webform from a different page.

## Before

Submitting any webform from any page using a modal would redirect to `/dashboard`.

![peek 2017-11-21 13-05](https://user-images.githubusercontent.com/6374064/33074066-c4a2c716-cebc-11e7-8d22-2677889fbb0c.gif)

## After

Submitting any webform from any page using a modal will refresh the current page.

![peek 2017-11-21 12-54](https://user-images.githubusercontent.com/6374064/33073946-5c1c2836-cebc-11e7-83b0-4ee3642aaf1a.gif)

## Notes

This callback is applied to any client webforms and only to the `#ajax` element of the form. Currently we have only the "Edit my Details" and "Create Emergency Contact" webforms, but the latter will be replaced the forms in PCHR-2846. We will also have the onboarding form, but that is not submitted using AJAX.

 I cannot think of any other situations where we would want to redirect a client webform to `/dashboard` and am a bit confused why it was implemented in this way in the first place.

---

- [x] Tests Pass
