### PR TITLE
PCHR-2961: Show help menu to auth users only, via upgrader

### DIFF
--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.features.menu_links.inc
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.features.menu_links.inc
@@ -99,6 +99,13 @@ function civihr_employee_portal_features_menu_default_menu_links() {
     'link_title' => 'Help',
     'options' => array(
       'identifier' => 'main-menu_help://civihr-documentation.readthedocs.io/en/latest/self-service-portal/login-screen/',
+      'alter' => TRUE,
+      'roles_for_menu' => array(
+        'show' => array(),
+        'hide' => array(
+          1 => 1,
+        ),
+      ),
       'attributes' => array(
         'class' => array(
           0 => 'fa',


### PR DESCRIPTION
_(nevermind the name of the branch with the wrong ticket number, the correct ticket was created after the PR)_

Now with the [roles_for_menu](https://www.drupal.org/project/roles_for_menu) module added to the ssp (see https://github.com/civicrm/civicrm-buildkit/pull/379/files), the visibility setting of the help menu can simply be exported in a feature