### PR TITLE
PCHR-2947: Style HR Details

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -4693,12 +4693,18 @@ function civihr_employee_portal_node_view($node, $view_mode, $langcode) {
 // Note: Under "Redirection location" NO redirect option should be select to get the confirmation message with ajax.
 // We can use this trick to make it generic for all webforms those have No redirect settings enabled under "Redirection location" setting.
 function civihr_employee_portal_form_alter(&$form, &$form_state, $form_id) {
-
-    if ($form_id == 'webform_client_form_' . variable_get('my_details_webform_nid') ||
-        $form_id == 'webform_client_form_11' || $form_id == 'webform_client_form_12' ||
-        $form_id == 'webform_client_form_' . variable_get('emergency_contact_webform_nid')) {
-        $form['#attributes']['class'][] = 'civihr_form civihr_form--reset form-horizontal';
-    }
+  $customClasses = 'civihr_form civihr_form--reset form-horizontal';
+  $formNode = CRM_Utils_Array::value('#node', $form);
+  $title = isset($formNode->title) ? $formNode->title : NULL;
+  $formsWithCustomClasses = [
+    'Emergency contact - edit',
+    'My details - edit',
+    'Create Dependant',
+    'Create Emergency Contact',
+  ];
+  if (in_array($title, $formsWithCustomClasses)) {
+    $form['#attributes']['class'][] = $customClasses;
+  }
 
     // Form become outdated fix
     if ($form_id == 'views_exposed_form') {

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -4695,6 +4695,7 @@ function civihr_employee_portal_node_view($node, $view_mode, $langcode) {
 function civihr_employee_portal_form_alter(&$form, &$form_state, $form_id) {
 
     if ($form_id == 'webform_client_form_' . variable_get('my_details_webform_nid') ||
+        $form_id == 'webform_client_form_11' || $form_id == 'webform_client_form_12' ||
         $form_id == 'webform_client_form_' . variable_get('emergency_contact_webform_nid')) {
         $form['#attributes']['class'][] = 'civihr_form civihr_form--reset form-horizontal';
     }

--- a/civihr_employee_portal/templates/civihr-employee-portal-my-details--block.tpl.php
+++ b/civihr_employee_portal/templates/civihr-employee-portal-my-details--block.tpl.php
@@ -67,6 +67,7 @@ if (!$user->uid) {
         <?php print $contact_details; ?>
       </div>
     </div>
+    <div class="col-md-offset-7 vertical-splitter visible-md visible-lg"></div>
     <div class="col-md-5 chr_panel--my-details__data-group">
       <h5
         class="chr_panel--my-details__data-group__title"><?php print $address_data_title ?></h5>

--- a/civihr_employee_portal/templates/civihr-employee-portal-my-details--block.tpl.php
+++ b/civihr_employee_portal/templates/civihr-employee-portal-my-details--block.tpl.php
@@ -67,7 +67,6 @@ if (!$user->uid) {
         <?php print $contact_details; ?>
       </div>
     </div>
-    <div class="col-md-offset-7 vertical-splitter hidden-xs hidden-sm"></div>
     <div class="col-md-5 chr_panel--my-details__data-group">
       <h5
         class="chr_panel--my-details__data-group__title"><?php print $address_data_title ?></h5>


### PR DESCRIPTION
## Overview
This PR styles the newly created Emergency and Dependents blocks and their modal popup in HR Details Tab.. Refer https://github.com/compucorp/civihr-employee-portal-theme/pull/278 for screenshots.

## Technical Details
**BackEnd**
1. Instead of relying on a drupal variable to store the ID of each webform we use the form title to decide if custom classes should be applied
1. The webforms created in the parent ticket were added to the list

**FrontEnd**
1. Added `visible-md visible-lg` instead of `hidden-xs hidden-sm` to the `vertical-splitter`, so that the line is not visible is iPad

---