### PR TITLE
PCHR-2988: Fix Onboarding Form Location Types

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.install
+++ b/civihr_employee_portal/civihr_employee_portal.install
@@ -1,6 +1,7 @@
 <?php
 
 use Drupal\civihr_employee_portal\Helpers\WebformHelper;
+use Drupal\civihr_employee_portal\Forms\OnboardingWebForm;
 
 /**
  * Create Report Pages and Report Age Settings menu links.
@@ -236,6 +237,44 @@ function civihr_employee_portal_update_7011() {
   }
 
   node_delete($node->nid);
+}
+
+/**
+ * Fixes location type IDs in the onboarding form.
+ */
+function civihr_employee_portal_update_7016() {
+  $onboardingForm = WebformHelper::findOneByTitle(OnboardingWebForm::NAME);
+  $civicrmWebform = &$onboardingForm->webform_civicrm;
+  $contactData = &$civicrmWebform['data']['contact'][1];
+  $phoneData = &$contactData['phone'];
+  $addressData = &$contactData['address'];
+  $emailData = &$contactData['email'];
+  $instantMessengerData = &$contactData['im'];
+
+  civicrm_initialize();
+  $locationTypes = civicrm_api3('LocationType', 'get')['values'];
+  $locationTypes = array_column($locationTypes, 'name', 'id');
+  $homeTypeID = array_search('Home', $locationTypes);
+  $workTypeID = array_search('Work', $locationTypes);
+
+  $workPhone = &$phoneData[1];
+  $homePhone = &$phoneData[2];
+  $homeEmail = &$emailData[2];
+  $workEmail = &$emailData[1];
+  $homeAddress = &$addressData[1];
+  $workInstantMessenger = &$instantMessengerData[1];
+
+  $locationKey = 'location_type_id';
+
+  $workPhone[$locationKey] = $workTypeID;
+  $homePhone[$locationKey] = $homeTypeID;
+  $workEmail[$locationKey] = $workTypeID;
+  $homeEmail[$locationKey] = $homeTypeID;
+  $homeAddress[$locationKey] = $homeTypeID;
+  $workInstantMessenger[$locationKey] = $workTypeID;
+
+  // todo not saving :-(
+  node_save($onboardingForm);
 }
 
 /**

--- a/civihr_employee_portal/civihr_employee_portal.install
+++ b/civihr_employee_portal/civihr_employee_portal.install
@@ -273,8 +273,7 @@ function civihr_employee_portal_update_7016() {
   $homeAddress[$locationKey] = $homeTypeID;
   $workInstantMessenger[$locationKey] = $workTypeID;
 
-  // todo not saving :-(
-  node_save($onboardingForm);
+  drupal_write_record('webform_civicrm_forms', $civicrmWebform, 'nid');
 }
 
 /**


### PR DESCRIPTION
## Overview

Onboarding form export and import uses `location_type_id`. However `location_type_id` can be different from site to site. This PR sets the onboarding form fields to use the correct location types.

## Before

On staging some of the location type IDs were different and pointed to unexpected location types for onboarding form components.

## After

The onboarding form components use the correct location type IDs.

- Work Phone Number (Work - Phone)
- Home Phone Number (Home - Phone)
- Work Email (Work)
- Home Email (Home)
- Instant Messenger (Work)

## Notes

- This is a temporary fix. More comprehensive fixed to improve the importing and exporting of webforms will be done at a later stage.

---

- [x] Tests Pass
