### PR TITLE
PCHR-2991: Include shoreditch css files in onboarding form page

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -32,7 +32,9 @@ function civihr_employee_portal_css_alter(&$css) {
 
     _remove_resources($css, $removeFiles);
   } else {
-    _remove_shoreditch_resources($css);
+    if (!strpos(url(current_path(), array('absolute' => TRUE)), 'onboarding-form')) {
+      _remove_shoreditch_resources($css);
+    }
   }
 }
 

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -32,7 +32,7 @@ function civihr_employee_portal_css_alter(&$css) {
 
     _remove_resources($css, $removeFiles);
   } else {
-    if (!strpos(url(current_path(), array('absolute' => TRUE)), 'onboarding-form')) {
+    if (drupal_get_path_alias() !== 'onboarding-form') {
       _remove_shoreditch_resources($css);
     }
   }


### PR DESCRIPTION
## Overview
This PR includes the `org.civicrm.shoreditch` css file (custom-civicrm.js) file in onboarding form page as it contains the datepicker styles.

## Technical Details
1. `css` file(s) from `org.civicrm.shoreditch`  extension is added only for onboarding-form page in file civihr_employee_portal/civihr_employee_portal.module.
```php
/**
 * Implements hook_css_alter().
 */
function civihr_employee_portal_css_alter(&$css) {
  ...
  if (_isCiviCRM()) {
    ...
  } else {
    if (!strpos(url(current_path(), array('absolute' => TRUE)), 'onboarding-form')) {
      _remove_shoreditch_resources($css);
    }
  }
}
```

## Comments
- The styles from `org.civicrm.shoreditch` were excluded  all pages except civicrm pages.

## Tests
⏹ PHP Unit Tests - not added