### PR TITLE
PCHR-3038: Report tabs menu changes

### DIFF
--- a/civihr_employee_portal/css/custom.css
+++ b/civihr_employee_portal/css/custom.css
@@ -135,18 +135,17 @@ span.appraisals-employee-legend {
 }
 
 .report-tabs {
-  font-size: 0; /* Removes gap between inline-block elements */
+  display: table;
   margin-top: 12px;
 }
 
 .report-tabs.nav-tabs.nav-justified > li {
-  display: inline-block;
-  font-size: 0px;
-  min-width: 15%;
+  width: 15%;
+  white-space: nowrap;
 }
 
 .report-tabs.nav-justified > li:first-child {
-  min-width: 85%;
+  width: 85%;
 }
 
 .report-content {
@@ -204,4 +203,10 @@ span.appraisals-employee-legend {
 
 .footer-logo {
   margin-top: 25px;
+}
+
+@media (max-width: 768px) {
+  .report-tabs.nav-tabs.nav-justified > li {
+    width: 100%;
+  }
 }

--- a/civihr_employee_portal/css/custom.css
+++ b/civihr_employee_portal/css/custom.css
@@ -135,7 +135,18 @@ span.appraisals-employee-legend {
 }
 
 .report-tabs {
+  font-size: 0; /* Removes gap between inline-block elements */
   margin-top: 12px;
+}
+
+.report-tabs.nav-tabs.nav-justified > li {
+  display: inline-block;
+  font-size: 0px;
+  min-width: 15%;
+}
+
+.report-tabs.nav-justified > li:first-child {
+  min-width: 85%;
 }
 
 .report-content {

--- a/civihr_employee_portal/css/custom.css
+++ b/civihr_employee_portal/css/custom.css
@@ -205,6 +205,10 @@ span.appraisals-employee-legend {
   margin-top: 25px;
 }
 
+/**
+ * 768px correspond to the small devices and tablets breakpoint from bootstrap:
+ * https://getbootstrap.com/docs/3.3/css/#grid-options
+ */
 @media (max-width: 768px) {
   .report-tabs.nav-tabs.nav-justified > li {
     width: 100%;

--- a/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-custom.tpl.php
+++ b/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-custom.tpl.php
@@ -29,12 +29,18 @@
   <ul class="nav nav-tabs nav-justified nav-tabs-header report-tabs">
     <?php if (!empty($jsonUrl)): ?>
       <li role="presentation" class="active">
-        <a data-tab="report-builder" href="#report-builder">Report Builder</a>
+        <a data-tab="report-builder" href="#report-builder">
+          <i class="fa fa-bar-chart"></i>
+          Report Builder
+        </a>
       </li>
     <?php endif; ?>
     <?php if (!empty($tableUrl)): ?>
       <li role="presentation">
-        <a data-tab="view-data" href="#view-data">View Data</a>
+        <a data-tab="view-data" href="#view-data">
+          <i class="fa fa-table"></i>
+          View Data
+        </a>
       </li>
     <?php endif; ?>
   </ul>

--- a/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-custom.tpl.php
+++ b/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-custom.tpl.php
@@ -28,19 +28,23 @@
 
   <ul class="nav nav-tabs nav-justified nav-tabs-header report-tabs">
     <?php if (!empty($jsonUrl)): ?>
-      <li role="presentation" class="active"><a data-tab="pivot-table" href="#pivot-table">Pivot Table</a></li>
+      <li role="presentation" class="active">
+        <a data-tab="report-builder" href="#report-builder">Report Builder</a>
+      </li>
     <?php endif; ?>
     <?php if (!empty($tableUrl)): ?>
-      <li role="presentation"><a data-tab="data" href="#data">Data</a></li>
+      <li role="presentation">
+        <a data-tab="view-data" href="#view-data">View Data</a>
+      </li>
     <?php endif; ?>
   </ul>
 
   <div class="report-content panel-pane pane-block chr_panel chr_panel--no-padding">
     <?php if (!empty($jsonUrl)): ?>
-      <div class="report-block pivot-table tab-pane">
+      <div class="report-block report-builder tab-pane">
         <div class="chr_search-result__header">
           <div class="chr_search-result__total">
-            Pivot Table
+            Report Builder
           </div>
         </div>
         <div id="reportPivotTableConfiguration">
@@ -78,7 +82,7 @@
       </div>
     <?php endif; ?>
     <?php if (!empty($tableUrl)): ?>
-      <div class="report-block data pane-content hidden">
+      <div class="report-block view-data pane-content hidden">
         <div id="reportTable"><?php print $table; ?></div>
         <?php if (!empty($exportUrl)): ?>
           <div class="chr_panel__footer">


### PR DESCRIPTION
## Overview
This PR adds the following changes to the report tabs menu:

* Renames the tabs items.
* Adds icons to each item.
* Changes the order of the menu items.
* makes the first option's width 85% of the container.

The tabs were renamed as follows:

* Pivot Table ---> Report Builder
* Data ---> View Data

The order was changed so the Report Builder goes first and View Data second.

## Before
![anim](https://user-images.githubusercontent.com/1642119/33944232-ecb59b66-dff1-11e7-9572-e8ff4fbc63ad.gif)


## After
![anim](https://user-images.githubusercontent.com/1642119/33937576-67627dce-dfda-11e7-969f-c3193f66c0b0.gif)


## Technical Details
Tab items were changed from display like table-cell to display inline to be able to change the width of the Report Builder item:

```css
.report-tabs {
  font-size: 0; /* Removes gap between inline-block elements */
  margin-top: 12px;
}

.report-tabs.nav-tabs.nav-justified > li {
  display: inline-block;
  font-size: 0px;
  min-width: 15%;
}

.report-tabs.nav-justified > li:first-child {
  min-width: 85%;
}
```

Backstop scenario ssp-reports.json from HRCore was run successfully.

---

- [x] Tests Pass
