### PR TITLE
PCHR-3040: Report layout update

### DIFF
--- a/civihr_employee_portal/css/custom.css
+++ b/civihr_employee_portal/css/custom.css
@@ -300,7 +300,7 @@ span.appraisals-employee-legend {
 }
 
 #reportPivotTable .report-field-rows table {
-  min-height: 80px;
+  min-height: 50vh;
 }
 
 #reportPivotTable .pvtRendererArea {

--- a/civihr_employee_portal/css/custom.css
+++ b/civihr_employee_portal/css/custom.css
@@ -8,7 +8,8 @@ and open the template in the editor.
     Author     : gergelymeszaros
 */
 
-.view-absence-list .views-field, .view-absence-list th {
+.view-absence-list .views-field,
+.view-absence-list th {
   width: 15%;
 }
 
@@ -34,7 +35,8 @@ and open the template in the editor.
   }
 }
 
-.table-up, .table-down {
+.table-up,
+.table-down {
   color: #007;
   cursor: pointer;
 
@@ -180,7 +182,8 @@ span.appraisals-employee-legend {
   margin-right: 10px;
 }
 
-#reportPivotTable .report-filters, #reportPivotTable .report-function {
+#reportPivotTable .report-filters,
+#reportPivotTable .report-function {
   position: relative;
 }
 
@@ -206,7 +209,8 @@ span.appraisals-employee-legend {
   padding-top: 20px;
 }
 
-#civihrReports .report-block, .report-filters:before, .report-function,
+#civihrReports .report-block,
+#reportPivotTable .report-function,
 #reportPivotTable #report-filters,
 #reportPivotTable .report-fields-selection table,
 #reportPivotTable .report-field-rows table,

--- a/civihr_employee_portal/css/custom.css
+++ b/civihr_employee_portal/css/custom.css
@@ -162,7 +162,6 @@ span.appraisals-employee-legend {
 }
 
 #reportPivotTableConfiguration {
-  border-bottom: 1px solid #ddd;
   padding: 10px 10px;
   margin-top: 12px;
 }
@@ -179,6 +178,68 @@ span.appraisals-employee-legend {
 
 .view-id-hr_resource_types_list .add-button-icon {
   margin-right: 10px;
+}
+
+#reportPivotTable .report-filters, .report-function {
+  position: relative;
+}
+
+#reportPivotTable .report-filters:before {
+  border: 1px solid #c3cbd6;
+  content: '';
+  display: block;
+  height: 100%;
+  left: 15px;
+  position: absolute;
+  top: 0;
+  width: calc(100% - 30px);
+}
+
+#reportPivotTable .report-function {
+  padding-top: 20px;
+}
+
+#civihrReports .report-block, .report-filters:before, .report-function,
+#reportPivotTable .pvtAxisContainer {
+  border: 1px solid #c3cbd6;
+}
+
+#reportPivotTable .row {
+  display: table;
+  margin-bottom: 15px;
+}
+
+#reportPivotTable .row:last-child {
+  margin-bottom: 0;
+}
+
+#reportPivotTable .row > [class*="col-"] {
+  display: table-cell;
+  float: none;
+  vertical-align: top;
+}
+
+#reportPivotTable .report-field-columns {
+  position: relative;
+}
+
+#reportPivotTable .report-field-columns table {
+  bottom: 0;
+  min-height: 80px;
+  position: absolute;
+  width: calc(100% - 30px);
+}
+
+#reportPivotTable .report-field-rows {
+  padding: 0;
+}
+
+#reportPivotTable .report-field-rows table {
+  min-height: 80px;
+}
+
+#reportPivotTable .pvtRendererArea {
+  padding: 0;
 }
 
 #footer {

--- a/civihr_employee_portal/css/custom.css
+++ b/civihr_employee_portal/css/custom.css
@@ -272,8 +272,8 @@ span.appraisals-employee-legend {
   display: block;
   width: 100%;
   max-height: 50vh;
-  overflow-x: hidden;
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 #reportPivotTable .report-fields-selection table li {
@@ -286,10 +286,9 @@ span.appraisals-employee-legend {
   height: auto;
   line-height: 1.2em;
   padding: 8px 20px 8px 15px;
-  padding-right: 20px;
   position: relative;
   white-space: normal;
-  width: 100%;
+  width: inherit;
 }
 
 #reportPivotTable .report-fields-selection table li span.pvtTriangle,
@@ -299,16 +298,13 @@ span.appraisals-employee-legend {
   right: 10px;
 }
 
-#reportPivotTable .report-field-rows {
+#reportPivotTable .report-field-rows,
+#reportPivotTable .pvtRendererArea {
   padding: 0;
 }
 
 #reportPivotTable .report-field-rows table {
   min-height: 50vh;
-}
-
-#reportPivotTable .pvtRendererArea {
-  padding: 0;
 }
 
 #reportPivotTable [uib-datepicker-popup-wrap] table {

--- a/civihr_employee_portal/css/custom.css
+++ b/civihr_employee_portal/css/custom.css
@@ -223,6 +223,26 @@ span.appraisals-employee-legend {
   border: 1px solid #c3cbd6;
 }
 
+#reportPivotTable .pvtAxisContainer.highlight {
+  background: #fbfbfc;
+  border-width: 2px;
+}
+
+#reportPivotTable .pvtAxisContainer::after {
+  content: 'Drop here';
+  line-height: 33px;
+  opacity: 0;
+  transition: opacity 0.4s ease;
+}
+
+#reportPivotTable .pvtAxisContainer.highlight::after {
+  opacity: 1;
+}
+
+#reportPivotTable .pvtAxisContainer.highlight .drop-here-message {
+  content: 'Drop Here';
+}
+
 #reportPivotTable .row {
   display: table;
   margin-bottom: 15px;

--- a/civihr_employee_portal/css/custom.css
+++ b/civihr_employee_portal/css/custom.css
@@ -318,6 +318,14 @@ span.appraisals-employee-legend {
   padding: 0;
 }
 
+#reportPivotTable [uib-datepicker-popup-wrap] table {
+  margin: 0;
+}
+
+#reportPivotTable table.uib-daypicker tbody td {
+  padding: 7px 0;
+}
+
 #footer {
   height: 250px;
   color: #727e8a;

--- a/civihr_employee_portal/css/custom.css
+++ b/civihr_employee_portal/css/custom.css
@@ -227,23 +227,12 @@ span.appraisals-employee-legend {
   border: none;
 }
 
-#reportPivotTable .highlight {
+#reportPivotTable .pvtAxisContainer {
+  transition: background 0.4s ease;
+}
+
+#reportPivotTable .pvtAxisContainer.highlight {
   background: #fbfbfc;
-}
-
-#reportPivotTable .pvtAxisContainer::after {
-  content: 'Drop here';
-  line-height: 33px;
-  opacity: 0;
-  transition: opacity 0.4s ease;
-}
-
-#reportPivotTable .pvtAxisContainer.highlight::after {
-  opacity: 1;
-}
-
-#reportPivotTable .pvtAxisContainer.highlight .drop-here-message {
-  content: 'Drop Here';
 }
 
 #reportPivotTable .row {

--- a/civihr_employee_portal/css/custom.css
+++ b/civihr_employee_portal/css/custom.css
@@ -230,6 +230,29 @@ span.appraisals-employee-legend {
   width: calc(100% - 30px);
 }
 
+#reportPivotTable .report-fields-selection table li {
+  margin-bottom: 5px;
+  width: 100%;
+}
+
+#reportPivotTable .report-fields-selection table li span.pvtAttr,
+#reportPivotTable .report-field-rows table li span.pvtAttr {
+  height: auto;
+  line-height: 1.2em;
+  padding: 8px 20px 8px 15px;
+  padding-right: 20px;
+  position: relative;
+  white-space: normal;
+  width: 100%;
+}
+
+#reportPivotTable .report-fields-selection table li span.pvtTriangle,
+#reportPivotTable .report-field-rows table li span.pvtTriangle {
+  position: absolute;
+  top: calc(50% - 1px);
+  right: 10px;
+}
+
 #reportPivotTable .report-field-rows {
   padding: 0;
 }

--- a/civihr_employee_portal/css/custom.css
+++ b/civihr_employee_portal/css/custom.css
@@ -193,6 +193,16 @@ span.appraisals-employee-legend {
   position: absolute;
   top: 0;
   width: calc(100% - 30px);
+  z-index: 0;
+}
+
+#reportPivotTable .report-filters #report-filters {
+  position: relative;
+  z-index: 1;
+}
+
+#reportPivotTable .report-filters .panel-body {
+  background: none;
 }
 
 #reportPivotTable .report-function {

--- a/civihr_employee_portal/css/custom.css
+++ b/civihr_employee_portal/css/custom.css
@@ -263,10 +263,10 @@ span.appraisals-employee-legend {
 
 #reportPivotTable .report-fields-selection table {
   display: block;
-  width: 100%;
   max-height: 50vh;
   overflow-y: auto;
   overflow-x: hidden;
+  width: 100%;
 }
 
 #reportPivotTable .report-fields-selection table li {

--- a/civihr_employee_portal/css/custom.css
+++ b/civihr_employee_portal/css/custom.css
@@ -132,6 +132,10 @@ span.appraisals-employee-legend {
   margin-right: 8px;
 }
 
+#civihrReports .crm_custom-select > select {
+  z-index: 0;
+}
+
 .report-filters .btn-report-date-filter {
   float: none;
 }

--- a/civihr_employee_portal/css/custom.css
+++ b/civihr_employee_portal/css/custom.css
@@ -180,8 +180,17 @@ span.appraisals-employee-legend {
   margin-right: 10px;
 }
 
-#reportPivotTable .report-filters, .report-function {
+#reportPivotTable .report-filters, #reportPivotTable .report-function {
   position: relative;
+}
+
+#reportPivotTable .report-function-group .pvtVals {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+#reportPivotTable .report-function-group .pvtAttrDropdown {
+  margin-top: 0;
 }
 
 #reportPivotTable .report-filters:before {

--- a/civihr_employee_portal/css/custom.css
+++ b/civihr_employee_portal/css/custom.css
@@ -219,13 +219,19 @@ span.appraisals-employee-legend {
 }
 
 #civihrReports .report-block, .report-filters:before, .report-function,
-#reportPivotTable .pvtAxisContainer {
+#reportPivotTable .report-fields-selection table,
+#reportPivotTable .report-field-rows table,
+#reportPivotTable .report-field-columns table {
   border: 1px solid #c3cbd6;
 }
 
-#reportPivotTable .pvtAxisContainer.highlight {
+#reportPivotTable .pvtAxisContainer,
+#reportPivotTable .report-fields-selection tbody {
+  border: none;
+}
+
+#reportPivotTable .highlight {
   background: #fbfbfc;
-  border-width: 2px;
 }
 
 #reportPivotTable .pvtAxisContainer::after {
@@ -267,6 +273,14 @@ span.appraisals-employee-legend {
   min-height: 80px;
   position: absolute;
   width: calc(100% - 30px);
+}
+
+#reportPivotTable .report-fields-selection table {
+  display: block;
+  width: 100%;
+  max-height: 50vh;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 #reportPivotTable .report-fields-selection table li {

--- a/civihr_employee_portal/css/custom.css
+++ b/civihr_employee_portal/css/custom.css
@@ -193,18 +193,6 @@ span.appraisals-employee-legend {
   margin-top: 0;
 }
 
-#reportPivotTable .report-filters:before {
-  border: 1px solid #c3cbd6;
-  content: '';
-  display: block;
-  height: 100%;
-  left: 15px;
-  position: absolute;
-  top: 0;
-  width: calc(100% - 30px);
-  z-index: 0;
-}
-
 #reportPivotTable .report-filters #report-filters {
   position: relative;
   z-index: 1;
@@ -219,6 +207,7 @@ span.appraisals-employee-legend {
 }
 
 #civihrReports .report-block, .report-filters:before, .report-function,
+#reportPivotTable #report-filters,
 #reportPivotTable .report-fields-selection table,
 #reportPivotTable .report-field-rows table,
 #reportPivotTable .report-field-columns table {

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -186,6 +186,16 @@
   };
 
   /**
+   * Make the report field rows container at least the same height as the field
+   * selection.
+   */
+  HRReport.prototype.makeReportFieldRowsContainerFullHeight = function () {
+    var fullHeight = this.pivotTableContainer.find('.report-fields-selection table').height();
+
+    this.pivotTableContainer.find('.report-field-rows table').css('min-height', fullHeight);
+  };
+
+  /**
    * Move the report original elements into new layout elements.
    */
   HRReport.prototype.moveReportElements = function () {
@@ -231,6 +241,7 @@
 
     this.updateDropdown();
     this.updateFilterbox();
+    this.makeReportFieldRowsContainerFullHeight();
   };
 
   /**

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -152,8 +152,26 @@
    *
    */
   HRReport.prototype.updateCustomTemplate = function () {
+    this.moveReportElementFromTo('.pvtRenderer', '.chart-type-select');
+    this.moveReportElementFromTo('.pvtAggregator', '.report-function');
+    this.moveReportElementFromTo('.pvtCols', '.report-columns table tr');
+    this.moveReportElementFromTo('.pvtRows', '.report-rows table tr');
+    this.moveReportElementFromTo('.pvtUnused', '.fields-selection-list table tr');
+    this.moveReportElementFromTo('.pvtRendererArea', '.report-area');
     this.updateDropdown();
     this.updateFilterbox();
+  };
+
+  HRReport.prototype.moveReportElementFromTo = function (fromSelector, toSelector) {
+    var fromElement = this.pivotTableContainer.find(fromSelector);
+    var toElement = jQuery(toSelector);
+
+    if (!fromElement.length) {
+      return;
+    }
+
+    toElement.empty();
+    fromElement.detach().appendTo(toElement);
   };
 
   /**

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -489,7 +489,7 @@
    * once a field is dropped in a column or row container.
    */
   HRReport.prototype.bindDragAndDropEventListeners = function () {
-    var draggableItems = this.pivotTableContainer.find('.report-fields-selection .pvtAxisContainer');
+    var draggableItems = this.pivotTableContainer.find('.report-fields-selection .pvtAxisContainer, .report-field-columns .pvtAxisContainer, .report-field-rows .pvtAxisContainer');
     var droppableContainers = this.pivotTableContainer.find('.report-field-columns .pvtAxisContainer, .report-field-rows .pvtAxisContainer');
     var highlightClass = 'highlight';
 

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -203,16 +203,6 @@
   };
 
   /**
-   * Make the report field rows container at least the same height as the field
-   * selection.
-   */
-  HRReport.prototype.makeReportFieldRowsContainerFullHeight = function () {
-    var fullHeight = this.pivotTableContainer.find('.report-fields-selection table').height();
-
-    this.pivotTableContainer.find('.report-field-rows table').css('min-height', fullHeight);
-  };
-
-  /**
    * Move the report original elements into new layout elements.
    */
   HRReport.prototype.moveReportElements = function () {
@@ -259,7 +249,6 @@
 
     this.updateDropdown();
     this.updateFilterbox();
-    this.makeReportFieldRowsContainerFullHeight();
   };
 
   /**

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -168,6 +168,23 @@
   };
 
   /**
+   * Highlights droppable containers when report fields are dragged
+   */
+  HRReport.prototype.highlightDroppableContainersOnFieldsDrag = function () {
+    var draggableItems = this.pivotTableContainer.find('.report-fields-selection .pvtAxisContainer');
+    var droppableContainers = this.pivotTableContainer.find('.report-field-columns .pvtAxisContainer, .report-field-rows .pvtAxisContainer');
+    var highlightClass = 'highlight';
+
+    draggableItems.on('sortstart', function () {
+      droppableContainers.addClass(highlightClass);
+    });
+
+    draggableItems.on('sortstop', function () {
+      droppableContainers.removeClass(highlightClass);
+    });
+  };
+
+  /**
    * Moves elements inside the report into a new element.
    *
    * @param {String} fromSelector - the path for the source element to move.
@@ -237,6 +254,7 @@
       this.moveReportElements();
       this.appendFilters();
       this.bindFilters();
+      this.highlightDroppableContainersOnFieldsDrag();
     }
 
     this.updateDropdown();

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -42,7 +42,8 @@
     var html = '<div class="report-section">' +
       '<div class="row report-header-section">' +
         '<div class="report-filters col-sm-3"></div>' +
-        '<div class="report-function col-sm-2">' +
+        '<div class="report-function col-sm-2 form-group">' +
+          '<label>Chart Functions</label>' +
           '<div class="report-function-select"></div>' +
           '<div class="report-function-group"></div>' +
         '</div>' +

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -234,7 +234,7 @@
   };
 
   /**
-   * Updates the layout of the pivot tablet and form element styles.
+   * Updates the layout of the pivot table and form element styles.
    */
   HRReport.prototype.updateCustomTemplate = function () {
     var hasReportSectionElement = this.pivotTableContainer.find('.report-section').length;

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -1,3 +1,5 @@
+/* global angular, Drupal, jQuery, moment, Ps, swal */
+
 (function ($) {
   'use strict';
 
@@ -379,6 +381,7 @@
    * @param string viewReportDataTableId
    */
   HRReport.prototype.refreshReportTableViewInstance = function (viewReportDataTableId) {
+    var AjaxViews = Drupal.views.ajaxView;
     var viewReportDataTableSettings = Drupal.settings.views.ajaxViews['views_dom_id:' + viewReportDataTableId];
     var viewReportDataTableNewId = this.getReportTableDomID();
 
@@ -387,7 +390,7 @@
 
     viewReportDataTableSettings.view_dom_id = viewReportDataTableNewId;
     Drupal.settings.views.ajaxViews['views_dom_id:' + viewReportDataTableNewId] = viewReportDataTableSettings;
-    Drupal.views.instances['views_dom_id:' + viewReportDataTableNewId] = new Drupal.views.ajaxView(Drupal.settings.views.ajaxViews['views_dom_id:' + viewReportDataTableNewId]);
+    Drupal.views.instances['views_dom_id:' + viewReportDataTableNewId] = new AjaxViews(Drupal.settings.views.ajaxViews['views_dom_id:' + viewReportDataTableNewId]);
   };
 
   /**

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -222,14 +222,13 @@
   HRReport.prototype.updateCustomTemplate = function () {
     var hasReportSectionElement = this.pivotTableContainer.find('.report-section').length;
 
-    if (hasReportSectionElement) {
-      return;
+    if (!hasReportSectionElement) {
+      this.createReportSectionElement();
+      this.moveReportElements();
+      this.appendFilters();
+      this.bindFilters();
     }
 
-    this.createReportSectionElement();
-    this.moveReportElements();
-    this.appendFilters();
-    this.bindFilters();
     this.updateDropdown();
     this.updateFilterbox();
   };
@@ -239,7 +238,7 @@
    *
    */
   HRReport.prototype.updateDropdown = function () {
-    $('.pvtUi select').each(function () {
+    $('.report-content select').each(function () {
       var selectClass = 'crm_custom-select crm_custom-select--full';
 
       if (!$(this).parent().hasClass('crm_custom-select')) {

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -65,7 +65,7 @@
     var that = this;
     this.pivotTableContainer.pivotUI(this.data, {
       rendererName: 'Table',
-      renderers: CRM.$.extend(
+      renderers: $.extend(
         jQuery.pivotUtilities.renderers,
         jQuery.pivotUtilities.c3_renderers,
         jQuery.pivotUtilities.export_renderers
@@ -402,7 +402,7 @@
     if (!this.jsonUrl) {
       return;
     }
-    CRM.$.ajax({
+    $.ajax({
       url: this.jsonUrl + filterValues,
       error: function () {
         console.log('Error refreshing Report JSON data.');
@@ -413,7 +413,7 @@
         that.data = data;
         that.pivotTableContainer.pivotUI(data, {
           rendererName: 'Table',
-          renderers: CRM.$.extend(
+          renderers: $.extend(
             jQuery.pivotUtilities.renderers,
             jQuery.pivotUtilities.c3_renderers
           ),
@@ -441,7 +441,7 @@
       return;
     }
     var tableDomId = this.getReportTableDomID();
-    CRM.$.ajax({
+    $.ajax({
       url: that.tableUrl + filterValues,
       error: function () {
         console.log('Error refreshing Report data table.');
@@ -459,7 +459,7 @@
    * Return unique Drupal View's DOM ID of data table
    */
   HRReport.prototype.getReportTableDomID = function () {
-    var reportTableDiv = CRM.$('#reportTable > div.view:first');
+    var reportTableDiv = $('#reportTable > div.view:first');
     var reportTableClasses = reportTableDiv.attr('class').split(' ');
     for (var i in reportTableClasses) {
       if (reportTableClasses[i].substring(0, 12) === 'view-dom-id-') {
@@ -497,7 +497,7 @@
       return;
     }
 
-    CRM.$('.report-filters input[type="submit"]').bind('click', function (e) {
+    $('.report-filters input[type="submit"]').bind('click', function (e) {
       e.preventDefault();
       that.applyFilters();
     });
@@ -505,13 +505,13 @@
 
   HRReport.prototype.applyFilters = function () {
     var that = this;
-    var formSerialize = CRM.$('.report-filters form:first').serializeArray();
+    var formSerialize = $('.report-filters form:first').serializeArray();
 
     formSerialize.map(function (input) {
       input.value = that.formatDate(input.value, 'DD/MM/YYYY', 'YYYY-MM-DD');
     });
 
-    formSerialize = CRM.$.param(formSerialize);
+    formSerialize = $.param(formSerialize);
 
     if (that.jsonUrl) {
       that.refreshJson('?' + formSerialize);
@@ -551,7 +551,7 @@
       return false;
     }
 
-    CRM.$.ajax({
+    $.ajax({
       url: '/reports/' + that.reportName + '/configuration/' + configId,
       error: function () {
         swal('Failed', 'Error loading Report configuration!', 'error');
@@ -627,7 +627,7 @@
     var that = this;
     var reportName = this.reportName;
 
-    CRM.$.ajax({
+    $.ajax({
       url: '/reports/' + reportName + '/configuration/' + configId + '/save',
       data: {
         label: configName,
@@ -640,20 +640,20 @@
         if (data.status === 'success') {
           // Update select with new option if we saved a new configuration:
           if (data['id']) {
-            CRM.$('.report-config-select').append('<option value="' + data['id'] + '">' + data['label'] + '</option>');
+            $('.report-config-select').append('<option value="' + data['id'] + '">' + data['label'] + '</option>');
             // Sort options by their labels alphabetically.
-            CRM.$('.report-config-select').append(CRM.$('.report-config-select option').remove().sort(function (a, b) {
+            $('.report-config-select').append($('.report-config-select option').remove().sort(function (a, b) {
               var aText = $(a).text();
               var bText = $(b).text();
 
               return (aText > bText) ? 1 : ((aText < bText) ? -1 : 0);
             }));
-            CRM.$('.report-config-select').val(data['id']);
+            $('.report-config-select').val(data['id']);
           }
           swal('Success', 'Report configuration has been saved', 'success');
         } else if (data.status === 'already_exists') {
           // If there is already a configuration with this label then we ask for overwriting it.
-          CRM.$('.report-config-select').val(data['id']);
+          $('.report-config-select').val(data['id']);
           that.configSave('Configuration with this name already exists. Do you want to modify it?');
         } else {
           swal('Failed', 'Error saving Report configuration!', 'error');
@@ -683,14 +683,14 @@
       confirmButtonText: 'Yes',
       closeOnConfirm: false
     }, function () {
-      CRM.$.ajax({
+      $.ajax({
         url: '/reports/' + reportName + '/configuration/' + configId + '/delete',
         error: function () {
           swal('Failed', 'Error deleting Report configuration!', 'error');
         },
         success: function (data) {
           if (data.status === 'success') {
-            CRM.$('.report-config-select option[value=' + configId + ']').remove();
+            $('.report-config-select option[value=' + configId + ']').remove();
             swal('Success', 'Report configuration has been deleted', 'success');
           } else {
             swal('Failed', 'Error deleting Report configuration!', 'error');
@@ -707,7 +707,7 @@
    * @returns {Integer}
    */
   HRReport.prototype.getReportConfigurationId = function () {
-    return CRM.$('.report-config-select').val();
+    return $('.report-config-select').val();
   };
 
   /**
@@ -783,26 +783,26 @@
       this.instance.initAngular();
 
       // Tabs bindings
-      CRM.$('.report-tabs a').bind('click', function (e) {
-        CRM.$('.report-tabs li').removeClass('active');
-        CRM.$(this).parent().addClass('active');
-        CRM.$('.report-block').addClass('hidden');
-        CRM.$('.report-block.' + CRM.$(this).data('tab')).removeClass('hidden');
+      $('.report-tabs a').bind('click', function (e) {
+        $('.report-tabs li').removeClass('active');
+        $(this).parent().addClass('active');
+        $('.report-block').addClass('hidden');
+        $('.report-block.' + $(this).data('tab')).removeClass('hidden');
       });
 
       switchTabsOnLoad();
 
       // Reports configuration bindings
-      CRM.$('.report-config-select').bind('change', function (e) {
+      $('.report-config-select').bind('change', function (e) {
         that.instance.configGet();
       });
-      CRM.$('.report-config-save-btn').bind('click', function (e) {
+      $('.report-config-save-btn').bind('click', function (e) {
         that.instance.configSave();
       });
-      CRM.$('.report-config-save-new-btn').bind('click', function (e) {
+      $('.report-config-save-new-btn').bind('click', function (e) {
         that.instance.configSaveNew();
       });
-      CRM.$('.report-config-delete-btn').bind('click', function (e) {
+      $('.report-config-delete-btn').bind('click', function (e) {
         that.instance.configDelete();
       });
 
@@ -815,7 +815,7 @@
 
         hash ? tabSelector += '[data-tab="' + hash.substr(1) + '"]' : tabSelector += ':first';
 
-        CRM.$(tabSelector).click();
+        $(tabSelector).click();
       }
     }
   };

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -23,6 +23,17 @@
   };
 
   /**
+   * Appends drag and drop instructions for the field rows and columns.
+   */
+  HRReport.prototype.appendFieldsDraggingInstructions = function () {
+    var columnsMessage = 'Drag and drop a field here from the list on the left to add as a column heading / horizontal axis in the report.';
+    var rowsMessage = 'Drag and drop a field here from the list on the left to add as a row heading / vertical axis in the report.';
+
+    $('.report-field-columns .pvtAxisContainer').append('<p class="instructions">' + columnsMessage + '</p>');
+    $('.report-field-rows .pvtAxisContainer').append('<p class="instructions">' + rowsMessage + '</p>');
+  };
+
+  /**
    * Compiles the filters element into an angular component. This is done for
    * elements created outside of the Angular cycle (ie: created using jQuery, etc.)
    */
@@ -169,23 +180,6 @@
   };
 
   /**
-   * Highlights droppable containers when report fields are dragged
-   */
-  HRReport.prototype.highlightDroppableContainersOnFieldsDrag = function () {
-    var draggableItems = this.pivotTableContainer.find('.report-fields-selection .pvtAxisContainer');
-    var droppableContainers = this.pivotTableContainer.find('.report-field-columns .pvtAxisContainer, .report-field-rows .pvtAxisContainer');
-    var highlightClass = 'highlight';
-
-    draggableItems.on('sortstart', function () {
-      droppableContainers.addClass(highlightClass);
-    });
-
-    draggableItems.on('sortstop', function () {
-      droppableContainers.removeClass(highlightClass);
-    });
-  };
-
-  /**
    * Moves elements inside the report into a new element.
    *
    * @param {String} fromSelector - the path for the source element to move.
@@ -245,7 +239,8 @@
       this.moveReportElements();
       this.appendFilters();
       this.bindFilters();
-      this.highlightDroppableContainersOnFieldsDrag();
+      this.appendFieldsDraggingInstructions();
+      this.bindDragAndDropEventListeners();
     }
 
     this.updateDropdown();
@@ -486,6 +481,28 @@
     viewReportDataTableSettings.view_dom_id = viewReportDataTableNewId;
     Drupal.settings.views.ajaxViews['views_dom_id:' + viewReportDataTableNewId] = viewReportDataTableSettings;
     Drupal.views.instances['views_dom_id:' + viewReportDataTableNewId] = new AjaxViews(Drupal.settings.views.ajaxViews['views_dom_id:' + viewReportDataTableNewId]);
+  };
+
+  /**
+   * Binds drag and drop event listeners for the field containers. These are
+   * used for highlighting the droppable containers and removing instructions
+   * once a field is dropped in a column or row container.
+   */
+  HRReport.prototype.bindDragAndDropEventListeners = function () {
+    var draggableItems = this.pivotTableContainer.find('.report-fields-selection .pvtAxisContainer');
+    var droppableContainers = this.pivotTableContainer.find('.report-field-columns .pvtAxisContainer, .report-field-rows .pvtAxisContainer');
+    var highlightClass = 'highlight';
+
+    draggableItems.on('sortstart', function () {
+      droppableContainers.addClass(highlightClass);
+    });
+
+    draggableItems.on('sortstop', function (event) {
+      var targetContainer = $(event.toElement).parents('.pvtAxisContainer');
+
+      droppableContainers.removeClass(highlightClass);
+      targetContainer.find('.instructions').slideUp();
+    });
   };
 
   /**

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -19,7 +19,7 @@
   HRReport.prototype.init = function (options) {
     $.extend(this, options);
     this.processData(this.data);
-    this.originalFilterElement = jQuery('#report-filters').detach();
+    this.originalFilterElement = $('#report-filters').detach();
   };
 
   /**
@@ -192,7 +192,7 @@
    */
   HRReport.prototype.moveReportElementFromTo = function (fromSelector, toSelector) {
     var fromElement = this.pivotTableContainer.find(fromSelector);
-    var toElement = jQuery(toSelector);
+    var toElement = $(toSelector);
 
     if (!fromElement.length) {
       return;
@@ -768,7 +768,7 @@
         this.isCollapsed = true;
       });
 
-      angular.bootstrap(jQuery('#civihrReports')[0], ['civihrReports']);
+      angular.bootstrap($('#civihrReports')[0], ['civihrReports']);
     });
   };
 

--- a/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-custom.tpl.php
+++ b/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-custom.tpl.php
@@ -33,7 +33,7 @@
           <form>
             <div class="row form-group">
               <div class="col-md-2">
-                <label>Configuration</label>
+                <label>Select existing report:</label>
               </div>
               <div class="col-md-5">
                 <div class="crm_custom-select">

--- a/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-custom.tpl.php
+++ b/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-custom.tpl.php
@@ -1,31 +1,4 @@
 <div id="civihrReports">
-  <?php if (!empty($filters)): ?>
-    <div
-      ng-controller="FiltersController as filters"
-      id="report-filters"
-      class="panel panel-pane pane-block chr_panel chr_panel--no-padding panel--sliding-body"
-      ng-class="{ 'panel--sliding-body': filters.filtersCollapsed }">
-      <div class="pane-content">
-        <div class="chr_search-result__header" ng-click="filters.filtersCollapsed = !filters.filtersCollapsed">
-          <div class="chr_search-result__total">
-            <i
-              class="chr_search-result__icon glyphicon glyphicon-chevron-right"
-              ng-class="{ 'glyphicon-chevron-right': filters.filtersCollapsed, 'glyphicon-chevron-down': !filters.filtersCollapsed }">
-            </i>
-            <span ng-class="{ 'hide': !filters.filtersCollapsed }">Show Filters</span>
-            <span class="hide" ng-class="{ 'hide': filters.filtersCollapsed }">Hide Filters</span>
-          </div>
-        </div>
-
-        <div
-          class="panel-body-wrap panel-body-wrap--collapse"
-          ng-class="{ 'panel-body-wrap--collapse': filters.filtersCollapsed }">
-            <?php print render($filters); ?>
-        </div>
-      </div>
-    </div>
-  <?php endif; ?>
-
   <ul class="nav nav-tabs nav-justified nav-tabs-header report-tabs">
     <?php if (!empty($jsonUrl)): ?>
       <li role="presentation" class="active">
@@ -96,11 +69,16 @@
           </form>
         </div>
         <div class="row">
-          <div class="report-filters col-md-2">
+          <div class="report-filters col-md-3">
+            <?php if (!empty($filters)): ?>
+              <div id="report-filters">
+                <?php print render($filters); ?>
+              </div>
+            <?php endif; ?>
           </div>
-          <div class="report-function col-md-2">
+          <div class="report-function col-md-3">
           </div>
-          <div class="report-columns col-md-8">
+          <div class="report-columns col-md-6">
             <table>
               <tr>
               </tr>
@@ -108,7 +86,7 @@
           </div>
         </div>
         <div class="row">
-        <div class="fields-selection col-md-2">
+        <div class="fields-selection col-md-3">
             Select fields:
           <div class="fields-selection-list">
             <table>
@@ -117,13 +95,13 @@
             </table>
           </div>
         </div>
-        <div class="report-rows col-md-2">
+        <div class="report-rows col-md-3">
           <table>
             <tr>
             </tr>
           </table>
         </div>
-        <div class="report-area col-md-8">
+        <div class="report-area col-md-6">
         </div>
       </div>
         <div id="reportPivotTable" class="pvtTable-civi"></div>

--- a/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-custom.tpl.php
+++ b/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-custom.tpl.php
@@ -55,35 +55,77 @@
         </div>
         <div id="reportPivotTableConfiguration">
           <form>
-            <div class="form-item">
-              Configuration:
-            </div>
-            <div class="form-item">
-              <div class="crm_custom-select">
-                <select name="id" class="report-config-select skip-js-custom-select">
-                  <option value=""><?php print t('-- select configuration --'); ?></option>
-                  <?php if (!empty($configurationList)): ?>
-                    <?php foreach ($configurationList as $key => $value): ?>
-                      <option value="<?php print $key; ?>"><?php print $value; ?></option>
-                    <?php endforeach; ?>
-                  <?php endif; ?>
-                </select>
-                <span class="crm_custom-select__arrow"></span>
+            <div class="row">
+              <div class="col-md-2">
+                <div>Configuration</div>
+              </div>
+              <div class="col-md-5">
+                <div class="crm_custom-select">
+                  <select name="id" class="report-config-select skip-js-custom-select">
+                    <option value=""><?php print t('-- select configuration --'); ?></option>
+                    <?php if (!empty($configurationList)): ?>
+                      <?php foreach ($configurationList as $key => $value): ?>
+                        <option value="<?php print $key; ?>"><?php print $value; ?></option>
+                      <?php endforeach; ?>
+                    <?php endif; ?>
+                  </select>
+                  <span class="crm_custom-select__arrow"></span>
+                </div>
+              </div>
+              <div class="col-md-5">
+                <?php if (user_access('manage hrreports configuration')): ?>
+                  <div class="form-item">
+                    <input type="button" class="report-config-save-btn btn btn-primary" value="<?php print t('Save Report'); ?>">
+                  </div>
+                  <div class="form-item">
+                    <input type="button" class="report-config-save-new-btn btn btn-primary" value="<?php print t('Save As New'); ?>">
+                  </div>
+                  <div class="form-item">
+                    <input type="button" class="report-config-delete-btn btn btn-danger" value="<?php print t('Delete'); ?>">
+                  </div>
+                <?php endif; ?>
               </div>
             </div>
-            <?php if (user_access('manage hrreports configuration')): ?>
-              <div class="form-item">
-                <input type="button" class="report-config-save-btn btn btn-primary" value="<?php print t('Save Report'); ?>">
+            <div class="row">
+              <div class="col-md-2">
+                Chart Type
               </div>
-              <div class="form-item">
-                <input type="button" class="report-config-save-new-btn btn btn-primary" value="<?php print t('Save As New'); ?>">
+              <div class="chart-type-select col-md-5">
               </div>
-              <div class="form-item">
-                <input type="button" class="report-config-delete-btn btn btn-danger" value="<?php print t('Delete'); ?>">
-              </div>
-            <?php endif; ?>
+            </div>
           </form>
         </div>
+        <div class="row">
+          <div class="report-filters col-md-2">
+          </div>
+          <div class="report-function col-md-2">
+          </div>
+          <div class="report-columns col-md-8">
+            <table>
+              <tr>
+              </tr>
+            </table>
+          </div>
+        </div>
+        <div class="row">
+        <div class="fields-selection col-md-2">
+            Select fields:
+          <div class="fields-selection-list">
+            <table>
+              <tr>
+              </tr>
+            </table>
+          </div>
+        </div>
+        <div class="report-rows col-md-2">
+          <table>
+            <tr>
+            </tr>
+          </table>
+        </div>
+        <div class="report-area col-md-8">
+        </div>
+      </div>
         <div id="reportPivotTable" class="pvtTable-civi"></div>
       </div>
     <?php endif; ?>

--- a/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-custom.tpl.php
+++ b/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-custom.tpl.php
@@ -26,6 +26,9 @@
             Report Builder
           </div>
         </div>
+        <div id="report-filters" ng-controller="FiltersController as filters">
+          <?php print render($filters); ?>
+        </div>
         <div id="reportPivotTableConfiguration">
           <form>
             <div class="row">
@@ -68,44 +71,8 @@
             </div>
           </form>
         </div>
-        <div class="row">
-          <div class="report-filters col-md-3">
-            <?php if (!empty($filters)): ?>
-              <div id="report-filters">
-                <?php print render($filters); ?>
-              </div>
-            <?php endif; ?>
-          </div>
-          <div class="report-function col-md-3">
-          </div>
-          <div class="report-columns col-md-6">
-            <table>
-              <tr>
-              </tr>
-            </table>
-          </div>
-        </div>
-        <div class="row">
-        <div class="fields-selection col-md-3">
-            Select fields:
-          <div class="fields-selection-list">
-            <table>
-              <tr>
-              </tr>
-            </table>
-          </div>
-        </div>
-        <div class="report-rows col-md-3">
-          <table>
-            <tr>
-            </tr>
-          </table>
-        </div>
-        <div class="report-area col-md-6">
-        </div>
       </div>
-        <div id="reportPivotTable" class="pvtTable-civi"></div>
-      </div>
+      <div id="reportPivotTable" class="pvtTable-civi"></div>
     <?php endif; ?>
     <?php if (!empty($tableUrl)): ?>
       <div class="report-block view-data pane-content hidden">

--- a/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-custom.tpl.php
+++ b/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-custom.tpl.php
@@ -31,9 +31,9 @@
         </div>
         <div id="reportPivotTableConfiguration">
           <form>
-            <div class="row">
+            <div class="row form-group">
               <div class="col-md-2">
-                <div>Configuration</div>
+                <label>Configuration</label>
               </div>
               <div class="col-md-5">
                 <div class="crm_custom-select">
@@ -62,9 +62,9 @@
                 <?php endif; ?>
               </div>
             </div>
-            <div class="row">
+            <div class="row form-group">
               <div class="col-md-2">
-                Chart Type
+                <label>Chart Type</label>
               </div>
               <div class="chart-type-select col-md-5">
               </div>


### PR DESCRIPTION
## Overview
This PR updates the layout of the report page so it follows the mock detailed in the [Report Improvements Wiki](https://compucorp.atlassian.net/wiki/spaces/PCHR/pages/123699243/Reporting+User+Experience+Improvements).

![image](https://user-images.githubusercontent.com/1642119/34517617-22c016da-f052-11e7-97f8-0995f4a12934.jpg)

## Before
![anim](https://user-images.githubusercontent.com/1642119/34517232-941ee15a-f050-11e7-897c-8565cdb07f16.gif)

## After
![anim](https://user-images.githubusercontent.com/1642119/34565565-b6e7f64a-f131-11e7-91d9-d05798d59706.gif)

## Technical Details

### Replacing the layout
To replace the layout DOM manipulation was needed since the report is generated by the [Pivot Table plugin](https://github.com/nicolaskruchten/pivottable) which doesn't support custom templates.

The template is first appended inside the pivot table container:

```js
HRReport.prototype.createReportSectionElement = function () {
  var html = '<div class="report-section">' +
    '<div class="row report-header-section">' +
      '<div class="report-filters col-sm-3"></div>' +
      '<div class="report-function col-sm-2">' +
        '<div class="report-function-select"></div>' +
        '<div class="report-function-group"></div>' +
      '</div>' +
      '<div class="report-field-columns col-sm-7"><table><tr></tr></table></div>' +
    '</div>' +
    '<div class="row report-content-section">' +
      '<div class="report-fields-selection col-sm-3"><table><tr></tr></table></div>' +
      '<div class="report-field-rows col-sm-2"><table><tr></tr></table></div>' +
      '<div class="report-area col-sm-7"></div>' +
    '</div>' +
  '</div>';

  this.pivotTableContainer.append(html);
};
```

And then each report section is moved to its new container:

```js
HRReport.prototype.updateCustomTemplate = function () {
  var hasReportSectionElement = this.pivotTableContainer.find('.report-section').length;

  if (!hasReportSectionElement) {
    this.createReportSectionElement();
    this.moveReportElements(); // <---- here each section is moved to its new container
    this.appendFilters();
    this.bindFilters();
    this.appendFieldsDraggingInstructions();
    this.bindDragAndDropEventListeners();
  }

  this.updateDropdown();
  this.updateFilterbox();
};
```

To move the elements, we detatch them from the DOM and then append them to the new container using this function:

```js
HRReport.prototype.moveReportElementFromTo = function (fromSelector, toSelector) {
  var fromElement = this.pivotTableContainer.find(fromSelector);
  var toElement = jQuery(toSelector);

  if (!fromElement.length) {
    return;
  }

  toElement.empty();
  fromElement.detach().appendTo(toElement);
};
```

### Fields selection scroll

To reduce the height of the report a vertical scroll was added to the fields selection:

```css

#reportPivotTable .report-fields-selection table {
  display: block; /* needs to be set as block or scrolls won't be displayed */
  width: 100%;
  max-height: 50vh;
  overflow-x: hidden;
  overflow-y: auto;
}
```

### Filters

The filters are generated outside of the pivot tablet element and are initialized using Angular. Angular is used to display the date pickers, set the initial date, format the date, and for showing/hiding the filter panel (which has been removed in the new layout).

Detaching and attaching angular elements somewhere else or cloning them just doesn't work (the date picker stops working for example). To be able to place the filters inside their new container, the Angular `$compile` function was wrapped into a `compileAngularElement` function:

```js
angularModule.run(['$compile', '$rootScope', function ($compile, $rootScope) {
  compileAngularElement = function (html) {
    var element = angular.element(html);
    var scope = $rootScope.$new();

    $compile(element)(scope);
    return element;
  };
}]);
``` 

The function is then used for compiling the filter's HTML like this:

```js
HRReport.prototype.appendFilters = function () {
  var element = this.originalFilterElement.clone();
  var filtersContainer = this.pivotTableContainer.find('.report-filters');

  compileAngularElement(element);
  filtersContainer.empty();
  element.appendTo(filtersContainer);
};
```

### Date Picker fixes

The date picker component's style, when inside the `#pivotReport` element, inherits a few rules that are not desired.

For example, an extra padding added by the SSP Theme [here](https://github.com/compucorp/civihr-employee-portal-theme/blob/staging/civihr_default_theme/scss/layout/_table.scss#L11). That padding is useful for the report, fields, etc. but not for the date picker.

A value of `7px 0` was applied instead. This came for the default value the date picker would have taken if not for the rule stated above.

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
    <td><img src="https://user-images.githubusercontent.com/1642119/34526821-ff4069e4-f079-11e7-8d86-2d2e7e5459d1.png" /></td>
    <td><img src="https://user-images.githubusercontent.com/1642119/34526710-afc9e34a-f079-11e7-993c-e259fd4b7b19.png" /></td>
</table>

Also, the z-index of select elements was changed from 2 to 0 so they don't display over the date picker.

```css
#civihrReports .crm_custom-select > select {
  z-index: 0;
}
```

### Fields instructions and highlighting

Instructions for drag and dropping fields onto column and row containers was added via Javascript since the target containers are generated by the pivot table plugin.

The instructions are appended as follows:

```js
HRReport.prototype.appendFieldsDraggingInstructions = function () {
  var columnsMessage = 'Drag and drop a field here from the list on the left to add as a column heading / horizontal axis in the report.';
  var rowsMessage = 'Drag and drop a field here from the list on the left to add as a row heading / vertical axis in the report.';

  $('.report-field-columns .pvtAxisContainer').append('<p class="instructions">' + columnsMessage + '</p>');
  $('.report-field-rows .pvtAxisContainer').append('<p class="instructions">' + rowsMessage + '</p>');
};
```

Drag and drop even listeners were added for highlighting the droppable areas and also to remove the instructions once fields have been added to them:

```js
HRReport.prototype.bindDragAndDropEventListeners = function () {
  var draggableItems = this.pivotTableContainer.find('.report-fields-selection .pvtAxisContainer, .report-field-columns .pvtAxisContainer, .report-field-rows .pvtAxisContainer');
  var droppableContainers = this.pivotTableContainer.find('.report-field-columns .pvtAxisContainer, .report-field-rows .pvtAxisContainer');
  var highlightClass = 'highlight';

  draggableItems.on('sortstart', function () {
    droppableContainers.addClass(highlightClass);
  });

  draggableItems.on('sortstop', function (event) {
    var targetContainer = $(event.toElement).parents('.pvtAxisContainer');

    droppableContainers.removeClass(highlightClass);
    targetContainer.find('.instructions').slideUp();
  });
};
```

### jQuery reference

Most references to `jQuery` and `CRM.$` were renamed to `$` since they are synonymous. Only references to pivot table renderers were left using the jQuery variable:

```js
this.pivotTableContainer.pivotUI(this.data, {
  // ...
  renderers: $.extend(
    jQuery.pivotUtilities.renderers,
    jQuery.pivotUtilities.c3_renderers,
    jQuery.pivotUtilities.export_renderers
  ),
  // ...
});
``` 

## Comments

This PR doesn't cover the following:

* Mobile or Small Screen view.
* Auto selecting a report configuration.

These will be worked in other Tickets/PRs.

The changes were tested manually since the report page changes completely. 

  
  
  