### PR TITLE
PCHR-3133: Report configuration changes

### DIFF
--- a/civihr_employee_portal/css/custom.css
+++ b/civihr_employee_portal/css/custom.css
@@ -285,7 +285,7 @@ span.appraisals-employee-legend {
   padding: 8px 20px 8px 15px;
   position: relative;
   white-space: normal;
-  width: inherit;
+  width: 100%;
 }
 
 #reportPivotTable .report-fields-selection table li span.pvtTriangle,

--- a/civihr_employee_portal/css/custom.css
+++ b/civihr_employee_portal/css/custom.css
@@ -168,7 +168,7 @@ span.appraisals-employee-legend {
 }
 
 #reportPivotTableConfiguration {
-  padding: 10px 10px;
+  padding: 10px 20px;
   margin-top: 12px;
 }
 
@@ -176,6 +176,10 @@ span.appraisals-employee-legend {
   display: inline-block;
   vertical-align: middle;
   padding-left: 10px;
+}
+
+#reportPivotTableConfiguration .crm_custom-select {
+  width: 100%;
 }
 
 .view-id-hr_resource_types_list .add-button {

--- a/civihr_employee_portal/css/custom.css
+++ b/civihr_employee_portal/css/custom.css
@@ -178,10 +178,6 @@ span.appraisals-employee-legend {
   padding-left: 10px;
 }
 
-#reportPivotTableConfiguration .crm_custom-select {
-  width: 100%;
-}
-
 .view-id-hr_resource_types_list .add-button {
   margin-bottom: 20px;
 }

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -801,6 +801,7 @@
       this.bindReportConfigurationEvents();
       this.bindTabsEvents();
       this.switchToTabSpecifiedOnTheUrl();
+      this.displayConfigurationOptionsAccordingToAvailableConfigurations();
     },
     bindReportConfigurationEvents: function () {
       $('.report-tabs a').bind('click', function (e) {
@@ -809,6 +810,21 @@
         $('.report-block').addClass('hidden');
         $('.report-block.' + $(this).data('tab')).removeClass('hidden');
       });
+    },
+    displayConfigurationOptionsAccordingToAvailableConfigurations: function () {
+      var deleteOption, hasSavedConfigurations, updateOption;
+
+      deleteOption = $('.report-config-delete-btn');
+      updateOption = $('.report-config-save-btn');
+      hasSavedConfigurations = $('.report-config-select option').length >= 2;
+
+      if (hasSavedConfigurations) {
+        deleteOption.fadeIn('fast');
+        updateOption.fadeIn('fast');
+      } else {
+        deleteOption.fadeOut('fast');
+        updateOption.fadeOut('fast');
+      }
     },
     bindTabsEvents: function () {
       var self = this;

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -796,45 +796,43 @@
   Drupal.behaviors.civihr_employee_portal_reports = {
     instance: null,
     attach: function (context, settings) {
-      var that = this;
       this.instance = new HRReport();
       this.instance.initAngular();
-
-      // Tabs bindings
+      this.bindReportConfigurationEvents();
+      this.bindTabsEvents();
+      this.switchToTabSpecifiedOnTheUrl();
+    },
+    bindReportConfigurationEvents: function () {
       $('.report-tabs a').bind('click', function (e) {
         $('.report-tabs li').removeClass('active');
         $(this).parent().addClass('active');
         $('.report-block').addClass('hidden');
         $('.report-block.' + $(this).data('tab')).removeClass('hidden');
       });
+    },
+    bindTabsEvents: function () {
+      var self = this;
 
-      switchTabsOnLoad();
-
-      // Reports configuration bindings
       $('.report-config-select').bind('change', function (e) {
-        that.instance.configGet();
+        self.instance.configGet();
       });
       $('.report-config-save-btn').bind('click', function (e) {
-        that.instance.configSave();
+        self.instance.configSave();
       });
       $('.report-config-save-new-btn').bind('click', function (e) {
-        that.instance.configSaveNew();
+        self.instance.configSaveNew();
       });
       $('.report-config-delete-btn').bind('click', function (e) {
-        that.instance.configDelete();
+        self.instance.configDelete();
       });
+    },
+    switchToTabSpecifiedOnTheUrl: function () {
+      var tabSelector = '.report-tabs a';
+      var hash = window.location.hash;
 
-      /**
-       * Switch to correct tab, on page load
-       */
-      function switchTabsOnLoad () {
-        var tabSelector = '.report-tabs a';
-        var hash = window.location.hash;
+      hash ? tabSelector += '[data-tab="' + hash.substr(1) + '"]' : tabSelector += ':first';
 
-        hash ? tabSelector += '[data-tab="' + hash.substr(1) + '"]' : tabSelector += ':first';
-
-        $(tabSelector).click();
-      }
+      $(tabSelector).click();
     }
   };
 })(jQuery);

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -864,11 +864,9 @@
      * only the save option is available and the others are hidden.
      */
     displayConfigurationOptionsIfConfigurationsHaveBeenSaved: function () {
-      var deleteOption, hasSavedConfigurations, updateOption;
-
-      deleteOption = $('.report-config-delete-btn');
-      updateOption = $('.report-config-save-btn');
-      hasSavedConfigurations = $('.report-config-select option').length >= 2;
+      var deleteOption = $('.report-config-delete-btn');
+      var updateOption = $('.report-config-save-btn');
+      var hasSavedConfigurations = $('.report-config-select option').length >= 2;
 
       if (hasSavedConfigurations) {
         deleteOption.fadeIn('fast');
@@ -886,7 +884,7 @@
       var tabSelector = '.report-tabs a';
       var hash = window.location.hash;
 
-      hash ? tabSelector += '[data-tab="' + hash.substr(1) + '"]' : tabSelector += ':first';
+      tabSelector += hash ? '[data-tab="' + hash.substr(1) + '"]' : ':first';
 
       $(tabSelector).click();
     }

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -78,11 +78,7 @@
     $('.pvtAxisContainer .instructions').each(function () {
       var hasFields = $(this).siblings().length;
 
-      if (hasFields) {
-        $(this).slideUp();
-      } else {
-        $(this).slideDown();
-      }
+      hasFields ? $(this).slideUp() : $(this).slideDown();
     });
   };
 
@@ -90,7 +86,6 @@
    * Init PivotTable.js library
    */
   HRReport.prototype.initPivotTable = function () {
-    var that = this;
     this.pivotTableContainer.pivotUI(this.data, {
       rendererName: 'Table',
       renderers: $.extend(
@@ -103,15 +98,15 @@
       cols: [],
       aggregatorName: 'Count',
       unusedAttrsVertical: false,
-      aggregators: that.getAggregators(),
+      aggregators: this.getAggregators(),
       derivedAttributes: this.derivedAttributes,
 
       // It's necessary to make all the DOM changes here
       // because the library doesn't have support to custom template
       // https://github.com/nicolaskruchten/pivottable/issues/484
       onRefresh: function (config) {
-        return that.pivotTableOnRefresh(config);
-      }
+        return this.pivotTableOnRefresh(config);
+      }.bind(this)
     }, false);
   };
 
@@ -835,24 +830,22 @@
      * deleting them.
      */
     bindReportConfigurationEvents: function () {
-      var self = this;
-
       $('.report-config-select').bind('change', function (e) {
-        self.instance.configGet();
-      });
+        this.instance.configGet();
+      }.bind(this));
       $('.report-config-save-btn').bind('click', function (e) {
-        self.instance.configSave();
-      });
+        this.instance.configSave();
+      }.bind(this));
       $('.report-config-save-new-btn').bind('click', function (e) {
-        self.instance.configSaveNew(function () {
-          self.displayConfigurationOptionsIfConfigurationsHaveBeenSaved();
-        });
-      });
+        this.instance.configSaveNew(function () {
+          this.displayConfigurationOptionsIfConfigurationsHaveBeenSaved();
+        }.bind(this));
+      }.bind(this));
       $('.report-config-delete-btn').bind('click', function (e) {
-        self.instance.configDelete(function () {
-          self.displayConfigurationOptionsIfConfigurationsHaveBeenSaved();
-        });
-      });
+        this.instance.configDelete(function () {
+          this.displayConfigurationOptionsIfConfigurationsHaveBeenSaved();
+        }.bind(this));
+      }.bind(this));
     },
     /**
      * Bind tab switching events for the report tabs.

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -615,7 +615,7 @@
   /**
    * Save new Report configuration basing on currently set configuration.
    */
-  HRReport.prototype.configSaveNew = function () {
+  HRReport.prototype.configSaveNew = function (callback) {
     var that = this;
 
     swal({
@@ -631,7 +631,7 @@
         swal.showInputError('Configuration name cannot be empty.');
         return false;
       }
-      that.configSaveProcess(0, inputValue);
+      that.configSaveProcess(0, inputValue, callback);
     });
   };
 
@@ -641,7 +641,7 @@
    * @param {Integer} configId
    * @param {String} configName
    */
-  HRReport.prototype.configSaveProcess = function (configId, configName) {
+  HRReport.prototype.configSaveProcess = function (configId, configName, callback) {
     var that = this;
     var reportName = this.reportName;
 
@@ -667,6 +667,7 @@
               return (aText > bText) ? 1 : ((aText < bText) ? -1 : 0);
             }));
             $('.report-config-select').val(data['id']);
+            callback && callback();
           }
           swal('Success', 'Report configuration has been saved', 'success');
         } else if (data.status === 'already_exists') {
@@ -684,7 +685,7 @@
   /**
    * Delete currently active configuration.
    */
-  HRReport.prototype.configDelete = function () {
+  HRReport.prototype.configDelete = function (callback) {
     var configId = this.getReportConfigurationId();
     if (!configId) {
       swal('No configuration selected', 'Please choose configuration to delete.', 'error');
@@ -710,6 +711,7 @@
           if (data.status === 'success') {
             $('.report-config-select option[value=' + configId + ']').remove();
             swal('Success', 'Report configuration has been deleted', 'success');
+            callback && callback();
           } else {
             swal('Failed', 'Error deleting Report configuration!', 'error');
           }
@@ -836,10 +838,14 @@
         self.instance.configSave();
       });
       $('.report-config-save-new-btn').bind('click', function (e) {
-        self.instance.configSaveNew();
+        self.instance.configSaveNew(function () {
+          self.displayConfigurationOptionsAccordingToAvailableConfigurations();
+        });
       });
       $('.report-config-delete-btn').bind('click', function (e) {
-        self.instance.configDelete();
+        self.instance.configDelete(function () {
+          self.displayConfigurationOptionsAccordingToAvailableConfigurations();
+        });
       });
     },
     switchToTabSpecifiedOnTheUrl: function () {

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -814,7 +814,7 @@
       this.bindReportConfigurationEvents();
       this.bindTabsEvents();
       this.switchToTabSpecifiedOnTheUrl();
-      this.displayConfigurationOptionsAccordingToAvailableConfigurations();
+      this.displayConfigurationOptionsIfConfigurationsHaveBeenSaved();
     },
     bindReportConfigurationEvents: function () {
       $('.report-tabs a').bind('click', function (e) {
@@ -824,7 +824,7 @@
         $('.report-block.' + $(this).data('tab')).removeClass('hidden');
       });
     },
-    displayConfigurationOptionsAccordingToAvailableConfigurations: function () {
+    displayConfigurationOptionsIfConfigurationsHaveBeenSaved: function () {
       var deleteOption, hasSavedConfigurations, updateOption;
 
       deleteOption = $('.report-config-delete-btn');
@@ -850,12 +850,12 @@
       });
       $('.report-config-save-new-btn').bind('click', function (e) {
         self.instance.configSaveNew(function () {
-          self.displayConfigurationOptionsAccordingToAvailableConfigurations();
+          self.displayConfigurationOptionsIfConfigurationsHaveBeenSaved();
         });
       });
       $('.report-config-delete-btn').bind('click', function (e) {
         self.instance.configDelete(function () {
-          self.displayConfigurationOptionsAccordingToAvailableConfigurations();
+          self.displayConfigurationOptionsIfConfigurationsHaveBeenSaved();
         });
       });
     },

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -240,6 +240,7 @@
       this.appendFilters();
       this.bindFilters();
       this.appendFieldsDraggingInstructions();
+      this.displayInstructionsIfDroppableHasNoFields();
       this.bindDragAndDropEventListeners();
     }
 
@@ -498,10 +499,20 @@
     });
 
     draggableItems.on('sortstop', function (event) {
-      var targetContainer = $(event.toElement).parents('.pvtAxisContainer');
-
       droppableContainers.removeClass(highlightClass);
-      targetContainer.find('.instructions').slideUp();
+      this.displayInstructionsIfDroppableHasNoFields();
+    }.bind(this));
+  };
+
+  HRReport.prototype.displayInstructionsIfDroppableHasNoFields = function () {
+    $('.pvtAxisContainer .instructions').each(function () {
+      var hasFields = $(this).siblings().length;
+
+      if (hasFields) {
+        $(this).slideUp();
+      } else {
+        $(this).slideDown();
+      }
     });
   };
 

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -71,6 +71,22 @@
   };
 
   /**
+   * Hides the report rows and columns instructions if there are fields inside
+   * of their container, otherwise displays the instructions.
+   */
+  HRReport.prototype.displayInstructionsIfDroppableHasNoFields = function () {
+    $('.pvtAxisContainer .instructions').each(function () {
+      var hasFields = $(this).siblings().length;
+
+      if (hasFields) {
+        $(this).slideUp();
+      } else {
+        $(this).slideDown();
+      }
+    });
+  };
+
+  /**
    * Init PivotTable.js library
    */
   HRReport.prototype.initPivotTable = function () {
@@ -504,18 +520,6 @@
     }.bind(this));
   };
 
-  HRReport.prototype.displayInstructionsIfDroppableHasNoFields = function () {
-    $('.pvtAxisContainer .instructions').each(function () {
-      var hasFields = $(this).siblings().length;
-
-      if (hasFields) {
-        $(this).slideUp();
-      } else {
-        $(this).slideDown();
-      }
-    });
-  };
-
   /**
    * Bind filters UI events
    */
@@ -808,6 +812,16 @@
    */
   Drupal.behaviors.civihr_employee_portal_reports = {
     instance: null,
+    /**
+     * This method runs when the page is ready. The method is executed by Drupal.
+     * More information:
+     * https://www.drupal.org/docs/7/api/javascript-api/managing-javascript-in-drupal-7
+     *
+     * @param {Element} context - A reference to the document where the script is
+     *   being executed.
+     * @param {Object} settings - A map of configuration options shared between
+     *   all behaviours.
+     */
     attach: function (context, settings) {
       this.instance = new HRReport();
       this.instance.initAngular();
@@ -816,30 +830,11 @@
       this.switchToTabSpecifiedOnTheUrl();
       this.displayConfigurationOptionsIfConfigurationsHaveBeenSaved();
     },
+    /**
+     * Binds report configuration events for changing, saving, updating and
+     * deleting them.
+     */
     bindReportConfigurationEvents: function () {
-      $('.report-tabs a').bind('click', function (e) {
-        $('.report-tabs li').removeClass('active');
-        $(this).parent().addClass('active');
-        $('.report-block').addClass('hidden');
-        $('.report-block.' + $(this).data('tab')).removeClass('hidden');
-      });
-    },
-    displayConfigurationOptionsIfConfigurationsHaveBeenSaved: function () {
-      var deleteOption, hasSavedConfigurations, updateOption;
-
-      deleteOption = $('.report-config-delete-btn');
-      updateOption = $('.report-config-save-btn');
-      hasSavedConfigurations = $('.report-config-select option').length >= 2;
-
-      if (hasSavedConfigurations) {
-        deleteOption.fadeIn('fast');
-        updateOption.fadeIn('fast');
-      } else {
-        deleteOption.fadeOut('fast');
-        updateOption.fadeOut('fast');
-      }
-    },
-    bindTabsEvents: function () {
       var self = this;
 
       $('.report-config-select').bind('change', function (e) {
@@ -859,6 +854,41 @@
         });
       });
     },
+    /**
+     * Bind tab switching events for the report tabs.
+     */
+    bindTabsEvents: function () {
+      $('.report-tabs a').bind('click', function (e) {
+        $('.report-tabs li').removeClass('active');
+        $(this).parent().addClass('active');
+        $('.report-block').addClass('hidden');
+        $('.report-block.' + $(this).data('tab')).removeClass('hidden');
+      });
+    },
+    /**
+     * Displays the Report Configuration's save/update/delete options depending
+     * on the availability of configurations. If no configurations are available
+     * only the save option is available and the others are hidden.
+     */
+    displayConfigurationOptionsIfConfigurationsHaveBeenSaved: function () {
+      var deleteOption, hasSavedConfigurations, updateOption;
+
+      deleteOption = $('.report-config-delete-btn');
+      updateOption = $('.report-config-save-btn');
+      hasSavedConfigurations = $('.report-config-select option').length >= 2;
+
+      if (hasSavedConfigurations) {
+        deleteOption.fadeIn('fast');
+        updateOption.fadeIn('fast');
+      } else {
+        deleteOption.fadeOut('fast');
+        updateOption.fadeOut('fast');
+      }
+    },
+    /**
+     * Automatically switches the current selected tab depending on the tab class
+     * provided in the URL.
+     */
     switchToTabSpecifiedOnTheUrl: function () {
       var tabSelector = '.report-tabs a';
       var hash = window.location.hash;

--- a/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-custom.tpl.php
+++ b/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-custom.tpl.php
@@ -71,8 +71,9 @@
             </div>
           </form>
         </div>
+        <hr />
+        <div id="reportPivotTable" class="pvtTable-civi"></div>
       </div>
-      <div id="reportPivotTable" class="pvtTable-civi"></div>
     <?php endif; ?>
     <?php if (!empty($tableUrl)): ?>
       <div class="report-block view-data pane-content hidden">

--- a/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-custom.tpl.php
+++ b/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-custom.tpl.php
@@ -36,7 +36,7 @@
                 <label>Select existing report:</label>
               </div>
               <div class="col-md-5">
-                <div class="crm_custom-select">
+                <div class="crm_custom-select crm_custom-select--full">
                   <select name="id" class="report-config-select skip-js-custom-select">
                     <option value=""><?php print t('-- select configuration --'); ?></option>
                     <?php if (!empty($configurationList)): ?>


### PR DESCRIPTION
## Overview
This PR adds a few fixed requests in [this comment](https://github.com/compucorp/civihr-employee-portal/pull/414#issuecomment-355333041) including:

* The configuration options were aligned to the "report builder" title.
* The configurations list was expanded to 100% so it's aligned with the chart type select and its own save/delete options.
* The configuration options (save, update, and delete buttons) are displayed depending on the context. If there are no configurations saved only "Save as New" is displayed.

In addition this PR fixes these two issues:

* The report would still be visible when switching to the "View Data" tab.
* Field instructions would still be visible when switching report configurations.

## Report Configuration style fixes

### Before
![leave reports hr17 9000 1](https://user-images.githubusercontent.com/1642119/34611812-6ce42c54-f1fd-11e7-8170-e3b92d6d99f1.png)


### After
![leave reports hr17 9000](https://user-images.githubusercontent.com/1642119/34611755-20da11e8-f1fd-11e7-9a00-1b8da05b009e.png)

## Displaying configuration save/update/delete options

### Before
![anim](https://user-images.githubusercontent.com/1642119/34612197-08e8d806-f1ff-11e7-9cd3-e2a7d7935ec7.gif)

### After
![anim](https://user-images.githubusercontent.com/1642119/34612250-595429ee-f1ff-11e7-9612-abc098fc5692.gif)

Only "Save as New" is displayed when there are no configurations saved.

### Technical details

Drupal.behaviors.civihr_employee_portal_reports was refactored so the `attatch` sequence is split into sub methods. This was done for readability's sake:

```js
Drupal.behaviors.civihr_employee_portal_reports = {
  attach: function (context, settings) {
    this.instance = new HRReport();
    this.instance.initAngular();
    this.bindReportConfigurationEvents();
    this.bindTabsEvents();
    this.switchToTabSpecifiedOnTheUrl();
    this.displayConfigurationOptionsIfConfigurationsHaveBeenSaved();
  }
  // ...
}
```

The `displayConfigurationOptionsIfConfigurationsHaveBeenSaved` will show or hide the configuration options depending on the availability of configurations:

```js
displayConfigurationOptionsIfConfigurationsHaveBeenSaved: function () {
  var deleteOption, hasSavedConfigurations, updateOption;

  deleteOption = $('.report-config-delete-btn');
  updateOption = $('.report-config-save-btn');
  hasSavedConfigurations = $('.report-config-select option').length >= 2;

  if (hasSavedConfigurations) {
    deleteOption.fadeIn('fast');
    updateOption.fadeIn('fast');
  } else {
    deleteOption.fadeOut('fast');
    updateOption.fadeOut('fast');
  }
}
```
When a configuration is saved and there was none the configuration options need to be updated. A callback function was added to both `configSaveNew` and `configDelete` to accomplish this:

```js
bindReportConfigurationEvents: function () {
  var self = this;

  $('.report-config-select').bind('change', function (e) {
    self.instance.configGet();
  });
  $('.report-config-save-btn').bind('click', function (e) {
    self.instance.configSave();
  });
  $('.report-config-save-new-btn').bind('click', function (e) {
    self.instance.configSaveNew(function () {
      self.displayConfigurationOptionsIfConfigurationsHaveBeenSaved();
    });
  });
  $('.report-config-delete-btn').bind('click', function (e) {
    self.instance.configDelete(function () {
      self.displayConfigurationOptionsIfConfigurationsHaveBeenSaved();
    });
  });
}
```

## Report field instructions

### Before
![anim](https://user-images.githubusercontent.com/1642119/34612912-19d1636a-f202-11e7-8605-375b62cb9f1e.gif)

### After
![anim](https://user-images.githubusercontent.com/1642119/34612803-a093d2d0-f201-11e7-8c01-a9766887f6fe.gif)

### Technical details
the `displayInstructionsIfDroppableHasNoFields` was created so it displays or hides the instructions depending on the presence of fields in their container:

```js
HRReport.prototype.displayInstructionsIfDroppableHasNoFields = function () {
  $('.pvtAxisContainer .instructions').each(function () {
    var hasFields = $(this).siblings().length;

    if (hasFields) {
      $(this).slideUp();
    } else {
      $(this).slideDown();
    }
  });
};
```

The `displayInstructionsIfDroppableHasNoFields` method is called after dropping a field in a container:

```js
draggableItems.on('sortstop', function (event) {
  droppableContainers.removeClass(highlightClass);
  this.displayInstructionsIfDroppableHasNoFields();
}.bind(this));
```
And after the whole report has been recreated:

```js
HRReport.prototype.updateCustomTemplate = function () {
  var hasReportSectionElement = this.pivotTableContainer.find('.report-section').length;

  if (!hasReportSectionElement) {
    this.createReportSectionElement();
    this.moveReportElements();
    this.appendFilters();
    this.bindFilters();
    this.appendFieldsDraggingInstructions();
    this.displayInstructionsIfDroppableHasNoFields(); // <--- here
    this.bindDragAndDropEventListeners();
  }

  this.updateDropdown();
  this.updateFilterbox();
};
```


## Switching tabs issue

### Before
![anim](https://user-images.githubusercontent.com/1642119/34611645-c0b6bb36-f1fc-11e7-86f7-d4eb6f3ee248.gif)

### After
![anim](https://user-images.githubusercontent.com/1642119/34611733-101623f6-f1fd-11e7-8a9d-b1bfb3918420.gif)

### Technical details
The report pivot tablet element (`#reportPivotTable`) was outside of the tab's pane (first introduced on #414 when moving the report elements). This was moved inside the tab's pane for the Report Builder and an horizontal rule was added to separate the header from the content.

```html
<div class="report-block report-builder tab-pane">
  <div class="chr_search-result__header">
    <div class="chr_search-result__total">
      Report Builder
    </div>
  </div>
  <div id="report-filters" ng-controller="FiltersController as filters">...</div>
  <div id="reportPivotTableConfiguration">...</div>
  <hr />
  <div id="reportPivotTable" class="pvtTable-civi"></div> <!-- here -->
</div>
```


---

- BackstopJS tests are giving false positives so the report page has been tested manually.

  
  