### PR TITLE
PCHR-3012: Onboarding Form Image Upload Limit

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.install
+++ b/civihr_employee_portal/civihr_employee_portal.install
@@ -277,6 +277,15 @@ function civihr_employee_portal_update_7016() {
 }
 
 /**
+ * Refreshes the node export files since the onboarding form file upload limit
+ * was increased.
+ */
+function civihr_employee_portal_update_7017() {
+  civicrm_initialize();
+  drush_civihr_employee_portal_refresh_node_export_files();
+}
+
+/**
  * Function to determine whether menu link exists or not.
  *
  * @param string

--- a/civihr_employee_portal/features/node_export_files/onboarding_form.export
+++ b/civihr_employee_portal/features/node_export_files/onboarding_form.export
@@ -4233,7 +4233,7 @@ array(
             'wrapper_classes' => 'onboarding_wizard_profile_pic_upload_image',
             'css_classes' => '',
             'filtering' => array(
-              'size' => '2 MB',
+              'size' => '10 MB',
               'types' => array(
                 'gif',
                 'jpg',


### PR DESCRIPTION
## Overview

The onboarding form user image upload size limit should be 10 MB. It is currently 2 MB

## Before

The onboarding form user image upload size limit was 2 MB

![image](https://user-images.githubusercontent.com/6374064/34955656-5e3a6c72-fa1d-11e7-87cf-3d568bd24d4d.png)

## After

The onboarding form user image upload size limit is 10 MB

![image](https://user-images.githubusercontent.com/6374064/34955707-92688786-fa1d-11e7-84f2-773329c209ca.png)

---

- [x] Tests Pass