### PR TITLE
PCHR-3178: Remove "Report Builder" header

### DIFF
--- a/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-custom.tpl.php
+++ b/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-custom.tpl.php
@@ -21,11 +21,6 @@
   <div class="report-content panel-pane pane-block chr_panel chr_panel--no-padding">
     <?php if (!empty($jsonUrl)): ?>
       <div class="report-block report-builder tab-pane">
-        <div class="chr_search-result__header">
-          <div class="chr_search-result__total">
-            Report Builder
-          </div>
-        </div>
         <div id="report-filters" ng-controller="FiltersController as filters">
           <?php print render($filters); ?>
         </div>


### PR DESCRIPTION
## Overview
This PR removes the Report Builder header from report pages. 

The reason to remove this header is because it's part of the [Report Improvement requirements](https://compucorp.atlassian.net/wiki/spaces/PCHR/pages/123699243/Reporting+User+Experience+Improvements).

## Before
![leave reports hr17 9000 3](https://user-images.githubusercontent.com/1642119/34963130-4280dee4-fa1d-11e7-9f02-bd15dc63ed9a.png)


## After
![leave reports hr17 9000 2](https://user-images.githubusercontent.com/1642119/34963060-dde2b656-fa1c-11e7-9ec2-597a9aebc55f.png)


## Technical Details
This markup was removed from `civihr-employee-portal-civihr-report-custom.tpl.php`:

```html
<div class="chr_search-result__header">
  <div class="chr_search-result__total">
    Report Builder
  </div>
</div>
```
