### PR TITLE
PCHR-3177: Fix Report dropdown arrows

### DIFF
--- a/civihr_employee_portal/css/custom.css
+++ b/civihr_employee_portal/css/custom.css
@@ -132,7 +132,7 @@ span.appraisals-employee-legend {
   margin-right: 8px;
 }
 
-#civihrReports .crm_custom-select > select {
+#civihrReports .crm_custom-select {
   z-index: 0;
 }
 

--- a/civihr_employee_portal/css/custom.css
+++ b/civihr_employee_portal/css/custom.css
@@ -132,10 +132,6 @@ span.appraisals-employee-legend {
   margin-right: 8px;
 }
 
-#civihrReports .crm_custom-select {
-  z-index: 0;
-}
-
 .report-filters .btn-report-date-filter {
   float: none;
 }
@@ -198,11 +194,6 @@ span.appraisals-employee-legend {
 
 #reportPivotTable .report-function-group .pvtAttrDropdown {
   margin-top: 0;
-}
-
-#reportPivotTable .report-filters #report-filters {
-  position: relative;
-  z-index: 1;
 }
 
 #reportPivotTable .report-filters .panel-body {


### PR DESCRIPTION
## Overview
This PR fixes an issue where the dropdown arrow of select elements inside of the report page would not open their select element when clicked.

## Before
![anim](https://user-images.githubusercontent.com/1642119/34965981-b23df7ec-fa2e-11e7-9d5e-47afd9d79bc6.gif)
Clicking on the dropdown arrow doesn't work.

## After
![anim](https://user-images.githubusercontent.com/1642119/34965931-553c0d86-fa2e-11e7-9ec8-e271d1920513.gif)

## Technical Details
This issue was introduced by [this commit](https://github.com/compucorp/civihr-employee-portal/commit/ab00dce2) since it overrides the z-index of the select element which originally was 2. The purpose of this commit was to fix date pickers to display above the select elements.

The datepickers were not being displayed on top of the selects because a parent element was using `z-index: 1` ([here](https://github.com/compucorp/civihr-employee-portal/pull/418/files#diff-c9717edfd0ee9646951283cf7eadc4e4L205)).

These z-index rules were not needed and were introduced in order to fix z-index issues before the report layout change, but they are not needed anymore and were removed.
