### PR TITLE
PCHR-3175: Rename filter labels

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5566,7 +5566,7 @@ function civihr_employee_portal_form_views_exposed_form_alter(&$form, &$form_sta
  * @param array $form_state
  * @param string $form_id
  */
-function _civihr_employee_portal_form_view_exposed_form_alter_people_report(&$form, $form_state, $form_id) {
+function _civihr_employee_portal_form_view_exposed_form_alter_people_report(&$form, &$form_state, $form_id) {
   $form['between_date_filter']['value'] = setInputDatepickerForm();
   $form['between_date_filter']['#prefix'] = '<header class="form-group"><label>Headcount on date:</label></header>';
 }
@@ -5578,7 +5578,7 @@ function _civihr_employee_portal_form_view_exposed_form_alter_people_report(&$fo
  * @param array $form_state
  * @param string $form_id
  */
-function _civihr_employee_portal_form_view_exposed_form_alter_leave_report(&$form, $form_state, $form_id) {
+function _civihr_employee_portal_form_view_exposed_form_alter_leave_report(&$form, &$form_state, $form_id) {
   $dateFields = &$form['absence_date_filter'];
   $dateFields['min'] = setInputDatepickerForm('From:');
   $dateFields['max'] = setInputDatepickerForm('To:');
@@ -5592,7 +5592,7 @@ function _civihr_employee_portal_form_view_exposed_form_alter_leave_report(&$for
  * @param array $form_state
  * @param string $form_id
  */
-function _civihr_employee_portal_form_view_exposed_form_alter_actions_wrapper(&$form, $form_state, $form_id) {
+function _civihr_employee_portal_form_view_exposed_form_alter_actions_wrapper(&$form, &$form_state, $form_id) {
   $form['#attributes']['class'][] = 'row';
 
   $form['submit']['#attributes'] = ['class' => ['chr_action']];
@@ -5608,7 +5608,7 @@ function _civihr_employee_portal_form_view_exposed_form_alter_actions_wrapper(&$
  * @param array $form_state
  * @param string $form_id
  */
-function _civihr_employee_portal_form_view_exposed_form_alter_labels_as_placeholders(&$form, $form_state, $form_id) {
+function _civihr_employee_portal_form_view_exposed_form_alter_labels_as_placeholders(&$form, &$form_state, $form_id) {
   foreach ($form as $key => $value) {
     if (isset($form['#info']["filter-$key"])) {
       $form[$key]['#prefix'] = '<div class="col-sm-6">';

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5568,7 +5568,7 @@ function civihr_employee_portal_form_views_exposed_form_alter(&$form, &$form_sta
  */
 function _civihr_employee_portal_form_view_exposed_form_alter_people_report(&$form, $form_state, $form_id) {
   $form['between_date_filter']['value'] = setInputDatepickerForm();
-  $form['between_date_filter']['#prefix'] = '<div class="form-group"><label>Headcount on date:</label></div>';
+  $form['between_date_filter']['#prefix'] = '<header class="form-group"><label>Headcount on date:</label></header>';
 }
 
 /**
@@ -5579,9 +5579,10 @@ function _civihr_employee_portal_form_view_exposed_form_alter_people_report(&$fo
  * @param string $form_id
  */
 function _civihr_employee_portal_form_view_exposed_form_alter_leave_report(&$form, $form_state, $form_id) {
-  $key = 'absence_date_filter';
-  $form[$key]['min'] = setInputDatepickerForm($form[$key]['min']['#title']);
-  $form[$key]['max'] = setInputDatepickerForm($form[$key]['max']['#title']);
+  $dateFields = &$form['absence_date_filter'];
+  $dateFields['min'] = setInputDatepickerForm('From:');
+  $dateFields['max'] = setInputDatepickerForm('To:');
+  $dateFields['#prefix'] = '<header class="form-group"><label>Leave dates:</label></header>';
 }
 
 /**

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5537,50 +5537,59 @@ function civihr_employee_portal_hrreport_custom_printtable($reportName, $dateFil
  * @param $form_state
  */
 function civihr_employee_portal_form_views_exposed_form_alter(&$form, &$form_state, $form_id) {
-  /**
-   *  Staff Directory filters form, HR Documents filters form
-   */
-  $exposed_filters_forms = ['views-exposed-form-civihr-staff-directory-page', 'views-exposed-form-hr-documents-hr-resources'];
-
-  if (isset($form['#id']) && in_array($form['#id'], $exposed_filters_forms)) {
-    $form['#attributes']['class'][] = 'row';
-
-    $form['submit']['#attributes'] = ['class' => ['chr_action']];
-    $form['submit']['#prefix'] = '<div class="col-sm-12"><div class="chr_panel__footer"><div class="chr_actions-wrapper">';
-    $form['submit']['#suffix'] = '</div></div></div>';
-
-    foreach ($form as $key => $value) {
-      if (isset($form['#info']["filter-$key"])) {
-        $form[$key]['#prefix'] = '<div class="col-sm-6">';
-        $form[$key]['#suffix'] = '</div>';
-
-        // Take the <label> value and use it as placeholder instead
-        if ($value['#type'] == 'textfield') {
-          $form[$key]['#attributes'] = ['placeholder' => $form['#info']["filter-$key"]['label']];
-        }
-
-        $form['#info']["filter-$key"]['label'] = '';
-      }
-    }
-  }
-
-  if(strpos($form['#id'], 'views-exposed-form-civihr-report-') !== false) {
-    foreach ($form as $key => $value) {
-      if (isset($form[$key]['value'])) {
-        $form[$key]['value'] = setInputDatepickerForm($form['#info']["filter-$key"]['label']);
-      }
-
-      if (isset($form[$key]['min'])) {
-        $form[$key]['min'] = setInputDatepickerForm($form[$key]['min']['#title']);
-      }
-
-      if (isset($form[$key]['max'])) {
-        $form[$key]['max'] = setInputDatepickerForm($form[$key]['max']['#title']);
-      }
-    }
+  switch ($form['#id']) {
+    // People's report filters:
+    case 'views-exposed-form-civihr-report-people-default':
+      _civihr_employee_portal_form_view_exposed_form_alter_people_report($form, $form_state, $form_id);
+      break;
+    // Leave and Absence's report filters:
+    case 'views-exposed-form-civihr-report-leave-and-absence-default':
+      _civihr_employee_portal_form_view_exposed_form_alter_leave_report($form, $form_state, $form_id);
+      break;
+    // Staff Directory and HR Document's form filters:
+    case 'views-exposed-form-civihr-staff-directory-page':
+    case 'views-exposed-form-hr-documents-hr-resources':
+      _civihr_employee_portal_form_view_exposed_form_alter_actions_wrapper($form, $form_state, $form_id);
+      _civihr_employee_portal_form_view_exposed_form_alter_labels_as_placeholders($form, $form_state, $form_id);
+      break;
   }
 
   $form['submit']['#value'] = 'Filter';
+}
+
+function _civihr_employee_portal_form_view_exposed_form_alter_people_report(&$form, $form_state, $form_id) {
+  $key = 'between_date_filter';
+  $form[$key]['value'] = setInputDatepickerForm($form['#info']["filter-$key"]['label']);
+}
+
+function _civihr_employee_portal_form_view_exposed_form_alter_leave_report(&$form, $form_state, $form_id) {
+  $key = 'absence_date_filter';
+  $form[$key]['min'] = setInputDatepickerForm($form[$key]['min']['#title']);
+  $form[$key]['max'] = setInputDatepickerForm($form[$key]['max']['#title']);
+}
+
+function _civihr_employee_portal_form_view_exposed_form_alter_actions_wrapper(&$form, $form_state, $form_id) {
+  $form['#attributes']['class'][] = 'row';
+
+  $form['submit']['#attributes'] = ['class' => ['chr_action']];
+  $form['submit']['#prefix'] = '<div class="col-sm-12"><div class="chr_panel__footer"><div class="chr_actions-wrapper">';
+  $form['submit']['#suffix'] = '</div></div></div>';
+}
+
+function _civihr_employee_portal_form_view_exposed_form_alter_labels_as_placeholders(&$form, $form_state, $form_id) {
+  foreach ($form as $key => $value) {
+    if (isset($form['#info']["filter-$key"])) {
+      $form[$key]['#prefix'] = '<div class="col-sm-6">';
+      $form[$key]['#suffix'] = '</div>';
+
+      // Take the <label> value and use it as placeholder instead
+      if ($value['#type'] == 'textfield') {
+        $form[$key]['#attributes'] = ['placeholder' => $form['#info']["filter-$key"]['label']];
+      }
+
+      $form['#info']["filter-$key"]['label'] = '';
+    }
+  }
 }
 
 /**

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5531,10 +5531,12 @@ function civihr_employee_portal_hrreport_custom_printtable($reportName, $dateFil
 }
 
 /**
- * Implement form_views_exposed_form_alter()
+ * Implement form_views_exposed_form_alter(). It executes form alterations
+ * depending on the form id.
  *
- * @param $form
- * @param $form_state
+ * @param array $form
+ * @param array $form_state
+ * @param string $form_id
  */
 function civihr_employee_portal_form_views_exposed_form_alter(&$form, &$form_state, $form_id) {
   switch ($form['#id']) {
@@ -5557,17 +5559,38 @@ function civihr_employee_portal_form_views_exposed_form_alter(&$form, &$form_sta
   $form['submit']['#value'] = 'Filter';
 }
 
+/**
+ * Defines the alterations for the People's report filters.
+ *
+ * @param array $form
+ * @param array $form_state
+ * @param string $form_id
+ */
 function _civihr_employee_portal_form_view_exposed_form_alter_people_report(&$form, $form_state, $form_id) {
   $key = 'between_date_filter';
   $form[$key]['value'] = setInputDatepickerForm($form['#info']["filter-$key"]['label']);
 }
 
+/**
+ * Defines the alterations for the Leave and Absence's report filters.
+ *
+ * @param array $form
+ * @param array $form_state
+ * @param string $form_id
+ */
 function _civihr_employee_portal_form_view_exposed_form_alter_leave_report(&$form, $form_state, $form_id) {
   $key = 'absence_date_filter';
   $form[$key]['min'] = setInputDatepickerForm($form[$key]['min']['#title']);
   $form[$key]['max'] = setInputDatepickerForm($form[$key]['max']['#title']);
 }
 
+/**
+ * Wraps the form actions inside a panel footer and actions wrapper elements.
+ *
+ * @param array $form
+ * @param array $form_state
+ * @param string $form_id
+ */
 function _civihr_employee_portal_form_view_exposed_form_alter_actions_wrapper(&$form, $form_state, $form_id) {
   $form['#attributes']['class'][] = 'row';
 
@@ -5576,6 +5599,14 @@ function _civihr_employee_portal_form_view_exposed_form_alter_actions_wrapper(&$
   $form['submit']['#suffix'] = '</div></div></div>';
 }
 
+/**
+ * Wraps each form element inside a Bootstrap column element and changes the label
+ * to a placeholder.
+ *
+ * @param array $form
+ * @param array $form_state
+ * @param string $form_id
+ */
 function _civihr_employee_portal_form_view_exposed_form_alter_labels_as_placeholders(&$form, $form_state, $form_id) {
   foreach ($form as $key => $value) {
     if (isset($form['#info']["filter-$key"])) {

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5567,8 +5567,8 @@ function civihr_employee_portal_form_views_exposed_form_alter(&$form, &$form_sta
  * @param string $form_id
  */
 function _civihr_employee_portal_form_view_exposed_form_alter_people_report(&$form, $form_state, $form_id) {
-  $key = 'between_date_filter';
-  $form[$key]['value'] = setInputDatepickerForm($form['#info']["filter-$key"]['label']);
+  $form['between_date_filter']['value'] = setInputDatepickerForm();
+  $form['between_date_filter']['#prefix'] = '<div class="form-group"><label>Headcount on date:</label></div>';
 }
 
 /**
@@ -5652,7 +5652,7 @@ function _civihr_employee_portal_get_view_csv_export_paths($view) {
  *
  * @return array
  */
-function setInputDatepickerForm($title) {
+function setInputDatepickerForm($title = null) {
   $idxKey = 'id_' . uniqid();
 
   return [

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -54,7 +54,7 @@
       '<div class="row report-header-section">' +
         '<div class="report-filters col-sm-3"></div>' +
         '<div class="report-function col-sm-2 form-group">' +
-          '<label>Chart Functions</label>' +
+          '<label>Chart Functions:</label>' +
           '<div class="report-function-select"></div>' +
           '<div class="report-function-group"></div>' +
         '</div>' +

--- a/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-custom.tpl.php
+++ b/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-custom.tpl.php
@@ -64,7 +64,7 @@
             </div>
             <div class="row form-group">
               <div class="col-md-2">
-                <label>Chart Type</label>
+                <label>Chart Type:</label>
               </div>
               <div class="chart-type-select col-md-5">
               </div>


### PR DESCRIPTION
## Overview
This PR renames the labels for the report filters based on these mockups:

Leave and Absence report filters:
![reporting user experience improvements p chr civihr confluence 2](https://user-images.githubusercontent.com/1642119/35040405-51a637ee-fb57-11e7-8ca7-770286b3bb94.png)

People's report filters:
![reporting user experience improvements p chr civihr confluence 1](https://user-images.githubusercontent.com/1642119/35040407-51f50982-fb57-11e7-87b6-672ba07d335b.png)


## Before
Leave and Absence's report:
![leave reports hr17 9000 6](https://user-images.githubusercontent.com/1642119/35040863-1d40870a-fb59-11e7-94e9-5e040fd87a14.png)

People's report:
![people reports hr17 9000 5](https://user-images.githubusercontent.com/1642119/35040884-32a28846-fb59-11e7-80b4-29722458178d.png)

## After
Leave and Absence's report:
![leave reports hr17 9000 4](https://user-images.githubusercontent.com/1642119/35040629-3d579066-fb58-11e7-9eb4-f519aa33d292.png)

People's report:
![people reports hr17 9000 6](https://user-images.githubusercontent.com/1642119/35040953-6dc7e9de-fb59-11e7-94ef-6ac379f57f75.png)

## Technical Details
The `civihr_employee_portal_form_views_exposed_form_alter` method was refactored. This method now redirects the flow to the specific form alteration functions depending on the form ID:

```php
function civihr_employee_portal_form_views_exposed_form_alter(&$form, &$form_state, $form_id) {
  switch ($form['#id']) {
    // People's report filters:
    case 'views-exposed-form-civihr-report-people-default':
      _civihr_employee_portal_form_view_exposed_form_alter_people_report($form, $form_state, $form_id);
      break;
    // Leave and Absence's report filters:
    case 'views-exposed-form-civihr-report-leave-and-absence-default':
      _civihr_employee_portal_form_view_exposed_form_alter_leave_report($form, $form_state, $form_id);
      break;
    // Staff Directory and HR Document's form filters:
    case 'views-exposed-form-civihr-staff-directory-page':
    case 'views-exposed-form-hr-documents-hr-resources':
      _civihr_employee_portal_form_view_exposed_form_alter_actions_wrapper($form, $form_state, $form_id);
      _civihr_employee_portal_form_view_exposed_form_alter_labels_as_placeholders($form, $form_state, $form_id);
      break;
  }

  $form['submit']['#value'] = 'Filter';
}
```
The switch pattern was used instead of running all alteration functions as suggested by @davialexandre [here](https://compucorp.atlassian.net/browse/PCHR-3175?focusedCommentId=65317&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-65317) because:

* For now, only the form ID is needed to determine which alterations to run and can't see this changing in the foreseeable future.
* It's more clear which alterations will run depending on the form ID - No need to check each individual function to see which one will run or not depending on the condition defined at the beginning of the function. 

For the Leave and Absence filters the alteration function is:
```php
function _civihr_employee_portal_form_view_exposed_form_alter_people_report(&$form, $form_state, $form_id) {
  $form['between_date_filter']['value'] = setInputDatepickerForm();
  $form['between_date_filter']['#prefix'] = '<header class="form-group"><label>Headcount on date:</label></header>';
}
```

And for the People filters is:
```php
function _civihr_employee_portal_form_view_exposed_form_alter_leave_report(&$form, $form_state, $form_id) {
  $dateFields = &$form['absence_date_filter'];
  $dateFields['min'] = setInputDatepickerForm('From:');
  $dateFields['max'] = setInputDatepickerForm('To:');
  $dateFields['#prefix'] = '<header class="form-group"><label>Leave dates:</label></header>';
}
```

In terms of refactoring, the Staff Directory's and HR Document filters was split into two functions:

an actions wrapper for the submit buttons:
```php
function _civihr_employee_portal_form_view_exposed_form_alter_actions_wrapper(&$form, $form_state, $form_id) {
  $form['#attributes']['class'][] = 'row';

  $form['submit']['#attributes'] = ['class' => ['chr_action']];
  $form['submit']['#prefix'] = '<div class="col-sm-12"><div class="chr_panel__footer"><div class="chr_actions-wrapper">';
  $form['submit']['#suffix'] = '</div></div></div>';
}
```

And a function that moves each label and converts them to field's placeholders:
```php
function _civihr_employee_portal_form_view_exposed_form_alter_labels_as_placeholders(&$form, $form_state, $form_id) {
  foreach ($form as $key => $value) {
    if (isset($form['#info']["filter-$key"])) {
      $form[$key]['#prefix'] = '<div class="col-sm-6">';
      $form[$key]['#suffix'] = '</div>';

      // Take the <label> value and use it as placeholder instead
      if ($value['#type'] == 'textfield') {
        $form[$key]['#attributes'] = ['placeholder' => $form['#info']["filter-$key"]['label']];
      }

      $form['#info']["filter-$key"]['label'] = '';
    }
  }
}
```

## Comments
This PR is related to: https://github.com/compucorp/civihr-employee-portal-theme/pull/297
since that PR gives a bit of marging to the filter's header introduced by this PR.
