### PR TITLE
PCHR-3176: Default filter dates

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5583,6 +5583,8 @@ function _civihr_employee_portal_form_view_exposed_form_alter_leave_report(&$for
   $dateFields['min'] = setInputDatepickerForm('From:');
   $dateFields['max'] = setInputDatepickerForm('To:');
   $dateFields['#prefix'] = '<header class="form-group"><label>Leave dates:</label></header>';
+  $dateFields['min']['#attributes']['ng-model'] = 'filters.filters.fromDate';
+  $dateFields['max']['#attributes']['ng-model'] = 'filters.filters.toDate';
 }
 
 /**
@@ -5663,11 +5665,12 @@ function setInputDatepickerForm($title = null) {
     '#description' => getCalendarButtonMarkup($idxKey),
     '#date_label_position' => 'within',
     '#attributes' => [
-      'ng-init' => "$idxKey = false; filters.dt$idxKey=filters.date",
-      'placeholder' => '{{filters.placeholderFormat}}',
-      'uib-datepicker-popup' => '{{filters.format}}',
+      'ng-init' => "ilters.$idxKey = false",
+      'placeholder' => '{{filters.dateFormat}}',
+      'uib-datepicker-popup' => '{{filters.dateFormat}}',
       'close-text' => 'Close',
-      'ng-model' => "filters.dt$idxKey",
+      'ng-model' => 'filters.filters.date',
+      'ng-disabled' => 'filters.loading.dates',
       'is-open' => "filters.$idxKey",
       'ng-click' => "filters.$idxKey = !filters.$idxKey"
     ],

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5665,7 +5665,7 @@ function setInputDatepickerForm($title = null) {
     '#description' => getCalendarButtonMarkup($idxKey),
     '#date_label_position' => 'within',
     '#attributes' => [
-      'ng-init' => "ilters.$idxKey = false",
+      'ng-init' => "filters.$idxKey = false",
       'placeholder' => '{{filters.dateFormat}}',
       'uib-datepicker-popup' => '{{filters.dateFormat}}',
       'close-text' => 'Close',

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -807,9 +807,11 @@
 
           (function init () {
             vm.loading.dates = true;
-            initFormFilterValues().finally(function () {
-              vm.loading.dates = false;
-            });
+
+            initFormFilterValues()
+              .finally(function () {
+                vm.loading.dates = false;
+              });
           })();
 
           /**
@@ -820,14 +822,15 @@
            * period dates have been initialized.
            */
           function initCurrentAbsencePeriodFilterDates () {
-            return AbsencePeriod.getCurrent().then(function (currentPeriod) {
-              if (!currentPeriod) {
-                return;
-              }
+            return AbsencePeriod.getCurrent()
+              .then(function (currentPeriod) {
+                if (!currentPeriod) {
+                  return;
+                }
 
-              formFiltersStore.values.fromDate = moment(currentPeriod.start_date).toDate();
-              formFiltersStore.values.toDate = moment(currentPeriod.end_date).toDate();
-            });
+                formFiltersStore.values.fromDate = moment(currentPeriod.start_date).toDate();
+                formFiltersStore.values.toDate = moment(currentPeriod.end_date).toDate();
+              });
           }
 
           /**

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -815,8 +815,8 @@
           })();
 
           /**
-           * Initializes the date filters using the start and end dates for the
-           * current absence period.
+           * Loads and sets the dates in the date filters using the start and
+           * end dates for the current absence period.
            *
            * @return {Promise} - Resolves to an empty promise after the current
            * period dates have been initialized.

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -792,12 +792,43 @@
           }
         });
       })
-      .controller('FiltersController', function (AbsencePeriod) {
-        this.format = 'dd/MM/yyyy';
-        this.placeholderFormat = 'dd/MM/yyyy';
-        this.date = new Date();
-        this.filtersCollapsed = true;
-      })
+      .controller('FiltersController', ['REPORT_NAME', 'AbsencePeriod',
+        function (REPORT_NAME, AbsencePeriod) {
+          var vm = this;
+
+          vm.dateFormat = 'dd/MM/yyyy';
+          vm.filters = {};
+          vm.loading = { dates: false };
+
+          (function init () {
+            if (REPORT_NAME === 'leave_and_absence') {
+              vm.loading.dates = true;
+              initCurrentAbsencePeriodFilterDates().finally(function () {
+                vm.loading.dates = false;
+              });
+            } else {
+              vm.filters.date = new Date();
+            }
+          })();
+
+          /**
+           * Initializes the date filters using the start and end dates for the
+           * current absence period.
+           *
+           * @return {Promise}
+           */
+          function initCurrentAbsencePeriodFilterDates () {
+            return AbsencePeriod.getCurrent().then(function (currentPeriod) {
+              if (!currentPeriod) {
+                return;
+              }
+
+              vm.filters.fromDate = moment(currentPeriod.start_date).toDate();
+              vm.filters.toDate = moment(currentPeriod.end_date).toDate();
+            });
+          }
+        }
+      ])
       .service('AbsencePeriod', function () {
         return {
           getCurrent: function () {

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -816,7 +816,8 @@
            * Initializes the date filters using the start and end dates for the
            * current absence period.
            *
-           * @return {Promise}
+           * @return {Promise} - Resolves to an empty promise after the current
+           * period dates have been initialized.
            */
           function initCurrentAbsencePeriodFilterDates () {
             return AbsencePeriod.getCurrent().then(function (currentPeriod) {
@@ -833,7 +834,8 @@
            * If form filters have not been initialized, they'll get their default
            * values depending on the current report.
            *
-           * @return {Promise}
+           * @return {Promise} - Resolves to an empty promise after the form
+           * filter values have been initialized.
            */
           function initFormFilterValues () {
             return $q(function (resolve, reject) {
@@ -858,6 +860,9 @@
         return {
           /**
            * Returns the current absence period or null if there is none.
+           *
+           * @return {Promise} - resolves to the current absence period or NULL
+           * in case there is none.
            */
           getCurrent: function () {
             var today = moment().format('YYYY-MM-DD');

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -792,11 +792,26 @@
           }
         });
       })
-      .controller('FiltersController', function () {
+      .controller('FiltersController', function (AbsencePeriod) {
         this.format = 'dd/MM/yyyy';
         this.placeholderFormat = 'dd/MM/yyyy';
         this.date = new Date();
         this.filtersCollapsed = true;
+      })
+      .service('AbsencePeriod', function () {
+        return {
+          getCurrent: function () {
+            var today = moment().format('YYYY-MM-DD');
+
+            return CRM.api3('AbsencePeriod', 'get', {
+              'start_date': { '<=': today },
+              'end_date': { '>=': today },
+              'sequential': 1
+            }).then(function (result) {
+              return result.values[0] || null;
+            });
+          }
+        };
       });
 
       angular.bootstrap($('#civihrReports')[0], ['civihrReports']);

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -797,9 +797,6 @@
         this.placeholderFormat = 'dd/MM/yyyy';
         this.date = new Date();
         this.filtersCollapsed = true;
-      })
-      .controller('SettingsController', function () {
-        this.isCollapsed = true;
       });
 
       angular.bootstrap($('#civihrReports')[0], ['civihrReports']);

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -18,6 +18,7 @@
    */
   HRReport.prototype.init = function (options) {
     $.extend(this, options);
+    this.initAngular();
     this.processData(this.data);
     this.originalFilterElement = $('#report-filters').detach();
   };
@@ -760,6 +761,8 @@
    *
    */
   HRReport.prototype.initAngular = function () {
+    var hrReportInstance = this;
+
     require([
       'common/angular',
       'common/services/angular-date/date-format',
@@ -781,6 +784,7 @@
           return element;
         };
       }])
+      .constant('REPORT_NAME', hrReportInstance.reportName)
       .directive('uibDatepickerPopupWrap', function sectionDirective () {
         return ({
           link: function (scope, element, attributes) {
@@ -819,7 +823,6 @@
      */
     attach: function (context, settings) {
       this.instance = new HRReport();
-      this.instance.initAngular();
       this.bindReportConfigurationEvents();
       this.bindTabsEvents();
       this.switchToTabSpecifiedOnTheUrl();

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -829,21 +829,26 @@
           }
         }
       ])
-      .service('AbsencePeriod', function () {
+      .service('AbsencePeriod', ['$q', function ($q) {
         return {
+          /**
+           * Returns the current absence period or null if there is none.
+           */
           getCurrent: function () {
             var today = moment().format('YYYY-MM-DD');
 
-            return CRM.api3('AbsencePeriod', 'get', {
-              'start_date': { '<=': today },
-              'end_date': { '>=': today },
-              'sequential': 1
-            }).then(function (result) {
-              return result.values[0] || null;
+            return $q(function (resolve, reject) {
+              CRM.api3('AbsencePeriod', 'get', {
+                'start_date': { '<=': today },
+                'end_date': { '>=': today },
+                'sequential': 1
+              }).then(function (result) {
+                resolve(result.values[0] || null);
+              }, reject);
             });
           }
         };
-      });
+      }]);
 
       angular.bootstrap($('#civihrReports')[0], ['civihrReports']);
     });


### PR DESCRIPTION
## Overview
This PR updates the default report filter dates depending on the report:

* For People's report the default date is the current date.
* For Leave and Absence's report the default dates are the current absence period start and end dates.

## Before
<table>
  <tr>
    <th>People's report</th>
    <th>Leave and Absence</th>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/1642119/35097108-205f5e94-fc25-11e7-9d54-e409889be1d9.png" /></td>
    <td><img src="https://user-images.githubusercontent.com/1642119/35097163-6997b250-fc25-11e7-87c9-da0950f25776.png" /></td>
  </tr>
</table>

## After
<table>
  <tr>
    <th>People's report</th>
    <th>Leave and Absence</th>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/1642119/35096875-2e3d3190-fc24-11e7-85ef-aa4797730550.png" /></td>
    <td><img src="https://user-images.githubusercontent.com/1642119/35096876-2f73d9f6-fc24-11e7-8a64-5590e6b5a0b4.png" /></td>
  </tr>
</table>

## Technical Details
A new AbsencePeriod service was created which returns the current absence period. For simplicity's sake and because this whole report will be revamped for the next release, the AbsencePeriod from L&A was not moved into a generic reqangular service.

The implementation is the following:

```js
.service('AbsencePeriod', ['$q', function ($q) {
  return {
    /**
     * Returns the current absence period or null if there is none.
     */
    getCurrent: function () {
      var today = moment().format('YYYY-MM-DD');

      return $q(function (resolve, reject) {
        CRM.api3('AbsencePeriod', 'get', {
          'start_date': { '<=': today },
          'end_date': { '>=': today },
          'sequential': 1
        }).then(function (result) {
          resolve(result.values[0] || null);
        }, reject);
      });
    }
  };
}]);
```

The `SettingsController` was removed since it was not being used anymore. This controller was previously used to open or close the filters panel, which is not collapsible any longer.

The report name was necessary in order to know which filter values to use. The report name was stored in a `REPORT_NAME` constant as follows:

```js
HRReport.prototype.initAngular = function () {
  var hrReportInstance = this;

  // code ...
  .constant('REPORT_NAME', hrReportInstance.reportName)
  // code
};
```

The angular initialization flow was changed from the `.attach` method to the `.init` method in order to properly pass the `reportName` option since it's not available on attach, but it is on init:

```js
HRReport.prototype.init = function (options) {
  $.extend(this, options);
  this.initAngular(); // <-------- here
  this.processData(this.data);
  this.originalFilterElement = $('#report-filters').detach();
};
```

Since all the report's DOM elements get recreated each time the filters are executed, the filter values are saved in a storage:

```js
.value('formFiltersStore', {
  initialized: false,
  values: {}
})
```

Without this, the filter values would be initialized every time the filters are submitted since the controller is attached to the DOM again and again overwriting any value the user might have selected.

The `FiltersController` was completely reworked:

* `format` and `placeholderFormat` were merged into a single `placeholderFormat` property.
* Instead of using a `date` property for the model, a `filters` property was created that can have different models depending on the report. The filters use the form filters store object so the values are preserved even if the controller is reinitialized:

```js
vm.dateFormat = 'dd/MM/yyyy';
vm.filters = formFiltersStore.values; // maps the filters store values to the controller's filters
vm.loading = { dates: false }; // used when loading dates for the filters
```
The init function initializes the form filter store values:

```js
(function init () {
  vm.loading.dates = true; // disables the filters while loading date values
  initFormFilterValues().finally(function () {
    vm.loading.dates = false;
  });
})();

function initFormFilterValues () {
  return $q(function (resolve, reject) {
    // skip initialization if form filter values have already been initialized: 
    if (formFiltersStore.initialized) {
      return resolve();
    }

    // for Leave and Absence it load the current absence period and stores them:
    if (REPORT_NAME === 'leave_and_absence') {
      initCurrentAbsencePeriodFilterDates().then(resolve, reject);
    } else {
      // for every other report it stores the current date:
      formFiltersStore.values.date = new Date();
      resolve();
    }
  })
  .then(function () {
    formFiltersStore.initialized = true;
  });
}
```

For loading the absence period dates and storing them the following was done:

```js
function initCurrentAbsencePeriodFilterDates () {
  return AbsencePeriod.getCurrent().then(function (currentPeriod) {
    if (!currentPeriod) {
      return;
    }

    formFiltersStore.values.fromDate = moment(currentPeriod.start_date).toDate();
    formFiltersStore.values.toDate = moment(currentPeriod.end_date).toDate();
  });
}
```

Finally, the input's attributes were modified so they follow the controller's changes:

```php
function setInputDatepickerForm($title = null) {
  $idxKey = 'id_' . uniqid();

  return [
    '#title' => $title,
    '#type' => 'textfield',
    '#size' => '10',
    '#description' => getCalendarButtonMarkup($idxKey),
    '#date_label_position' => 'within',
    '#attributes' => [
      'ng-init' => "filters.$idxKey = false",
      'placeholder' => '{{filters.dateFormat}}', // the placeholder and the date popup use the same date format
      'uib-datepicker-popup' => '{{filters.dateFormat}}',
      'close-text' => 'Close',
      'ng-model' => 'filters.filters.date', // the default model is `.filters.date`
      'ng-disabled' => 'filters.loading.dates', // disables the input while the dates are loading
      'is-open' => "filters.$idxKey",
      'ng-click' => "filters.$idxKey = !filters.$idxKey"
    ],
  ];
}
```

For the leave and absence report the min and max input were modified so they use the proper models:

```php
function _civihr_employee_portal_form_view_exposed_form_alter_leave_report(&$form, &$form_state, $form_id) {
  $dateFields = &$form['absence_date_filter'];
  $dateFields['min'] = setInputDatepickerForm('From:');
  $dateFields['max'] = setInputDatepickerForm('To:');
  $dateFields['#prefix'] = '<header class="form-group"><label>Leave dates:</label></header>';
  $dateFields['min']['#attributes']['ng-model'] = 'filters.filters.fromDate'; // here
  $dateFields['max']['#attributes']['ng-model'] = 'filters.filters.toDate'; // and here
}
```

