### PR TITLE
PCHR-3207: SSP Report fixes

### DIFF
--- a/civihr_employee_portal/css/custom.css
+++ b/civihr_employee_portal/css/custom.css
@@ -226,21 +226,6 @@ span.appraisals-employee-legend {
   background: #fbfbfc;
 }
 
-#reportPivotTable .row {
-  display: table;
-  margin-bottom: 15px;
-}
-
-#reportPivotTable .row:last-child {
-  margin-bottom: 0;
-}
-
-#reportPivotTable .row > [class*="col-"] {
-  display: table-cell;
-  float: none;
-  vertical-align: top;
-}
-
 #reportPivotTable .report-field-columns {
   position: relative;
 }

--- a/civihr_employee_portal/css/custom.css
+++ b/civihr_employee_portal/css/custom.css
@@ -230,21 +230,6 @@ span.appraisals-employee-legend {
   position: relative;
 }
 
-#reportPivotTable .report-field-columns table {
-  bottom: 0;
-  min-height: 80px;
-  position: absolute;
-  width: calc(100% - 30px);
-}
-
-#reportPivotTable .report-fields-selection table {
-  display: block;
-  max-height: 50vh;
-  overflow-y: auto;
-  overflow-x: hidden;
-  width: 100%;
-}
-
 #reportPivotTable .report-fields-selection table li {
   margin-bottom: 5px;
   width: 100%;
@@ -270,10 +255,6 @@ span.appraisals-employee-legend {
 #reportPivotTable .report-field-rows,
 #reportPivotTable .pvtRendererArea {
   padding: 0;
-}
-
-#reportPivotTable .report-field-rows table {
-  min-height: 50vh;
 }
 
 #reportPivotTable [uib-datepicker-popup-wrap] table {

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -7,9 +7,7 @@
   /**
    * Define HRReport object.
    */
-  function HRReport () {
-    this.initScrollbarFallback();
-  }
+  function HRReport () {}
 
   /**
    * Initialization function.
@@ -19,6 +17,7 @@
   HRReport.prototype.init = function (options) {
     $.extend(this, options);
     this.initAngular();
+    this.initScrollbarFallbackOnTabChange();
     this.processData(this.data);
     this.originalFilterElement = $('#report-filters').detach();
   };
@@ -408,12 +407,14 @@
    * Init the scrollbar fallback
    *
    */
-  HRReport.prototype.initScrollbarFallback = function () {
+  HRReport.prototype.initScrollbarFallbackOnTabChange = function () {
     var el = document.querySelector('.chr_custom-scrollbar');
 
-    if (el) {
-      Ps.initialize(el);
-    }
+    $('[data-tab="view-data"]').click(function () {
+      setTimeout(function () {
+        Ps.initialize(el);
+      }, 0);
+    });
   };
 
   /**
@@ -473,7 +474,6 @@
       success: function (data) {
         that.tableContainer.html(data);
         that.refreshReportTableViewInstance(tableDomId);
-        that.initScrollbarFallback();
       },
       type: 'GET'
     });

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -939,15 +939,13 @@
      * Bind tab switching events for the report tabs.
      */
     bindTabsEvents: function () {
-      var self = this;
-
-      $('.report-tabs a').bind('click', function (e) {
+      $('.report-tabs a').on('click', function (e) {
         $('.report-tabs li').removeClass('active');
-        $(this).parent().addClass('active');
+        $(e.target).parent().addClass('active');
         $('.report-block').addClass('hidden');
-        $('.report-block.' + $(this).data('tab')).removeClass('hidden');
-        self.initScrollbarFallbackOnTabChange();
-      });
+        $('.report-block.' + $(e.target).data('tab')).removeClass('hidden');
+        this.initScrollbarFallbackOnTabChange();
+      }.bind(this));
     },
     /**
      * Displays the Report Configuration's save/update/delete options depending

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -330,9 +330,12 @@
    * without breaking.
    */
   HRReport.prototype.adaptSvgProportionsToContainer = function () {
-    this.pivotTableContainer.find('svg').attr('viewBox', '0 0 800 800')
+    this.pivotTableContainer.find('svg')
       .removeAttr('width')
-      .removeAttr('height');
+      .removeAttr('height')
+      .each(function () {
+        $(this)[0].setAttribute('viewBox', '0 0 800 800');
+      });
   };
 
   /*

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -53,18 +53,18 @@
   HRReport.prototype.createReportSectionElement = function () {
     var html = '<div class="report-section">' +
       '<div class="row report-header-section">' +
-        '<div class="report-filters col-sm-3"></div>' +
-        '<div class="report-function col-sm-2 form-group">' +
+        '<div class="report-filters col-md-3"></div>' +
+        '<div class="report-function col-md-2 form-group">' +
           '<label>Chart Functions:</label>' +
           '<div class="report-function-select"></div>' +
           '<div class="report-function-group"></div>' +
         '</div>' +
-        '<div class="report-field-columns col-sm-7"><table><tr></tr></table></div>' +
+        '<div class="report-field-columns col-md-7"><table><tr></tr></table></div>' +
       '</div>' +
       '<div class="row report-content-section">' +
-        '<div class="report-fields-selection col-sm-3"><table><tr></tr></table></div>' +
-        '<div class="report-field-rows col-sm-2"><table><tr></tr></table></div>' +
-        '<div class="report-area col-sm-7"></div>' +
+        '<div class="report-fields-selection col-md-3"><table><tr></tr></table></div>' +
+        '<div class="report-field-rows col-md-2"><table><tr></tr></table></div>' +
+        '<div class="report-area col-md-7"></div>' +
       '</div>' +
     '</div>';
 

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -333,6 +333,10 @@
       .removeAttr('width')
       .removeAttr('height')
       .each(function () {
+        // The viewBox attribute is done ins this way because jQuery doesn't
+        // set it properly.
+        // The value of 800 800 was chosen because it gives the best ratio
+        // for displaying the charts.
         $(this)[0].setAttribute('viewBox', '0 0 800 800');
       });
   };

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -258,6 +258,7 @@
 
     this.updateDropdown();
     this.updateFilterbox();
+    this.adaptSvgProportionsToContainer();
   };
 
   /**
@@ -321,6 +322,17 @@
         });
       }
     });
+  };
+
+  /**
+   * Updates the SVG element proportions so it adapts them to its
+   * parent container. This helps the SVG charts to display their information
+   * without breaking.
+   */
+  HRReport.prototype.adaptSvgProportionsToContainer = function () {
+    this.pivotTableContainer.find('svg').attr('viewBox', '0 0 800 800')
+      .removeAttr('width')
+      .removeAttr('height');
   };
 
   /*

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -17,7 +17,6 @@
   HRReport.prototype.init = function (options) {
     $.extend(this, options);
     this.initAngular();
-    this.initScrollbarFallbackOnTabChange();
     this.processData(this.data);
     this.originalFilterElement = $('#report-filters').detach();
   };
@@ -405,20 +404,6 @@
   HRReport.prototype.show = function () {
     this.initPivotTable();
     this.applyFilters();
-  };
-
-  /**
-   * Init the scrollbar fallback
-   *
-   */
-  HRReport.prototype.initScrollbarFallbackOnTabChange = function () {
-    var el = document.querySelector('.chr_custom-scrollbar');
-
-    $('[data-tab="view-data"]').click(function () {
-      setTimeout(function () {
-        Ps.initialize(el);
-      }, 0);
-    });
   };
 
   /**
@@ -954,11 +939,14 @@
      * Bind tab switching events for the report tabs.
      */
     bindTabsEvents: function () {
+      var self = this;
+
       $('.report-tabs a').bind('click', function (e) {
         $('.report-tabs li').removeClass('active');
         $(this).parent().addClass('active');
         $('.report-block').addClass('hidden');
         $('.report-block.' + $(this).data('tab')).removeClass('hidden');
+        self.initScrollbarFallbackOnTabChange();
       });
     },
     /**
@@ -978,6 +966,15 @@
         deleteOption.fadeOut('fast');
         updateOption.fadeOut('fast');
       }
+    },
+    /**
+     * initializes the scrollbar fallback
+     *
+     */
+    initScrollbarFallbackOnTabChange: function () {
+      var el = document.querySelector('.chr_custom-scrollbar');
+
+      Ps.initialize(el);
     },
     /**
      * Automatically switches the current selected tab depending on the tab class


### PR DESCRIPTION
## Overview
This PR fixes the following report page issues:

* SVG charts breaking the new report layout. 
* Make the report look better in small screens, though it doesn't rearrange the elements as there are no wireframes for it.
* Fixes an issue where the data table scrolls would not appear  until scrolling with the mouse wheel or by chance.

## Before
### Desktop
![leave reports hr17 9000 13](https://user-images.githubusercontent.com/1642119/35257085-b28ba7fe-ffcd-11e7-8e82-91bbda9d8f63.png)

### Small Screens
![leave reports hr17 9000 16](https://user-images.githubusercontent.com/1642119/35257052-82a1af8e-ffcd-11e7-9715-078efe29db6f.png)


## After
### Desktop
![leave reports hr17 9000 11](https://user-images.githubusercontent.com/1642119/35256883-8873b08e-ffcc-11e7-9e03-8745eddafb6c.png)

### Small Screens
![leave reports hr17 9000 12](https://user-images.githubusercontent.com/1642119/35256939-e3bebeac-ffcc-11e7-9152-7919526ec287.png)
**Note:** Fields selection can't have a `overflow: scroll` without considerable JS changes since the draggable elements don't work well with overflowed elements.

## Scroll issue

### Before
![anim](https://user-images.githubusercontent.com/1642119/35257315-e99e8ada-ffce-11e7-9587-a15392edece7.gif)
**Notes:** The scrollbar only appears after scrolling with the mouse wheel. This is not a regression issue, it has been like that since the implementation of the report.

### After
![anim](https://user-images.githubusercontent.com/1642119/35257370-3a5d2832-ffcf-11e7-82dd-cde3d2324d7d.gif)


## Technical Details

### Moving CSS rules into SSP Theme

Some of the CSS rules for the pivot table where moved from the static [civihr_employee_portal/css/custom.css](https://github.com/compucorp/civihr-employee-portal/pull/422/files#diff-c9717edfd0ee9646951283cf7eadc4e4L229) file into [the SSP Theme](https://github.com/compucorp/civihr-employee-portal-theme/pull/302/files) because the former file should be removed at some point and all CSS rules should reside in the SSP Theme. This is a step towards that goal.

### Column breakpoints

The columns breakpoints changed from SM to MD since the line charts were breaking using the medium width.

### Adapting the SVG chart to parent container

The following method was added so the SVG charts can fit inside their parent container and adapt to its width:

```js
HRReport.prototype.adaptSvgProportionsToContainer = function () {
  this.pivotTableContainer.find('svg')
    .removeAttr('width') // No width or height = auto
    .removeAttr('height')
    .each(function () {
      // this is done so jQuery can properly set the viewBox attribute of the SVG element.
      // 0 0 are the origin coordinates
      // 800 800 were choosen because they give the best ratio to display the charts
      $(this)[0].setAttribute('viewBox', '0 0 800 800');
    });
};
```

### Fixing scrollbar issue

The problem with the scrollbar not showing up is that the `Ps.initialize(el)` only works when the DOM element is visible. To fix this, `Ps.initialize` is only executed when clicking on the "view-data" tab and a timeout is added to wait for the tabs component to properly display the data:

```js
HRReport.prototype.initScrollbarFallbackOnTabChange = function () {
  var el = document.querySelector('.chr_custom-scrollbar');

  $('[data-tab="view-data"]').click(function () {
    setTimeout(function () {
      Ps.initialize(el);
    }, 0);
  });
};
```

## Comments

All the CSS changes for this PR are included in this SSP Theme PR:
https://github.com/compucorp/civihr-employee-portal-theme/pull/302

