### PR TITLE
PCHR-3203: Tasks page modal No Result behaviour fix

### DIFF
--- a/civihr_employee_portal/views/views_export/views_tasks.inc
+++ b/civihr_employee_portal/views/views_export/views_tasks.inc
@@ -1,3 +1,5 @@
+<?php
+
 $view = new view();
 $view->name = 'Tasks';
 $view->description = '';

--- a/civihr_employee_portal/views/views_export/views_tasks.inc
+++ b/civihr_employee_portal/views/views_export/views_tasks.inc
@@ -1,5 +1,3 @@
-<?php
-
 $view = new view();
 $view->name = 'Tasks';
 $view->description = '';
@@ -267,6 +265,15 @@ $handler->display->display_options['filters']['status_id']['value'] = '2';
 $handler = $view->new_display('block', 'Completed Tasks block', 'block_1');
 $handler->display->display_options['defaults']['title'] = FALSE;
 $handler->display->display_options['title'] = 'Completed Tasks';
+$handler->display->display_options['defaults']['empty'] = FALSE;
+/* No results behavior: Global: Text area */
+$handler->display->display_options['empty']['area']['id'] = 'area';
+$handler->display->display_options['empty']['area']['table'] = 'views';
+$handler->display->display_options['empty']['area']['field'] = 'area';
+$handler->display->display_options['empty']['area']['label'] = 'No Results: Completed Tasks';
+$handler->display->display_options['empty']['area']['empty'] = TRUE;
+$handler->display->display_options['empty']['area']['content'] = '<div class="text-center"><p>No completed tasks available.</p></div>';
+$handler->display->display_options['empty']['area']['format'] = 'full_html';
 $handler->display->display_options['defaults']['fields'] = FALSE;
 /* Field: Task entity: Task entity ID */
 $handler->display->display_options['fields']['id']['id'] = 'id';
@@ -375,7 +382,7 @@ $handler->display->display_options['filters']['status_id']['id'] = 'status_id';
 $handler->display->display_options['filters']['status_id']['table'] = 'tasks';
 $handler->display->display_options['filters']['status_id']['field'] = 'status_id';
 $handler->display->display_options['filters']['status_id']['value'] = '2';
-$translatables['tasks'] = array(
+$translatables['Tasks'] = array(
   t('Master'),
   t('My Tasks'),
   t('more'),
@@ -400,4 +407,6 @@ $translatables['tasks'] = array(
   t('<a href="/civi_tasks/nojs/view_completed" class="ctools-use-modal ctools-modal-civihr-custom-large-style ctools-use-modal-processed chr_action--transparent chr_action--icon--list chr_action--icon--responsive show-complete-tasks"><span>Show completed tasks</span></a>'),
   t('Completed Tasks block'),
   t('Completed Tasks'),
+  t('No Results: Completed Tasks'),
+  t('<div class="text-center"><p>No completed tasks available.</p></div>'),
 );


### PR DESCRIPTION
## Overview
In SSP Tasks page, Show completed tasks popup does not show any notification when there are no completed tasks. This PR fixes the bug.

## Before
<img width="1219" alt="tasks___civihrnew2" src="https://user-images.githubusercontent.com/5058867/35263170-babb22f4-003d-11e8-800e-e00e00796480.png">


## After
<img width="1219" alt="tasks___civihrnew2" src="https://user-images.githubusercontent.com/5058867/35263104-714e2562-003d-11e8-8a81-ce1c768ce8d5.png">


## Technical Details
Added `NO RESULTS BEHAVIOR` to the `Completed Tasks block` in drupal.
