### PR TITLE
PCHR-3209: Add Link to Skip Onboarding

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -13,6 +13,7 @@ use Drupal\civihr_employee_portal\Forms\ContactForm;
 use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
 use Drupal\civihr_employee_portal\Page\HRDetailsPage;
 use Drupal\civihr_employee_portal\Webform\WebformTransferService;
+use Drupal\civihr_employee_portal\Helpers\LinkProvider;
 
 /**
  * Implements hook_css_alter().
@@ -4940,13 +4941,12 @@ function civihr_employee_portal_user_login_submit(&$form, &$form_state) {
  */
 function civihr_employee_portal_user_login(&$edit, $account) {
   if (!isset($_POST['form_id']) || $_POST['form_id'] != 'user_pass_reset') {
-    $sspEntryPath = 'dashboard';
-    $civicrmEntryPath = 'civicrm/tasksassignments/dashboard#/tasks';
-    $onboardingFormPath = 'onboarding-form';
 
     if (current_path() == drupal_get_destination()['destination']) {
-      $_GET['destination'] = user_access('access CiviCRM') ? $civicrmEntryPath : $sspEntryPath;
+      $_GET['destination'] = LinkProvider::getLandingPageLink($account);
     }
+
+    $onboardingFormPath = 'onboarding-form';
 
     if (_civihr_employee_portal_should_do_onboarding($account)) {
       $_GET['destination'] = $onboardingFormPath;

--- a/civihr_employee_portal/src/Forms/OnboardingWebForm.php
+++ b/civihr_employee_portal/src/Forms/OnboardingWebForm.php
@@ -5,6 +5,7 @@ namespace Drupal\civihr_employee_portal\Forms;
 use Drupal\civihr_employee_portal\Helpers\WebformHelper;
 use Drupal\civihr_employee_portal\Service\ContactService;
 use Drupal\civihr_employee_portal\Service\TaskCreationService;
+use Drupal\civihr_employee_portal\Helpers\LinkProvider;
 
 class OnboardingWebForm {
 
@@ -157,25 +158,15 @@ class OnboardingWebForm {
       return;
     }
 
-    if ($this->userCreatedAfterOnboardingReleased()) {
-      $helpText = 'Please complete your details using the onboarding wizard. '
-      . 'The data is saved directly onto your profile. You can always update '
-      . 'your details at a later date using the self service portal. You can '
-      . 'optionally skip this wizard and be reminded next time you login.';
-    } else {
-      $helpText = 'CiviHR users can now complete a quick and easy'
-        . ' wizard to enter their details into the system.<br/>Any information '
-        . 'that you have already provided to the system will be shown in the '
-        . 'wizard and can be updated.<br/><br/>You can optionally skip this '
-        . 'wizard and be reminded next time you login';
-    }
+    $helpText = $this->getHelpText();
+    $skipButtonMarkup = $this->getSkipButtonMarkup();
 
     // create a 'markup' element to show message
     $progressBarWeight = $form['progressbar']['#weight'];
     $classes = 'alert alert-success';
     $style = 'display: inline-block';
-    $format = '<p class="%s" style="%s">%s</p>';
-    $markup = sprintf($format, $classes, $style, $helpText);
+    $format = '<div class="%s" style="%s"><p>%s</p>%s</div>';
+    $markup = sprintf($format, $classes, $style, $helpText, $skipButtonMarkup);
 
     $form['submitted']['onboarding_explanation'] = [
       '#weight' => $progressBarWeight + 1,
@@ -184,20 +175,6 @@ class OnboardingWebForm {
       '#prefix' => '<div style="text-align: center;">',
       '#suffix' => '</div>'
     ];
-  }
-
-  /**
-   * Checks if the current logged in user was created after the onboarding
-   * feature was released.
-   *
-   * @return bool
-   */
-  private function userCreatedAfterOnboardingReleased() {
-    global $user;
-    $onboardingForm = WebformHelper::findOneByTitle(self::NAME);
-    $onboardingRelease = $onboardingForm->created;
-
-    return $user->created > $onboardingRelease;
   }
 
   /**
@@ -225,6 +202,62 @@ class OnboardingWebForm {
     unset($params['return']);
     $params['image_URL']  = $current;
     civicrm_api3('Contact', 'create', $params);
+  }
+
+  /**
+   * Gets the help text to show the user at the beginning of the onboarding
+   * form. Differs depending on whether they've been created before the
+   * onboarding feature was released.
+   *
+   * @return string
+   */
+  private function getHelpText() {
+    if ($this->userCreatedAfterOnboardingReleased()) {
+      return 'Please complete your details using the onboarding wizard. '
+        . 'The data is saved directly onto your profile. You can always update '
+        . 'your details at a later date using the self service portal.'
+        . '<br/><br/>You can optionally skip this wizard and be reminded next '
+        . 'time you login.';
+    } else {
+      return 'CiviHR users can now complete a quick and easy'
+        . ' wizard to enter their details into the system.<br/>Any information '
+        . 'that you have already provided to the system will be shown in the '
+        . 'wizard and can be updated.<br/><br/>You can optionally skip this '
+        . 'wizard and be reminded next time you login.';
+    }
+  }
+
+  /**
+   * Gets the markup for the button to skip the onboarding form. The button
+   * itself is wrapped in a link to the landing page for the user.
+   *
+   * @return string
+   */
+  private function getSkipButtonMarkup() {
+    $classes = 'btn btn-default-outline';
+    $style = 'float:none;';
+    $format = '<button type="button" style="%s" class="%s">%s</button>';
+    $buttonText = ts('Skip this step');
+    $buttonMarkup = sprintf($format, $style, $classes, $buttonText);
+
+    global $user;
+    $link = LinkProvider::getLandingPageLink($user);
+
+    return sprintf('<a href="%s">%s</a>', $link, $buttonMarkup);
+  }
+
+  /**
+   * Checks if the current logged in user was created after the onboarding
+   * feature was released.
+   *
+   * @return bool
+   */
+  private function userCreatedAfterOnboardingReleased() {
+    global $user;
+    $onboardingForm = WebformHelper::findOneByTitle(self::NAME);
+    $onboardingRelease = $onboardingForm->created;
+
+    return $user->created > $onboardingRelease;
   }
 
 }

--- a/civihr_employee_portal/src/Forms/OnboardingWebForm.php
+++ b/civihr_employee_portal/src/Forms/OnboardingWebForm.php
@@ -145,10 +145,6 @@ class OnboardingWebForm {
    * @param array $form
    */
   private function addHelpText(&$form) {
-    $helpText = 'CiviHR users can now complete a quick and easy'
-      . ' wizard to enter their details into the system.<br/>Any information '
-      . 'that you have already provided to the system will be shown in the '
-      . 'wizard and can be updated.';
 
     if (!isset($form['progressbar']['#page_num'])) {
       return;
@@ -157,8 +153,21 @@ class OnboardingWebForm {
     $currentPage = $form['progressbar']['#page_num'];
     $isFirstPage = $currentPage === 1;
 
-    if (!$isFirstPage || $this->userCreatedAfterOnboardingReleased()) {
+    if (!$isFirstPage) {
       return;
+    }
+
+    if ($this->userCreatedAfterOnboardingReleased()) {
+      $helpText = 'Please complete your details using the onboarding wizard. '
+      . 'The data is saved directly onto your profile. You can always update '
+      . 'your details at a later date using the self service portal. You can '
+      . 'optionally skip this wizard and be reminded next time you login.';
+    } else {
+      $helpText = 'CiviHR users can now complete a quick and easy'
+        . ' wizard to enter their details into the system.<br/>Any information '
+        . 'that you have already provided to the system will be shown in the '
+        . 'wizard and can be updated.<br/><br/>You can optionally skip this '
+        . 'wizard and be reminded next time you login';
     }
 
     // create a 'markup' element to show message

--- a/civihr_employee_portal/src/Forms/OnboardingWebForm.php
+++ b/civihr_employee_portal/src/Forms/OnboardingWebForm.php
@@ -237,7 +237,7 @@ class OnboardingWebForm {
     $classes = 'btn btn-default-outline';
     $style = 'float:none;';
     $format = '<button type="button" style="%s" class="%s">%s</button>';
-    $buttonText = ts('Skip this step');
+    $buttonText = ts('Skip and Remind Me Later');
     $buttonMarkup = sprintf($format, $style, $classes, $buttonText);
 
     global $user;

--- a/civihr_employee_portal/src/Forms/OnboardingWebForm.php
+++ b/civihr_employee_portal/src/Forms/OnboardingWebForm.php
@@ -213,7 +213,7 @@ class OnboardingWebForm {
    */
   private function getHelpText() {
     if ($this->userCreatedAfterOnboardingReleased()) {
-      return 'Please complete your details using the onboarding wizard. '
+      return 'Please complete your details using the onboarding wizard.<br/>'
         . 'The data is saved directly onto your profile. You can always update '
         . 'your details at a later date using the self service portal.'
         . '<br/><br/>You can optionally skip this wizard and be reminded next '

--- a/civihr_employee_portal/src/Forms/OnboardingWebForm.php
+++ b/civihr_employee_portal/src/Forms/OnboardingWebForm.php
@@ -235,9 +235,9 @@ class OnboardingWebForm {
    */
   private function getSkipButtonMarkup() {
     $classes = 'btn btn-default chr_onboarding-wizard_remind-me-later';
-    $format = '<button type="button" style="%s" class="%s">%s</button>';
+    $format = '<button type="button" class="%s">%s</button>';
     $buttonText = ts('Skip and Remind Me Later');
-    $buttonMarkup = sprintf($format, null, $classes, $buttonText);
+    $buttonMarkup = sprintf($format, $classes, $buttonText);
 
     global $user;
     $link = LinkProvider::getLandingPageLink($user);

--- a/civihr_employee_portal/src/Forms/OnboardingWebForm.php
+++ b/civihr_employee_portal/src/Forms/OnboardingWebForm.php
@@ -234,11 +234,10 @@ class OnboardingWebForm {
    * @return string
    */
   private function getSkipButtonMarkup() {
-    $classes = 'btn btn-default-outline';
-    $style = 'float:none;';
+    $classes = 'btn btn-default chr_onboarding-wizard_remind-me-later';
     $format = '<button type="button" style="%s" class="%s">%s</button>';
     $buttonText = ts('Skip and Remind Me Later');
-    $buttonMarkup = sprintf($format, $style, $classes, $buttonText);
+    $buttonMarkup = sprintf($format, null, $classes, $buttonText);
 
     global $user;
     $link = LinkProvider::getLandingPageLink($user);

--- a/civihr_employee_portal/src/Helpers/LinkProvider.php
+++ b/civihr_employee_portal/src/Helpers/LinkProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\civihr_employee_portal\Helpers;
+
+/**
+ * Provides links to different parts of the site
+ */
+class LinkProvider {
+
+  const SSP_DASHBOARD = 'dashboard';
+  const TASKS_DASHBOARD = 'civicrm/tasksassignments/dashboard#/tasks';
+
+  /**
+   * Gets the link where the user should be redirected to after login.
+   * Depending on user permissions the landing page will be different.
+   *
+   * @param array $user
+   *   The Drupal user to provide the link for
+   *
+   * @return string
+   *   The link to the landing page
+   */
+  public static function getLandingPageLink($user) {
+    $canAccessCiviCRM = user_access('access CiviCRM', $user);
+
+    return $canAccessCiviCRM ? self::TASKS_DASHBOARD : self::SSP_DASHBOARD;
+  }
+
+}


### PR DESCRIPTION
## Overview

Based on client feedback some people felt that there should be an option to skip the onboarding form. We [previously](https://github.com/compucorp/civihr-employee-portal/pull/387) added a description for users who had been created before the onboarding release. This description will be extended to all users, but the content will depend on whether they are users created before the onboarding release.

## Before

- There was no button to skip the onboarding form
- Only users created before the onboarding form release were shown a message explaining the form

#### Users created before onboarding:

![image](https://user-images.githubusercontent.com/6374064/35333830-19b3c8a4-0108-11e8-9e05-28fbda92512c.png)

#### Users created after onboarding

![image](https://user-images.githubusercontent.com/6374064/35333865-3b69997e-0108-11e8-818e-8e1f029fe138.png)

## After

- There is a button to skip the onboarding form
- All users will have a description of the onboarding form
- The description will differ depending on whether they were created before the onboarding form release
- The link will bring users with "Access CiviCRM" permission to the tasks dashboard, and those without this permission to the SSP dashboard.

#### Users created before onboarding:

![image](https://user-images.githubusercontent.com/6374064/35333918-70441a5c-0108-11e8-9925-298c7885b1fd.png)

#### Users created after onboarding

![image](https://user-images.githubusercontent.com/6374064/35334017-cc7b0a24-0108-11e8-9556-e042c579bff4.png)

## Notes
- The styles for the `Remind Me` Button has been fixed in https://github.com/compucorp/civihr-employee-portal-theme/pull/309. There the updated screenshots can be found.
- The same code to find the landing page would be used in two places, so I moved it to a new class, the `LinkProvider`

---

- [ ] Tests Pass
Some tests are not running because they depend on custom groups being present. I'll fix these in a separate ticket since they're not related to this.