### PR TITLE
PCHR-3202: Add helper class for backstop

### DIFF
--- a/civihr_employee_portal/views/templates/views-view-table--Tasks--block.tpl.php
+++ b/civihr_employee_portal/views/templates/views-view-table--Tasks--block.tpl.php
@@ -125,7 +125,11 @@ foreach ($rows as $row) {
 <?php if (user_access('can create and edit tasks')): ?>
   <div class="chr_panel__footer">
     <div class="chr_actions-wrapper">
-      <a href="/civi_tasks/nojs/create" class="chr_action ctools-use-modal ctools-modal-civihr-custom-style ctools-use-modal-processed">Create new task</a>
+      <a
+        href="/civi_tasks/nojs/create"
+        class="chr_action ctools-use-modal ctools-modal-civihr-custom-style ctools-use-modal-processed create-new-task">
+        Create new task
+      </a>
     </div>
   </div>
 <?php endif; ?>


### PR DESCRIPTION
## Overview
This PR adds a helper class `create-new-task` for the backstop js tests in https://github.com/civicrm/civihr/pull/2426
