### PR TITLE
PCHR-3223: Rename HR Admin link

### DIFF
--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.features.menu_links.inc
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.features.menu_links.inc
@@ -155,7 +155,7 @@ function civihr_employee_portal_features_menu_default_menu_links() {
     'menu_name' => 'main-menu',
     'link_path' => 'civicrm',
     'router_path' => 'civicrm',
-    'link_title' => 'HR admin',
+    'link_title' => 'HR Admin',
     'options' => array(
       'identifier' => 'main-menu_hr-admin:civicrm',
       'roles_for_menu' => array(
@@ -410,8 +410,8 @@ function civihr_employee_portal_features_menu_default_menu_links() {
   // Translatables
   // Included for use with string extractors like potx.
   t('Age groups');
+  t('HR Admin');
   t('HR Resources');
-  t('HR admin');
   t('Help');
   t('Home');
   t('Leave Reports');


### PR DESCRIPTION
## Overview
This PR renames the "HR admin" link on the SSP menu to "HR Admin" (capital A).

## Before
![dashboard hr17 9100 2](https://user-images.githubusercontent.com/1642119/35444646-908ecce8-0285-11e8-8c5a-a1d03982f554.png)

## After
![dashboard hr17 9100 1](https://user-images.githubusercontent.com/1642119/35444649-929e5648-0285-11e8-81e8-20581f441f88.png)

## Technical Details
The HR Admin menu link was updated using the Admin Structure interface. Only the changes related to the link renaming were committed since there is another [issue with the Report Settings block](https://compucorp.atlassian.net/browse/PCHR-3223?focusedCommentId=65854&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-65854) that needs to be addressed separately.


