### PR TITLE
PCHR-3090: Fix Smarty Warnings

### DIFF
--- a/civihr_employee_portal/templates/smarty/user_account_activated.tpl
+++ b/civihr_employee_portal/templates/smarty/user_account_activated.tpl
@@ -7,7 +7,9 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width">
     <title>Welcome to CiviHR!</title>
-    <style>@media only screen {
+    {literal}
+    <style>
+        @media only screen {
             html {
                 min-height: 100%;
                 background: #E8EEF0;
@@ -80,7 +82,9 @@
             .request-data .row .columns {
                 padding-bottom: 10px !important;
             }
-        }</style>
+        }
+    </style>
+    {/literal}
 </head>
 <body style="-moz-box-sizing: border-box; -ms-text-size-adjust: 100%; -webkit-box-sizing: border-box; -webkit-text-size-adjust: 100%; Margin: 0; box-sizing: border-box; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; min-width: 100%; padding: 0; text-align: left; width: 100% !important;">
 <table class="body" style="Margin: 0; background: #E8EEF0; border-collapse: collapse; border-spacing: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; height: 100%; line-height: 1.53846; margin: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">

--- a/civihr_employee_portal/templates/smarty/user_password_reset.tpl
+++ b/civihr_employee_portal/templates/smarty/user_password_reset.tpl
@@ -7,7 +7,9 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width">
     <title>Password Reset</title>
-    <style>@media only screen {
+    {literal}
+    <style>
+        @media only screen {
             html {
                 min-height: 100%;
                 background: #E8EEF0;
@@ -80,7 +82,9 @@
             .request-data .row .columns {
                 padding-bottom: 10px !important;
             }
-        }</style>
+        }
+    </style>
+    {/literal}
 </head>
 <body style="-moz-box-sizing: border-box; -ms-text-size-adjust: 100%; -webkit-box-sizing: border-box; -webkit-text-size-adjust: 100%; Margin: 0; box-sizing: border-box; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 1.53846; margin: 0; min-width: 100%; padding: 0; text-align: left; width: 100% !important;">
 <table class="body" style="Margin: 0; background: #E8EEF0; border-collapse: collapse; border-spacing: 0; color: #727E8A; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; height: 100%; line-height: 1.53846; margin: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">


### PR DESCRIPTION
## Overview

When sending the password reset email, or the user account creation email for the first time, a large number of warnings will appear mentioning unknown tags in the smarty templates. 

## Before

The first time the user account creation email, or the password reset email was sent it would generate a lot of warnings. The mail was still sent, and because templates are cached the warnings would not appear again. After clearing the `civicrm` cache the warnings would return another (single) time.

#### User Account Creation

![image](https://user-images.githubusercontent.com/6374064/35854322-f999deee-0b27-11e8-939e-e003c996b7e0.png)

#### Password Reset

![image](https://user-images.githubusercontent.com/6374064/35854363-13b7c156-0b28-11e8-851d-068bfbd65fac.png)

## After

Even with a clean cache no warnings are produced when sending the user account creation or password reset emails.

#### User Account Creation

![image](https://user-images.githubusercontent.com/6374064/35854814-541f7878-0b29-11e8-9fe1-28526ae4851d.png)

#### Password Reset

![image](https://user-images.githubusercontent.com/6374064/35854771-2d215aa2-0b29-11e8-8cb9-9eaffa0b6bc0.png)

## Technical Details

The warnings are generated because smarty tries to interpret the `<style>` element and finds curly braces. Smarty uses curly braces to designate a block that it should parse, similar to how PHP will parse code between the `<?php` tags.

Smarty offers a `{literal}` tag to avoid parsing anything between these opening and closing tags.

---

- [x] Tests Pass
