### PR TITLE
PCHR-3269: Fix Image Query Params

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.install
+++ b/civihr_employee_portal/civihr_employee_portal.install
@@ -330,7 +330,7 @@ function civihr_employee_portal_update_7021() {
 /**
  * Fixes contact images that have multiple 'photo' query params.
  */
-function civihr_employee_portal_update_7021() {
+function civihr_employee_portal_update_7022() {
   civicrm_initialize();
   $params = ['return' => ['image_URL']];
   $contacts = civicrm_api3('Contact', 'get', $params)['values'];

--- a/civihr_employee_portal/civihr_employee_portal.install
+++ b/civihr_employee_portal/civihr_employee_portal.install
@@ -2,6 +2,7 @@
 
 use Drupal\civihr_employee_portal\Helpers\WebformHelper;
 use Drupal\civihr_employee_portal\Forms\OnboardingWebForm;
+use Drupal\civihr_employee_portal\Helpers\UrlHelper;
 
 /**
  * Create Report Pages and Report Age Settings menu links.
@@ -327,9 +328,28 @@ function civihr_employee_portal_update_7021() {
 }
 
 /**
+ * Fixes contact images that have multiple 'photo' query params.
+ */
+function civihr_employee_portal_update_7021() {
+  civicrm_initialize();
+  $params = ['return' => ['image_URL']];
+  $contacts = civicrm_api3('Contact', 'get', $params)['values'];
+
+  foreach ($contacts as $contact) {
+    $imageUrl = $contact['image_URL'];
+    $dedupedImageUrl = UrlHelper::dedupeUrlQueryParams($imageUrl);
+
+    if ($imageUrl !== $dedupedImageUrl) {
+      $params = ['image_URL' => $dedupedImageUrl, 'id' => $contact['id']];
+      civicrm_api3('Contact', 'create', $params);
+    }
+  }
+}
+
+/**
  * Function to determine whether menu link exists or not.
  *
- * @param string
+ * @param string $path
  *   Path of the menu link.
  *
  * @return bool

--- a/civihr_employee_portal/src/Forms/OnboardingWebForm.php
+++ b/civihr_employee_portal/src/Forms/OnboardingWebForm.php
@@ -196,6 +196,11 @@ class OnboardingWebForm {
       return;
     }
 
+    parse_str(parse_url($current, PHP_URL_QUERY), $queryParts);
+    if (isset($queryParts['photo'])) {
+      return;
+    }
+
     $operator = FALSE === strpos($current, '?') ? '?' : '&';
     $current .= $operator . 'photo=0';
 

--- a/civihr_employee_portal/src/Forms/OnboardingWebForm.php
+++ b/civihr_employee_portal/src/Forms/OnboardingWebForm.php
@@ -196,6 +196,7 @@ class OnboardingWebForm {
       return;
     }
 
+    // don't append to url if photo is already set
     parse_str(parse_url($current, PHP_URL_QUERY), $queryParts);
     if (isset($queryParts['photo'])) {
       return;

--- a/civihr_employee_portal/src/Helpers/UrlHelper.php
+++ b/civihr_employee_portal/src/Helpers/UrlHelper.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\civihr_employee_portal\Helpers;
+
+class UrlHelper {
+
+  /**
+   * Removes duplicate query parts from a url. Accepts the value for the first
+   * part.
+   *
+   * @param string $url
+   *
+   * @return string
+   */
+  public static function dedupeUrlQueryParams($url) {
+    $origQueryString = parse_url($url, PHP_URL_QUERY);
+    $queryParts = explode('&', $origQueryString);
+
+    $queryPartsUnique = [];
+    foreach ($queryParts as $queryPart) {
+      list($key) = explode('=', $queryPart);
+      if (!isset($queryPartsUnique[$key])) {
+        $queryPartsUnique[$key] = $queryPart;
+      }
+    }
+
+    $newQueryString = implode('&', $queryPartsUnique);
+
+    return str_replace($origQueryString, $newQueryString, $url);
+  }
+
+}

--- a/civihr_employee_portal/src/Helpers/UrlHelper.php
+++ b/civihr_employee_portal/src/Helpers/UrlHelper.php
@@ -20,8 +20,14 @@ class UrlHelper {
     $queryParts = explode('&', $origQueryString);
 
     $queryPartsUnique = [];
-    foreach ($queryParts as $queryPart) {
+    foreach ($queryParts as $index => $queryPart) {
       list($key) = explode('=', $queryPart);
+
+      // give unique key to query params like foo[]=bar
+      if (substr($key, -2) === '[]') {
+        $key = $key . $index;
+      }
+
       if (!isset($queryPartsUnique[$key])) {
         $queryPartsUnique[$key] = $queryPart;
       }

--- a/civihr_employee_portal/src/Helpers/UrlHelper.php
+++ b/civihr_employee_portal/src/Helpers/UrlHelper.php
@@ -2,6 +2,9 @@
 
 namespace Drupal\civihr_employee_portal\Helpers;
 
+/**
+ * Helper class for operations on URLs
+ */
 class UrlHelper {
 
   /**

--- a/civihr_employee_portal/tests/Helpers/UrlHelperTest.php
+++ b/civihr_employee_portal/tests/Helpers/UrlHelperTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use Drupal\civihr_employee_portal\Helpers\UrlHelper;
+
+class UrlHelperTest extends \PHPUnit_Framework_TestCase {
+
+  /**
+   * @dataProvider duplicateQueryUrlProvider
+   *
+   * @param string $url
+   * @param string $expected
+   */
+  public function testDedupeWillReturnExpectedResults($url, $expected) {
+    $this->assertEquals($expected, UrlHelper::dedupeUrlQueryParams($url));
+  }
+
+  /**
+   * @return array
+   */
+  public function duplicateQueryUrlProvider() {
+    return [
+      [
+        '',
+        '',
+      ],
+      [
+        'http://www.civihr.net',
+        'http://www.civihr.net',
+      ],
+      [
+        'http://civihr.net/sites/default/files/webform/500_3.jpg?photo=0&photo=0&photo=0&photo=0&photo=0&photo=0',
+        'http://civihr.net/sites/default/files/webform/500_3.jpg?photo=0',
+      ],
+      [
+        'http://civihr.local/civicrm/contact/imagefile?photo=pp_2e6adadea8d41b0ac065e888f2e61dc5.jpeg',
+        'http://civihr.local/civicrm/contact/imagefile?photo=pp_2e6adadea8d41b0ac065e888f2e61dc5.jpeg',
+      ],
+      [
+        'http://civihr.local/civicrm/contact/imagefile?photo=pp_2e6adadea8d41b0ac065e888f2e61dc5.jpeg&photo=0',
+        'http://civihr.local/civicrm/contact/imagefile?photo=pp_2e6adadea8d41b0ac065e888f2e61dc5.jpeg',
+      ],
+      [
+        'http://www.civihr.net?foo=bar&bar=car&foo=bar2&bar=car2#someanchor',
+        'http://www.civihr.net?foo=bar&bar=car#someanchor',
+      ],
+    ];
+  }
+
+}

--- a/civihr_employee_portal/tests/Helpers/UrlHelperTest.php
+++ b/civihr_employee_portal/tests/Helpers/UrlHelperTest.php
@@ -43,6 +43,26 @@ class UrlHelperTest extends \PHPUnit_Framework_TestCase {
         'http://www.civihr.net?foo=bar&bar=car&foo=bar2&bar=car2#someanchor',
         'http://www.civihr.net?foo=bar&bar=car#someanchor',
       ],
+      [
+        'http://www.civihr.net?foo[]=1&foo[]=2&bar[a]=3',
+        'http://www.civihr.net?foo[]=1&foo[]=2&bar[a]=3',
+      ],
+      [
+        'http://www.civihr.net?foo[]=1&foo[]=2&1=a',
+        'http://www.civihr.net?foo[]=1&foo[]=2&1=a',
+      ],
+      [
+        'http://www.civihr.net?foo[]=1&foo[]=2&foo[a]=1&foo[a]=2',
+        'http://www.civihr.net?foo[]=1&foo[]=2&foo[a]=1',
+      ],
+      [
+        'http://www.civihr.net?foo[a][]=1&foo[a][]=2',
+        'http://www.civihr.net?foo[a][]=1&foo[a][]=2',
+      ],
+      [
+        'http://www.civihr.net?foo[a][b]=1&foo[a][b]=2',
+        'http://www.civihr.net?foo[a][b]=1',
+      ],
     ];
   }
 


### PR DESCRIPTION
## Overview

During the course of onboarding testing we discovered that when using the image uploaded from the webform for a contact image CiviCRM would show a warning about [an undefined "photo" index.](https://github.com/civicrm/civicrm-core/blob/17ae6ca46f1d544d40e5bfb77ab6727975ba7e17/CRM/Utils/File.php#L913).

To fix this I made [this commit](https://github.com/compucorp/civihr-employee-portal/pull/406/commits/92cc1dffd0f20040f1a58c2cf8ded77896eafbe1) to add `photo=0` to images when the onboarding form was submitted. This fixed the warning and both regular images and images saved from the webform were displayed without warning.

Unfortunately I did not consider this case:

1. A contact was created and somebody uploaded an image for them
1. This contact logs in and goes through the onboarding form
1. They do not upload their own image, so the existing image URL is used
1. This image URL is not stored by the webform, it's a regular `civicrm/contact/imagefile?photo=<imagename>` because an extra `photo=0` is still appended to the end it breaks the URL

## Before

* If a user with an existing contact image does the onboarding form an errant `photo=0` will be appended to their image URL, breaking the URL
* If a user redoes the onboarding form an extra `photo=0` will be appended to their image URL

Examples

|Image URL Before Onboarding|Image URL After Onboarding|
|--|--|
|`/civicrm/contact/imagefile?photo=cat.jpeg`|`/civicrm/contact/imagefile?photo=cat.jpeg&photo=0`|
|`/sites/default/files/webform/500_3.jpg?photo=0`|`/sites/default/files/webform/500_3.jpg?photo=0&photo=0`|

## After

* Users can complete the onboarding form as many times as they want, and their image URL will not be broken.
* Any existing image URLs with duplicate query parameters will be fixed

## Notes

It's possible that in production some administrators created contacts, uploaded their images, and then created accounts for these people. If these people logged in afterwards and complete onboarding _without_ changing their image, their image URLs would be broken, so I added an upgrader to fix these cases.

---

- [x] Tests Pass
