### PR TITLE
PCHR-3285: Redirect from the SSP report pages to the CiviHR admin

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5039,6 +5039,11 @@ function civihr_employee_portal_my_details() {
  * CiviHR Report - Landing page
  */
 function civihr_employee_portal_hrreport_landing_page() {
+  // This page can only be accessed via the CiviHR admin
+  if(empty($_GET['iframe'])) {
+    drupal_goto('/civicrm/reports');
+  }
+
   $jsOptions = ['type' => 'file', 'scope' => 'footer'];
 
   if (_civihr_employee_portal_is_extension_enabled('org.civicrm.reqangular')) {
@@ -5436,6 +5441,11 @@ function civihr_employee_portal_hrreport_printtable($viewName) {
  * @return array
  */
 function civihr_employee_portal_hrreport_custom($reportName) {
+  // This page can only be accessed via the CiviHR admin
+  if(empty($_GET['iframe'])) {
+    drupal_goto("/civicrm/reports/{$reportName}");
+  }
+
   _rebuild_reports_views();
 
   $view = views_get_view('civihr_report_' . $reportName);

--- a/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-landing-page.tpl.php
+++ b/civihr_employee_portal/templates/civihr-employee-portal-civihr-report-landing-page.tpl.php
@@ -3,7 +3,7 @@
 foreach ($menu as $item):
 ?>
     <li class="panel-pane pane-block chr_panel chr_panel--small-text">
-        <a href="<?php print $item['link_path']; ?>">
+        <a href="<?php print $item['link_path']; ?>?iframe=1">
             <h2 class="chr_panel__header chr_panel__header--with-border panel-title u-font-size-big">
               <span class="chr_panel__header-subtitle">
                 <?php print $item['link_title']; ?>


### PR DESCRIPTION
## Overview

On https://github.com/compucorp/civihr-employee-portal/pull/434, we made the SSP reports accessible in the CiviHR admin, using iframes. 

On the SSP, the report pages were updated to render without any surrounding elements (headers, footers, etc), so that, when displayed inside an iframe, they would look like as being part of the page. However, it's possible that some users have bookmarked these pages and, if they try to access them, they will see only the iframe contents. To fix this, we will now redirect any direct access to the reports in the SSP to the respective URLs in the CiviHR admin.

## Before

Users could access the report pages directly from the SSP. This would result in them seeing an almost empty page, without headers and footers.

## After

If users try to access the report pages directly from the SSP, they will be redirected to the respective page in the CiviHR admin, where the report is displayed inside an iframe.

## Technical Details

To know that a page is being displayed inside an iframe, we check for the presence of the `iframe` param in the URL. On https://github.com/civicrm/civihr/pull/2475, the report page on the CiviHR admin was updated to always pass that param to the iframe. The template for the reports landing page also had to be updated, to make sure the links to the reports will include the param as well. Otherwise, when clicking the link, the user would be redirected to the CiviHR admin again.

Also as part of https://github.com/civicrm/civihr/pull/2475, specific URLs for each of the reports were added. In case a user has a bookmark to one specific report, this will allows us to redirect him directly to that report on the CiviHR admin, instead of the landing page.


