### PR TITLE
PCHR-3283: Remove the views_json_query dependency from the SSP

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.info
+++ b/civihr_employee_portal/civihr_employee_portal.info
@@ -18,7 +18,6 @@ dependencies[] = panels
 dependencies[] = rules
 dependencies[] = rules_admin
 dependencies[] = entity
-dependencies[] = views_json_query
 dependencies[] = views_block_area
 dependencies[] = jquery_update
 dependencies[] = webform
@@ -61,7 +60,6 @@ files[] = views/includes/civihr_employee_portal_handler_appraisal_line_manager.i
 files[] = views/includes/civihr_employee_portal_handler_appraisal_due_date.inc
 files[] = views/includes/civihr_employee_portal_handler_tasks_date.inc
 files[] = views/includes/civihr_employee_portal_handler_documents_date.inc
-files[] = views/includes/views_json_query_argument_request_handler.inc
 files[] = views/includes/views_between_dates_filter_handler.inc
 
 ; Reports Views handlers

--- a/civihr_employee_portal/civihr_employee_portal.install
+++ b/civihr_employee_portal/civihr_employee_portal.install
@@ -347,6 +347,15 @@ function civihr_employee_portal_update_7022() {
 }
 
 /**
+ * Uninstall the views_json_query module
+ */
+function civihr_employee_portal_update_7023() {
+  $modules = ['views_json_query'];
+  module_disable(['views_json_query']);
+  drupal_uninstall_modules($modules);
+}
+
+/**
  * Function to determine whether menu link exists or not.
  *
  * @param string $path

--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -58,7 +58,7 @@ function civihr_employee_portal_views_data_alter(&$data) {
       'click sortable' => TRUE,
     ),
     'argument' => array(
-      'handler' => 'views_json_query_argument_request_handler',
+      'handler' => 'views_handler_argument',
       'name field' => 'birth_date',
       'numeric' => FALSE
     ),
@@ -426,7 +426,6 @@ function civihr_employee_portal_views_data_alter(&$data) {
       'handler' => 'views_handler_filter_string',
       'help' => t('Filter results to a particular result set'),
     ),
-    'sort' => array('handler' => 'views_json_query_handler_sort'),
   );
   $data['tasks']['activity_type_id'] = array(
     'title' => t('Task type'),
@@ -513,7 +512,6 @@ function civihr_employee_portal_views_data_alter(&$data) {
       'handler' => 'views_handler_filter_string',
       'help' => t('Filter results to a particular result set'),
     ),
-    'sort' => array('handler' => 'views_json_query_handler_sort'),
   );
   $data['documents']['activity_type_id'] = array(
     'title' => t('Document type'),
@@ -567,15 +565,14 @@ function civihr_employee_portal_views_data_alter(&$data) {
       'click sortable' => TRUE,
     ),
     'argument' => array(
-      'handler' => 'views_json_query_argument_request_handler',
+      'handler' => 'views_handler_argument',
       'name_field' => 'end_reason',
       'string' => TRUE
     ),
     'filter' => array(
-      'handler' => 'views_json_query_handler_filter',
+      'handler' => 'views_handler_filter_string',
       'help' => t('Filter results to a particular result set'),
     ),
-    'sort' => array('handler' => 'views_json_query_handler_sort'),
   );
   $data['hrjc_hour']['location_standard_hours'] = array(
     'title' => t('Contract location standard hours'),
@@ -585,15 +582,14 @@ function civihr_employee_portal_views_data_alter(&$data) {
       'click sortable' => TRUE,
     ),
     'argument' => array(
-      'handler' => 'views_json_query_argument_request_handler',
+      'handler' => 'views_handler_argument',
       'name_field' => 'location_standard_hours',
       'string' => TRUE
     ),
     'filter' => array(
-      'handler' => 'views_json_query_handler_filter',
+      'handler' => 'views_handler_filter_string',
       'help' => t('Filter results to a particular result set'),
     ),
-    'sort' => array('handler' => 'views_json_query_handler_sort'),
   );
   $data['hrjc_pay']['pay_scale'] = array(
     'title' => t('Contract pay scale'),
@@ -603,15 +599,14 @@ function civihr_employee_portal_views_data_alter(&$data) {
       'click sortable' => TRUE,
     ),
     'argument' => array(
-      'handler' => 'views_json_query_argument_request_handler',
+      'handler' => 'views_handler_argument',
       'name_field' => 'pay_scale',
       'string' => TRUE
     ),
     'filter' => array(
-      'handler' => 'views_json_query_handler_filter',
+      'handler' => 'views_handler_filter_string',
       'help' => t('Filter results to a particular result set'),
     ),
-    'sort' => array('handler' => 'views_json_query_handler_sort'),
   );
   $data['hrjc_pension']['is_enrolled'] = array(
     'title' => t('Contract pension is enrolled'),
@@ -621,15 +616,14 @@ function civihr_employee_portal_views_data_alter(&$data) {
       'click sortable' => TRUE,
     ),
     'argument' => array(
-      'handler' => 'views_json_query_argument_request_handler',
+      'handler' => 'views_handler_argument',
       'name_field' => 'is_enrolled',
       'string' => TRUE
     ),
     'filter' => array(
-      'handler' => 'views_json_query_handler_filter',
+      'handler' => 'views_handler_filter_string',
       'help' => t('Filter results to a particular result set'),
     ),
-    'sort' => array('handler' => 'views_json_query_handler_sort'),
   );
   $data['hrjc_role']['role_funder'] = array(
     'title' => t('Role funder'),
@@ -639,15 +633,14 @@ function civihr_employee_portal_views_data_alter(&$data) {
       'click sortable' => TRUE,
     ),
     'argument' => array(
-      'handler' => 'views_json_query_argument_request_handler',
+      'handler' => 'views_handler_argument',
       'name_field' => 'role_funder',
       'string' => TRUE
     ),
     'filter' => array(
-      'handler' => 'views_json_query_handler_filter',
+      'handler' => 'views_handler_filter_string',
       'help' => t('Filter results to a particular result set'),
     ),
-    'sort' => array('handler' => 'views_json_query_handler_sort'),
   );
   $data['hrjc_role']['role_percent_pay_funder'] = array(
     'title' => t('Role percent pay funder'),
@@ -657,15 +650,14 @@ function civihr_employee_portal_views_data_alter(&$data) {
       'click sortable' => TRUE,
     ),
     'argument' => array(
-      'handler' => 'views_json_query_argument_request_handler',
+      'handler' => 'views_handler_argument',
       'name_field' => 'role_percent_pay_funder',
       'string' => TRUE
     ),
     'filter' => array(
-      'handler' => 'views_json_query_handler_filter',
+      'handler' => 'views_handler_filter_string',
       'help' => t('Filter results to a particular result set'),
     ),
-    'sort' => array('handler' => 'views_json_query_handler_sort'),
   );
   $data['hrjc_role']['role_cost_center'] = array(
     'title' => t('Role cost center'),
@@ -675,15 +667,14 @@ function civihr_employee_portal_views_data_alter(&$data) {
       'click sortable' => TRUE,
     ),
     'argument' => array(
-      'handler' => 'views_json_query_argument_request_handler',
+      'handler' => 'views_handler_argument',
       'name_field' => 'role_cost_center',
       'string' => TRUE
     ),
     'filter' => array(
-      'handler' => 'views_json_query_handler_filter',
+      'handler' => 'views_handler_filter_string',
       'help' => t('Filter results to a particular result set'),
     ),
-    'sort' => array('handler' => 'views_json_query_handler_sort'),
   );
   $data['hrjc_role']['role_percent_pay_cost_center'] = array(
     'title' => t('Role percent pay cost center'),
@@ -693,15 +684,14 @@ function civihr_employee_portal_views_data_alter(&$data) {
       'click sortable' => TRUE,
     ),
     'argument' => array(
-      'handler' => 'views_json_query_argument_request_handler',
+      'handler' => 'views_handler_argument',
       'name_field' => 'role_percent_pay_cost_center',
       'string' => TRUE
     ),
     'filter' => array(
-      'handler' => 'views_json_query_handler_filter',
+      'handler' => 'views_handler_filter_string',
       'help' => t('Filter results to a particular result set'),
     ),
-    'sort' => array('handler' => 'views_json_query_handler_sort'),
   );
 
   $data['absence_activity']['absence_duration_days'] = array(
@@ -711,15 +701,14 @@ function civihr_employee_portal_views_data_alter(&$data) {
       'click sortable' => TRUE,
     ),
     'argument' => array(
-      'handler' => 'views_json_query_argument_request_handler',
+      'handler' => 'views_handler_argument',
       'name_field' => 'absence_duration_days',
       'string' => TRUE
     ),
     'filter' => array(
-      'handler' => 'views_json_query_handler_filter',
+      'handler' => 'views_handler_filter_string',
       'help' => t('Filter results to a particular result set'),
     ),
-    'sort' => array('handler' => 'views_json_query_handler_sort'),
   );
 
   $data['absence_activity']['absence_duration_hours'] = array(
@@ -729,17 +718,16 @@ function civihr_employee_portal_views_data_alter(&$data) {
       'click sortable' => TRUE,
     ),
     'argument' => array(
-      'handler' => 'views_json_query_argument_request_handler',
+      'handler' => 'views_handler_argument',
       'name_field' => 'absence_duration_hours',
       'string' => TRUE
     ),
     'filter' => array(
-      'handler' => 'views_json_query_handler_filter',
+      'handler' => 'views_handler_filter_string',
       'help' => t('Filter results to a particular result set'),
     ),
-    'sort' => array('handler' => 'views_json_query_handler_sort'),
   );
-  
+
   $data['absence_activity']['absence_amount_taken'] = array(
     'title' => t('Absence amount taken'),
     'real field' => 'absence_amount_taken',
@@ -747,15 +735,14 @@ function civihr_employee_portal_views_data_alter(&$data) {
       'click sortable' => TRUE,
     ),
     'argument' => array(
-      'handler' => 'views_json_query_argument_request_handler',
+      'handler' => 'views_handler_argument',
       'name_field' => 'absence_amount_taken',
       'string' => TRUE
     ),
     'filter' => array(
-      'handler' => 'views_json_query_handler_filter',
+      'handler' => 'views_handler_filter_string',
       'help' => t('Filter results to a particular result set'),
     ),
-    'sort' => array('handler' => 'views_json_query_handler_sort'),
   );
   $data['absence_activity']['absence_amount_accrued'] = array(
     'title' => t('Absence amount accrued'),
@@ -764,15 +751,14 @@ function civihr_employee_portal_views_data_alter(&$data) {
       'click sortable' => TRUE,
     ),
     'argument' => array(
-      'handler' => 'views_json_query_argument_request_handler',
+      'handler' => 'views_handler_argument',
       'name_field' => 'absence_amount_accrued',
       'string' => TRUE
     ),
     'filter' => array(
-      'handler' => 'views_json_query_handler_filter',
+      'handler' => 'views_handler_filter_string',
       'help' => t('Filter results to a particular result set'),
     ),
-    'sort' => array('handler' => 'views_json_query_handler_sort'),
   );
   $data['absence_activity']['absence_absolute_amount'] = array(
     'title' => t('Absence absolute duration'),
@@ -781,15 +767,14 @@ function civihr_employee_portal_views_data_alter(&$data) {
       'click sortable' => TRUE,
     ),
     'argument' => array(
-      'handler' => 'views_json_query_argument_request_handler',
+      'handler' => 'views_handler_argument',
       'name_field' => 'absence_absolute_amount',
       'string' => TRUE
     ),
     'filter' => array(
-      'handler' => 'views_json_query_handler_filter',
+      'handler' => 'views_handler_filter_string',
       'help' => t('Filter results to a particular result set'),
     ),
-    'sort' => array('handler' => 'views_json_query_handler_sort'),
   );
   $data['absence_activity']['absence_is_credit'] = array(
     'title' => t('Absence is credit'),
@@ -799,15 +784,14 @@ function civihr_employee_portal_views_data_alter(&$data) {
       'click sortable' => TRUE,
     ),
     'argument' => array(
-      'handler' => 'views_json_query_argument_request_handler',
+      'handler' => 'views_handler_argument',
       'name_field' => 'absence_is_credit',
       'string' => TRUE
     ),
     'filter' => array(
-      'handler' => 'views_json_query_handler_filter',
+      'handler' => 'views_handler_filter_string',
       'help' => t('Filter results to a particular result set'),
     ),
-    'sort' => array('handler' => 'views_json_query_handler_sort'),
   );
 
   $data['absence_activity']['absence_status'] = array(


### PR DESCRIPTION
## Overview

The CiviHR installation (both with buildkit or with the ansible playbook) is failing with this error:

```
>> Unable to patch views_json_query with views_json_query_civihr-v1.patch.    [error]
```

This PR removes the `views_json_query` module dependency to fix the error.

## Before

The CiviHR installation would fail at the step where a [patch](https://raw.githubusercontent.com/compucorp/civihr-employee-portal/master/patches/views_json_query_civihr-v1.patch) is applied to the views_json_query module. We use[ a development version](https://github.com/civicrm/civicrm-buildkit/blob/6aa2f04d131e3e1c6f7f3c5d5dfd1af779c31829/app/config/hr17/drush.make.tmpl#L205) of that module and that version was updated on earlier this month, as it's possible to see here:

![captura de tela de 2018-02-19 15-30-14](https://user-images.githubusercontent.com/388373/36392428-e1ec6afc-1589-11e8-88d5-7ff17e63ce95.png)

The patch is not compatible with this version, then drush cannot apply it and the installation fails.

## After

The SSP modules does not depend on the `views_json_query` module anymore. The module was originally added years ago, for some uncertain reason, and it's not really necessary anywhere. 

## Technical Details

The `views_json_query` module allows the creation of drupal views based on JSON files rather than database tables. The dependency was originally added on https://github.com/compucorp/civihr-employee-portal/commit/29f96ace0568e3b416a9ab6c88d6bb9368171a93, but, since there's no PR and no detailed information in the commit message, it's hard to know why it was added in the first place. Judging by the changes in that commit, it appears there was a json table/view back then, which, I assume, had data in a JSON format: https://github.com/compucorp/civihr-employee-portal/blob/29f96ace0568e3b416a9ab6c88d6bb9368171a93/civihr_employee_portal/views/civihr_employee_portal.views.inc#L15-L43

The [patch itself](https://raw.githubusercontent.com/compucorp/civihr-employee-portal/master/patches/views_json_query_civihr-v1.patch) dates back to 2015 and it also doesn't have any information on why it was necessary and what it does. Checking the diff, it's possible to see that, among a weird class structure that doesn't do anything, it adds a new "Array Contains" operator, that is currently not used anywhere.

Later, on https://github.com/compucorp/civihr-employee-portal/pull/204, some refactoring was done and the JSON based views were converted to database views.

However, after that, we still had some fields using handlers from the `views_json_query` module. They were added by https://github.com/compucorp/civihr-employee-portal/commit/9501c5b4f6282bfd134c708b7706fa8df7d14b41, which is squash commit created by mistake and that includes changes from dozens of different PRs. Because of the squash, it's not possible to track down where exactly the changes were made, but it's possible to say that none of these views have any type of JSON data.

The handlers were replaced with more generic ones. `views_json_query_argument_request_handler` was replaced by `views_handler_argument` and `views_json_query_handler_filter` was replaced by  `views_handler_filter_string`. Besides that, some fields were using the `views_json_query_handler_sort` handler for sorting, but none of them are actually being used for sorting in any of the views, so I completely removed the `sort` configuration.

Finally, an upgrader was added to disable and uninstall the module on existing sites.

- [x] Tests Pass