### PR TITLE
PCHR-3342: Style Users List

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5585,9 +5585,29 @@ function civihr_employee_portal_form_views_exposed_form_alter(&$form, &$form_sta
       _civihr_employee_portal_form_view_exposed_form_alter_actions_wrapper($form, $form_state, $form_id);
       _civihr_employee_portal_form_view_exposed_form_alter_labels_as_placeholders($form, $form_state, $form_id);
       break;
+    case 'views-exposed-form-users-list-page':
+      _civihr_employee_portal_form_view_exposed_alter_users_list($form, $form_state, $form_id);
+      break;
   }
 
   $form['submit']['#value'] = 'Filter';
+}
+
+/**
+ * Alters the Users List Exposed Filter
+ *
+ * @param array $form
+ * @param array $form_state
+ * @param string $form_id
+ */
+function _civihr_employee_portal_form_view_exposed_alter_users_list(&$form, &$form_state, $form_id) {
+
+  $accessField = &$form['access'];
+  $form['#info']["filter-access"]['label'] = '';
+  $accessField['min']['#prefix'] = $accessField['max']['#prefix'] = '<div class="col-sm-6">';
+  $accessField['min']['#suffix'] = $accessField['max']['#suffix'] = '</div>';
+  $accessField['min']['#title'] = 'Last Accessed From';
+  $accessField['max']['#title'] = 'To';
 }
 
 /**
@@ -6049,6 +6069,20 @@ function _is_hrreports_data_table_view($viewName) {
   }
 
   return FALSE;
+}
+
+/**
+ * Matches the $viewName to a list which should be scrollable and
+ * have no of records shown on top.
+ *
+ * @param string $viewName
+ *
+ * @return boolean
+ */
+function _is_scrollable_table_view_with_results($viewName) {
+  $viewsList = array('users_list');
+
+  return in_array($viewName, $viewsList);
 }
 
 /**

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5586,7 +5586,7 @@ function civihr_employee_portal_form_views_exposed_form_alter(&$form, &$form_sta
       _civihr_employee_portal_form_view_exposed_form_alter_labels_as_placeholders($form, $form_state, $form_id);
       break;
     case 'views-exposed-form-users-list-page':
-      _civihr_employee_portal_form_view_exposed_alter_users_list($form, $form_state, $form_id);
+      _civihr_employee_portal_form_view_exposed_form_alter_users_list($form, $form_state, $form_id);
       break;
   }
 
@@ -5600,10 +5600,9 @@ function civihr_employee_portal_form_views_exposed_form_alter(&$form, &$form_sta
  * @param array $form_state
  * @param string $form_id
  */
-function _civihr_employee_portal_form_view_exposed_alter_users_list(&$form, &$form_state, $form_id) {
-
+function _civihr_employee_portal_form_view_exposed_form_alter_users_list(&$form, &$form_state, $form_id) {
   $accessField = &$form['access'];
-  $form['#info']["filter-access"]['label'] = '';
+  $form['#info']['filter-access']['label'] = '';
   $accessField['min']['#prefix'] = $accessField['max']['#prefix'] = '<div class="col-sm-6">';
   $accessField['min']['#suffix'] = $accessField['max']['#suffix'] = '</div>';
   $accessField['min']['#title'] = 'Last Accessed From';
@@ -6080,7 +6079,7 @@ function _is_hrreports_data_table_view($viewName) {
  * @return boolean
  */
 function _is_scrollable_table_view_with_results($viewName) {
-  $viewsList = array('users_list');
+  $viewsList = ['users_list'];
 
   return in_array($viewName, $viewsList);
 }

--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.views_default.inc
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.views_default.inc
@@ -1965,7 +1965,21 @@ return date(\'Y-m-d\');';
   $handler->display->display_options['exposed_form']['type'] = 'basic';
   $handler->display->display_options['pager']['type'] = 'full';
   $handler->display->display_options['pager']['options']['items_per_page'] = '10';
+  $handler->display->display_options['pager']['options']['offset'] = '0';
+  $handler->display->display_options['pager']['options']['id'] = '0';
+  $handler->display->display_options['pager']['options']['quantity'] = '9';
+  $handler->display->display_options['pager']['options']['tags']['first'] = 'First';
+  $handler->display->display_options['pager']['options']['tags']['previous'] = 'Previous';
+  $handler->display->display_options['pager']['options']['tags']['next'] = 'Next';
+  $handler->display->display_options['pager']['options']['tags']['last'] = 'Last';
   $handler->display->display_options['style_plugin'] = 'table';
+  /* No results behavior: Global: Text area */
+  $handler->display->display_options['empty']['area']['id'] = 'area';
+  $handler->display->display_options['empty']['area']['table'] = 'views';
+  $handler->display->display_options['empty']['area']['field'] = 'area';
+  $handler->display->display_options['empty']['area']['empty'] = TRUE;
+  $handler->display->display_options['empty']['area']['content'] = '<div class="text-center">No Results</div>';
+  $handler->display->display_options['empty']['area']['format'] = 'full_html';
   /* Field: Bulk operations: User */
   $handler->display->display_options['fields']['views_bulk_operations']['id'] = 'views_bulk_operations';
   $handler->display->display_options['fields']['views_bulk_operations']['table'] = 'users';
@@ -2035,7 +2049,7 @@ return date(\'Y-m-d\');';
   $handler->display->display_options['fields']['uid']['field'] = 'uid';
   $handler->display->display_options['fields']['uid']['label'] = 'Operations';
   $handler->display->display_options['fields']['uid']['alter']['alter_text'] = TRUE;
-  $handler->display->display_options['fields']['uid']['alter']['text'] = '<a href="/user/[uid]/edit">Edit User Account</a> | <a href="/civicrm/contact/view?reset=1&cid=[id]">View Staff Record</a>';
+  $handler->display->display_options['fields']['uid']['alter']['text'] = '<a href="/user/[uid]/edit">Edit User Account</a><span class="chr_divider"> | </span><a href="/civicrm/contact/view?reset=1&cid=[id]">View Staff Record</a>';
   $handler->display->display_options['fields']['uid']['link_to_user'] = FALSE;
   /* Sort criterion: User: Created date */
   $handler->display->display_options['sorts']['created']['id'] = 'created';
@@ -2094,7 +2108,6 @@ return date(\'Y-m-d\');';
   $handler->display->display_options['filters']['access']['expose']['operator'] = 'access_op';
   $handler->display->display_options['filters']['access']['expose']['identifier'] = 'access';
 
-
   /* Display: Page */
   $handler = $view->new_display('page', 'Page', 'page');
   $handler->display->display_options['path'] = 'users-list';
@@ -2110,10 +2123,11 @@ return date(\'Y-m-d\');';
     t('Items per page'),
     t('- All -'),
     t('Offset'),
-    t('« first'),
-    t('‹ previous'),
-    t('next ›'),
-    t('last »'),
+    t('First'),
+    t('Previous'),
+    t('Next'),
+    t('Last'),
+    t('<div class="text-center">No Results</div>'),
     t('User'),
     t('- Choose an operation -'),
     t('Block the selected users'),
@@ -2121,14 +2135,14 @@ return date(\'Y-m-d\');';
     t('Username'),
     t('Status'),
     t('Roles'),
-    t('Member For'),
+    t('Duration'),
     t('Last access'),
     t('never'),
     t('Contact ID'),
     t('.'),
     t(','),
     t('Operations'),
-    t('<a href="/user/[uid]/edit">Edit User Account</a> | <a href="/civicrm/contact/view?reset=1&cid=[id]">View Staff Record</a>'),
+    t('<a href="/user/[uid]/edit">Edit User Account</a><span class="chr_divider"> | </span><a href="/civicrm/contact/view?reset=1&cid=[id]">View Staff Record</a>'),
     t('Active'),
     t('Last access: Between'),
     t('Page'),

--- a/civihr_employee_portal/templates/views-view-table-scrollable-with-results.tpl.php
+++ b/civihr_employee_portal/templates/views-view-table-scrollable-with-results.tpl.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @file
+ * Template to display a view as a table.
+ *
+ * - $title : The title of this group of rows.  May be empty.
+ * - $header: An array of header labels keyed by field id.
+ * - $caption: The caption for this table. May be empty.
+ * - $header_classes: An array of header classes keyed by field id.
+ * - $fields: An array of CSS IDs to use for each field id.
+ * - $classes: A class or classes to apply to the table, based on settings.
+ * - $row_classes: An array of classes to apply to each row, indexed by row
+ *   number. This matches the index in $rows.
+ * - $rows: An array of row items. Each row is an array of content.
+ *   $rows are keyed by row number, fields within rows are keyed by field ID.
+ * - $field_classes: An array of classes to apply to each field, indexed by
+ *   field id, then row number. This matches the index in $rows.
+ * @ingroup views_templates
+ */
+?>
+<div class="chr_search-result__header">
+  <div class="chr_search-result__total">
+    Results
+    <span class="chr_search-result__total__count"><?php echo count($rows); ?></span>
+  </div>
+</div>
+
+<div class="chr_table--scrollable">
+  <table <?php if ($classes) { print 'class="'. $classes . '" '; } ?><?php print $attributes; ?>>
+    <?php if (!empty($title) || !empty($caption)) : ?>
+      <caption><?php print $caption . $title; ?></caption>
+    <?php endif; ?>
+    <?php if (!empty($header)) : ?>
+      <thead>
+        <tr>
+          <?php foreach ($header as $field => $label): ?>
+            <th <?php if ($header_classes[$field]) { print 'class="'. $header_classes[$field] . '" '; } ?>>
+              <?php print $label; ?>
+            </th>
+          <?php endforeach; ?>
+        </tr>
+      </thead>
+    <?php endif; ?>
+    <tbody>
+      <?php foreach ($rows as $row_count => $row): ?>
+        <tr <?php if ($row_classes[$row_count]) { print 'class="' . implode(' ', $row_classes[$row_count]) .'"';  } ?>>
+          <?php foreach ($row as $field => $content): ?>
+            <td <?php if ($field_classes[$field][$row_count]) { print 'class="'. $field_classes[$field][$row_count] . '" '; } ?><?php print drupal_attributes($field_attributes[$field][$row_count]); ?>>
+              <?php print $content; ?>
+            </td>
+          <?php endforeach; ?>
+        </tr>
+      <?php endforeach; ?>
+    </tbody>
+  </table>
+</div>

--- a/civihr_employee_portal/templates/views-view-table.tpl.php
+++ b/civihr_employee_portal/templates/views-view-table.tpl.php
@@ -1,6 +1,8 @@
 <?php
 if (_is_hrreports_data_table_view($view->name)) {
-    include('views-view-table-hrreports.tpl.php');
+  include('views-view-table-hrreports.tpl.php');
+} else if (_is_scrollable_table_view_with_results($view->name)) {
+  include('views-view-table-scrollable-with-results.tpl.php');
 } else {
-    include('views-view-table-default.tpl.php');
+  include('views-view-table-default.tpl.php');
 }

--- a/civihr_employee_portal/views/templates/views-view--users-list--page.tpl.php
+++ b/civihr_employee_portal/views/templates/views-view--users-list--page.tpl.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * @file
+ * Main view template.
+ *
+ * Variables available:
+ * - $classes_array: An array of classes determined in
+ *   template_preprocess_views_view(). Default classes are:
+ *     .view
+ *     .view-[css_name]
+ *     .view-id-[view_name]
+ *     .view-display-id-[display_name]
+ *     .view-dom-id-[dom_id]
+ * - $classes: A string version of $classes_array for use in the class attribute
+ * - $css_name: A css-safe version of the view name.
+ * - $css_class: The user-specified classes names, if any
+ * - $header: The view header
+ * - $footer: The view footer
+ * - $rows: The results of the view query, if any
+ * - $empty: The empty text to display if the view is empty
+ * - $pager: The pager next/prev links to display, if any
+ * - $exposed: Exposed widget form/info to display
+ * - $feed_icon: Feed icon to display, if any
+ * - $more: A link to view more, if any
+ *
+ * @ingroup views_templates
+ */
+?>
+<div class="<?php print $classes; ?>">
+  <?php print render($title_prefix); ?>
+  <?php if ($title): ?>
+    <?php print $title; ?>
+  <?php endif; ?>
+  <?php print render($title_suffix); ?>
+  <?php if ($exposed): ?>
+    <div class="view-filters well">
+      <?php print $exposed; ?>
+    </div>
+  <?php endif; ?>
+
+  <?php if ($attachment_before): ?>
+    <div class="attachment attachment-before">
+      <?php print $attachment_before; ?>
+    </div>
+  <?php endif; ?>
+
+  <?php if ($rows): ?>
+    <div class="view-content">
+      <div class="chr_search-result">
+        <?php if ($header): ?>
+          <div class="chr_search-result__header">
+            <?php print $header; ?>
+          </div>
+        <?php endif; ?>
+
+        <div class="chr_search-result__content">
+          <?php print $rows; ?>
+        </div>
+
+        <div class="chr_search-result__footer">
+          <?php if ($pager): ?>
+            <div class="chr_search-result__pager chr_search-result__pager--full">
+              <?php print $pager; ?>
+            </div>
+            <div class="chr_search-result__pager chr_search-result__pager--mini">
+              <?php print $pager; ?>
+            </div>
+          <?php endif; ?>
+
+          <?php if ($footer): ?>
+            <?php print $footer; ?>
+          <?php endif; ?>
+        </div>
+      </div>
+    </div>
+  <?php elseif ($empty): ?>
+    <div class="view-empty">
+      <?php print $empty; ?>
+    </div>
+  <?php endif; ?>
+
+  <?php if ($attachment_after): ?>
+    <div class="attachment attachment-after">
+      <?php print $attachment_after; ?>
+    </div>
+  <?php endif; ?>
+
+  <?php if ($more): ?>
+    <?php print $more; ?>
+  <?php endif; ?>
+
+  <?php if ($feed_icon): ?>
+    <div class="feed-icon">
+      <?php print $feed_icon; ?>
+    </div>
+  <?php endif; ?>
+</div><?php /* class view */ ?>

--- a/civihr_employee_portal/views/views_export/views_users_list.php
+++ b/civihr_employee_portal/views/views_export/views_users_list.php
@@ -21,7 +21,21 @@ $handler->display->display_options['query']['type'] = 'views_query';
 $handler->display->display_options['exposed_form']['type'] = 'basic';
 $handler->display->display_options['pager']['type'] = 'full';
 $handler->display->display_options['pager']['options']['items_per_page'] = '10';
+$handler->display->display_options['pager']['options']['offset'] = '0';
+$handler->display->display_options['pager']['options']['id'] = '0';
+$handler->display->display_options['pager']['options']['quantity'] = '9';
+$handler->display->display_options['pager']['options']['tags']['first'] = 'First';
+$handler->display->display_options['pager']['options']['tags']['previous'] = 'Previous';
+$handler->display->display_options['pager']['options']['tags']['next'] = 'Next';
+$handler->display->display_options['pager']['options']['tags']['last'] = 'Last';
 $handler->display->display_options['style_plugin'] = 'table';
+/* No results behavior: Global: Text area */
+$handler->display->display_options['empty']['area']['id'] = 'area';
+$handler->display->display_options['empty']['area']['table'] = 'views';
+$handler->display->display_options['empty']['area']['field'] = 'area';
+$handler->display->display_options['empty']['area']['empty'] = TRUE;
+$handler->display->display_options['empty']['area']['content'] = '<div class="text-center">No Results</div>';
+$handler->display->display_options['empty']['area']['format'] = 'full_html';
 /* Field: Bulk operations: User */
 $handler->display->display_options['fields']['views_bulk_operations']['id'] = 'views_bulk_operations';
 $handler->display->display_options['fields']['views_bulk_operations']['table'] = 'users';
@@ -91,7 +105,7 @@ $handler->display->display_options['fields']['uid']['table'] = 'users';
 $handler->display->display_options['fields']['uid']['field'] = 'uid';
 $handler->display->display_options['fields']['uid']['label'] = 'Operations';
 $handler->display->display_options['fields']['uid']['alter']['alter_text'] = TRUE;
-$handler->display->display_options['fields']['uid']['alter']['text'] = '<a href="/user/[uid]/edit">Edit User Account</a> | <a href="/civicrm/contact/view?reset=1&cid=[id]">View Staff Record</a>';
+$handler->display->display_options['fields']['uid']['alter']['text'] = '<a href="/user/[uid]/edit">Edit User Account</a><span class="chr_divider"> | </span><a href="/civicrm/contact/view?reset=1&cid=[id]">View Staff Record</a>';
 $handler->display->display_options['fields']['uid']['link_to_user'] = FALSE;
 /* Sort criterion: User: Created date */
 $handler->display->display_options['sorts']['created']['id'] = 'created';
@@ -150,7 +164,6 @@ $handler->display->display_options['filters']['access']['expose']['label'] = 'La
 $handler->display->display_options['filters']['access']['expose']['operator'] = 'access_op';
 $handler->display->display_options['filters']['access']['expose']['identifier'] = 'access';
 
-
 /* Display: Page */
 $handler = $view->new_display('page', 'Page', 'page');
 $handler->display->display_options['path'] = 'users-list';
@@ -166,10 +179,11 @@ $translatables['users_list'] = array(
   t('Items per page'),
   t('- All -'),
   t('Offset'),
-  t('« first'),
-  t('‹ previous'),
-  t('next ›'),
-  t('last »'),
+  t('First'),
+  t('Previous'),
+  t('Next'),
+  t('Last'),
+  t('<div class="text-center">No Results</div>'),
   t('User'),
   t('- Choose an operation -'),
   t('Block the selected users'),
@@ -177,14 +191,14 @@ $translatables['users_list'] = array(
   t('Username'),
   t('Status'),
   t('Roles'),
-  t('Member For'),
+  t('Duration'),
   t('Last access'),
   t('never'),
   t('Contact ID'),
   t('.'),
   t(','),
   t('Operations'),
-  t('<a href="/user/[uid]/edit">Edit User Account</a> | <a href="/civicrm/contact/view?reset=1&cid=[id]">View Staff Record</a>'),
+  t('<a href="/user/[uid]/edit">Edit User Account</a><span class="chr_divider"> | </span><a href="/civicrm/contact/view?reset=1&cid=[id]">View Staff Record</a>'),
   t('Active'),
   t('Last access: Between'),
   t('Page'),


### PR DESCRIPTION
## Overview
As part of this PR the User List page in SSP is styled.

## Screencast
Refer https://github.com/compucorp/civihr-employee-portal-theme/pull/319

## Technical Details
1. `_civihr_employee_portal_form_view_exposed_alter_users_list ` has been added to `civihr_employee_portal.module`. Which applies `col-sm-6` class and also changes the labels for the Access field.
2. `views-view-table-scrollable-with-results.tpl.php` is created to show view tables with scrolling and also with results information on the header.
![2018-02-22 at 5 28 pm](https://user-images.githubusercontent.com/5058867/36537341-d9f8c7b4-17f5-11e8-935a-ae4398abe34b.png)

