### PR TITLE
PCHR-3346: Revoke permissions and assign new permission for to relevant roles

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.install
+++ b/civihr_employee_portal/civihr_employee_portal.install
@@ -388,6 +388,35 @@ function civihr_employee_portal_update_7024() {
 }
 
 /**
+ * Revokes the 'access users overview' and the 'administer users'
+ * permissions from the HR Admin and Regional HR Admin Role
+ */
+function civihr_employee_portal_update_7025() {
+  $permissionsToRevoke = ['access users overview', 'administer users'];
+  $roleNames = ['HR Admin', 'Regional HR Admin'];
+  $roles = user_roles();
+  $rolesToCheck  = array_intersect($roles, $roleNames);
+
+  foreach($rolesToCheck as $rid => $role) {
+    user_role_revoke_permissions($rid, $permissionsToRevoke);
+  }
+}
+
+/**
+ * Grants the 'administer staff accounts' permission to the
+ * the HR Admin and Regional HR Admin Role.
+ */
+function civihr_employee_portal_update_7026() {
+  $permissionsToAdd = ['administer staff accounts'];
+  $roleNames = ['HR Admin', 'Regional HR Admin'];
+  $roles = user_roles();
+  $rolesToCheck  = array_intersect($roles, $roleNames);
+
+  foreach($rolesToCheck as $rid => $role) {
+    user_role_grant_permissions($rid, $permissionsToAdd);
+  }
+}
+/**
  * Function to determine whether menu link exists or not.
  *
  * @param string $path

--- a/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
+++ b/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
@@ -406,8 +406,6 @@ function civihr_default_permissions_user_default_permissions() {
   $permissions['access users overview'] = array(
     'name' => 'access users overview',
     'roles' => array(
-      'HR Admin' => 'HR Admin',
-      'Regional HR Admin' => 'Regional HR Admin',
       'administrator' => 'administrator',
     ),
     'module' => 'administerusersbyrole',
@@ -806,6 +804,16 @@ function civihr_default_permissions_user_default_permissions() {
     'module' => 'system',
   );
 
+  // Exported permission: 'administer staff accounts'.
+  $permissions['administer staff accounts'] = array(
+    'name' => 'administer staff accounts',
+    'roles' => array(
+      'HR Admin' => 'HR Admin',
+      'Regional HR Admin' => 'Regional HR Admin',
+    ),
+    'module' => 'civicrm',
+  );
+
   // Exported permission: 'administer subpermission'.
   $permissions['administer subpermission'] = array(
     'name' => 'administer subpermission',
@@ -870,8 +878,6 @@ function civihr_default_permissions_user_default_permissions() {
   $permissions['administer users'] = array(
     'name' => 'administer users',
     'roles' => array(
-      'HR Admin' => 'HR Admin',
-      'Regional HR Admin' => 'Regional HR Admin',
       'administrator' => 'administrator',
     ),
     'module' => 'user',

--- a/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.info
+++ b/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.info
@@ -121,6 +121,7 @@ features[user_permission][] = administer rules
 features[user_permission][] = administer search
 features[user_permission][] = administer site configuration
 features[user_permission][] = administer software updates
+features[user_permission][] = administer staff accounts
 features[user_permission][] = administer subpermission
 features[user_permission][] = administer taxonomy
 features[user_permission][] = administer themes


### PR DESCRIPTION
## Overview
Sequel to [#2493](https://github.com/civicrm/civihr/pull/2493), which adds a new Permission: `CiviHRContactActions: Administer Staff Accounts` which will be used to access the User related links on the Contact actions menu  and also the new Users List page in SSP.  The `administer users` and `access users overview` permissions were revoked from the HR Admin and Regional HR Admin roles (since we no longer want these roles to have access to `admin/people` anymore) and the permission:  `administer staff accounts` was assigned to these roles.

The Manage Users Link in the SSP will be changed to point to the new Users List view and the permission updated in another PR.

## Before
- The HR Admin and Regional HR Admin have access to the `administer users` and `access users overview` permissions.
-  The HR Admin and Regional HR Admin does not have access to the `administer staff accounts` permission.

## After
- The HR Admin and Regional HR Admin no longer have access to the `administer users` and `access users overview` permissions.
-  The HR Admin and Regional HR Admin now have access to the `administer staff accounts` permission.

- [X] Tests Pass
