### PR TITLE
PCHR-3356: Adds an upgrader to revert default civihr user permissions

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.install
+++ b/civihr_employee_portal/civihr_employee_portal.install
@@ -356,6 +356,13 @@ function civihr_employee_portal_update_7023() {
 }
 
 /**
+ * Reverts the default CiviHR user permissions because they were modified
+ */
+function civihr_employee_portal_update_7024() {
+  features_revert(['civihr_default_permissions' => ['user_permission']]);
+}
+
+/**
  * Function to determine whether menu link exists or not.
  *
  * @param string $path


### PR DESCRIPTION
## Overview

Because of the changes in #446 we need a new upgrader to revert the default permissions.

## Before

There was no new updgrader to refresh permissions.

## After

A new upgrader was added which refreshes only the `user_permission` for `civihr_default_permissions`.

---

- [x] Tests Pass