### PR TITLE
PCHR-3362: Rename Default option to bulk edit.

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -4715,6 +4715,22 @@ function civihr_employee_portal_form_user_profile_form_alter(&$form, &$form_stat
   $form['#submit'][] = 'civihr_employee_portal_form_user_profile_form_submit';
 }
 
+
+/**
+ * Implementation of hook_views_bulk_operations_form_alter.
+ *
+ * Performs alterations on the VBO form before it is rendered.
+ *
+ * @param array $form
+ * @param array $form_state
+ * @param object $vbo
+ */
+function civihr_employee_portal_views_bulk_operations_form_alter(&$form, &$form_state, $vbo) {
+  if ($form['#id'] == 'views-form-users-list-page') {
+    $form['select']['operation']['#options'][0] = '- Bulk edit -';
+  }
+}
+
 /**
  * Redirect the user to the onboarding form if they've just set their password.
  */


### PR DESCRIPTION
## Overview
This PR renames the default option for the Bulk operations dropdown from `Choose an operation` to `Bulk edit`

## Before
 The default option for the Bulk operations dropdown is `Choose an operation`

![users list _ staging17 2018-02-26 14-39-57](https://user-images.githubusercontent.com/6951813/36673520-4c341ce2-1b03-11e8-88bc-c290ff4056ec.png)


## After
 The default option for the Bulk operations dropdown is `Bulk edit`

![users list _ staging17 2018-02-26 14-42-08](https://user-images.githubusercontent.com/6951813/36673529-540963aa-1b03-11e8-8455-6ddffaa28099.png)


Changes does not affect tests.
- [] Tests Pass
