### PR TITLE
PCHR-3273: Fix Staff Directory Responsiveness

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -6095,7 +6095,10 @@ function _is_hrreports_data_table_view($viewName) {
  * @return boolean
  */
 function _is_scrollable_table_view_with_results($viewName) {
-  $viewsList = ['users_list'];
+  $viewsList = [
+    'civihr_staff_directory',
+    'users_list'
+  ];
 
   return in_array($viewName, $viewsList);
 }

--- a/civihr_employee_portal/templates/views-view-table-scrollable-with-results.tpl.php
+++ b/civihr_employee_portal/templates/views-view-table-scrollable-with-results.tpl.php
@@ -22,7 +22,7 @@
 <div class="chr_search-result__header">
   <div class="chr_search-result__total">
     Results
-    <span class="chr_search-result__total__count"><?php echo count($rows); ?></span>
+    <span class="chr_search-result__total__count"><?php echo $view->total_rows; ?></span>
   </div>
 </div>
 

--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -1109,8 +1109,7 @@ function civihr_employee_portal_views_query_alter(&$view, &$query) {
  */
 function civihr_employee_portal_views_pre_view(&$view, &$display_id, &$args) {
   // Custom configuration start for items per page
-  if (($view->name == 'civihr_staff_directory' && $display_id == 'page') ||
-          ($view->name == 'hr_documents' && $display_id == 'hr_resources')) {
+  if ($view->name == 'hr_documents' && $display_id == 'hr_resources') {
 
     // Set the custom header
     $view->set_item_option(

--- a/civihr_employee_portal/views/views_export/views_hr_staff_directory.inc
+++ b/civihr_employee_portal/views/views_export/views_hr_staff_directory.inc
@@ -201,11 +201,6 @@ $handler->display->display_options['style_options']['info'] = array(
     'empty_column' => 0,
   ),
 );
-/* Header: Global: Result summary */
-$handler->display->display_options['header']['result']['id'] = 'result';
-$handler->display->display_options['header']['result']['table'] = 'views';
-$handler->display->display_options['header']['result']['field'] = 'result';
-$handler->display->display_options['header']['result']['content'] = '@total';
 /* Footer: Global: Unfiltered text */
 $handler->display->display_options['footer']['area_text_custom']['id'] = 'area_text_custom';
 $handler->display->display_options['footer']['area_text_custom']['table'] = 'views';
@@ -772,7 +767,6 @@ $translatables['civihr_staff_directory'] = array(
   t('‹ previous'),
   t('next ›'),
   t('last »'),
-  t('@total'),
   t('HRJobContract Revision entity'),
   t('HRJobContract Details entity'),
   t('HRJobContract Role entity'),


### PR DESCRIPTION
## Overview
In SSP Staff Directory, the views table was broken in the mobile view. This PR fixes that.

## Before
![civihr local_8914_staff-directory iphone 7 1](https://user-images.githubusercontent.com/5058867/36888739-df038848-1e1c-11e8-867a-6c1d5193162f.png)

## After
![civihr local_8914_staff-directory iphone 7](https://user-images.githubusercontent.com/5058867/36888742-e1144474-1e1c-11e8-9c75-68ad93f841c0.png)

## Technical Details
1. In `civihr_employee_portal/civihr_employee_portal.module`
Added `civihr_staff_directory` to the `$viewsList` array in `_is_scrollable_table_view_with_results` function, to use the `views-view-table-scrollable-with-results.tpl.php` which is meant to solve the scroll issue.

2. In `civihr_employee_portal.views.inc`
Removed `($view->name == 'civihr_staff_directory' && $display_id == 'page')` condition as `views-view-table-scrollable-with-results.tpl.php` already holds the header count.

3. From the staff directory view, removed the header from drupal views menu as `views-view-table-scrollable-with-results.tpl.php` already holds the header count.

4. In `views-view-table-scrollable-with-results.tpl.php` previously we were only showing the number of records visible i.e. if we had 12 records, and only 10 can be shown at once, and rest after pagination. Previously 10 was shown on header. Now it is fixed to show the total number.