### PR TITLE
PCHR-3487: Escape user entered data

### DIFF
--- a/civihr_employee_portal/views/includes/civihr_employee_portal_handler_aggregated_address.inc
+++ b/civihr_employee_portal/views/includes/civihr_employee_portal_handler_aggregated_address.inc
@@ -72,12 +72,12 @@ class civihr_employee_portal_handler_aggregated_address extends views_handler_fi
 
     return sprintf(
       $format,
-      ArrayHelper::value('street_address', $address),
-      ArrayHelper::value('supplemental_address_1', $address),
-      ArrayHelper::value('city', $address),
-      ArrayHelper::value('state_province_id.name', $address),
-      ArrayHelper::value('postal_code', $address),
-      ArrayHelper::value('country_id.name', $address)
+      filter_xss(ArrayHelper::value('street_address', $address)),
+      filter_xss(ArrayHelper::value('supplemental_address_1', $address)),
+      filter_xss(ArrayHelper::value('city', $address)),
+      filter_xss(ArrayHelper::value('state_province_id.name', $address)),
+      filter_xss(ArrayHelper::value('postal_code', $address)),
+      filter_xss(ArrayHelper::value('country_id.name', $address))
     );
   }
 }

--- a/civihr_employee_portal/views/includes/civihr_employee_portal_handler_emergency_contact_aggregated_address.inc
+++ b/civihr_employee_portal/views/includes/civihr_employee_portal_handler_emergency_contact_aggregated_address.inc
@@ -82,6 +82,9 @@ class civihr_employee_portal_handler_emergency_contact_aggregated_address extend
     $query = sprintf($format, $selectFields, $table, $id);
     $result = CRM_Core_DAO::executeQuery($query);
     $result = current($result->fetchAll());
+    foreach ($result as $i => $value) {
+      $result[$i] = filter_xss($value);
+    }
 
     return array_filter($result);
   }


### PR DESCRIPTION
Please check https://github.com/civicrm/civihr/pull/2545 for more details.

This is basically the same fix, but to some Drupal code, that was using the API and/or BAOs to fetch data from CiviCRM and print it to the screen. Here, the `filter_xss` function from the Drupal API was used to filter the data.