### PR TITLE
PCHR-3254: Fix Reports Export Not Being in CSV Format on Windows

### DIFF
--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.views_default.inc
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.views_default.inc
@@ -927,6 +927,14 @@ function civihr_employee_portal_features_views_default_views() {
   $handler->display->display_options['pager']['type'] = 'none';
   $handler->display->display_options['pager']['options']['offset'] = '0';
   $handler->display->display_options['style_plugin'] = 'views_data_export_csv';
+  $handler->display->display_options['style_options']['provide_file'] = 1;
+  $handler->display->display_options['style_options']['parent_sort'] = 0;
+  $handler->display->display_options['style_options']['quote'] = 1;
+  $handler->display->display_options['style_options']['trim'] = 0;
+  $handler->display->display_options['style_options']['replace_newlines'] = 0;
+  $handler->display->display_options['style_options']['newline_token'] = '1';
+  $handler->display->display_options['style_options']['header'] = 1;
+  $handler->display->display_options['style_options']['keep_html'] = 0;
   $handler->display->display_options['path'] = 'civihr_report_export_leave_and_absence';
   $translatables['civihr_report_leave_and_absence'] = array(
     t('Master'),
@@ -1867,6 +1875,14 @@ return date(\'Y-m-d\');';
   $handler->display->display_options['pager']['type'] = 'none';
   $handler->display->display_options['pager']['options']['offset'] = '0';
   $handler->display->display_options['style_plugin'] = 'views_data_export_csv';
+  $handler->display->display_options['style_options']['provide_file'] = 1;
+  $handler->display->display_options['style_options']['parent_sort'] = 0;
+  $handler->display->display_options['style_options']['quote'] = 1;
+  $handler->display->display_options['style_options']['trim'] = 0;
+  $handler->display->display_options['style_options']['replace_newlines'] = 0;
+  $handler->display->display_options['style_options']['newline_token'] = '1';
+  $handler->display->display_options['style_options']['header'] = 1;
+  $handler->display->display_options['style_options']['keep_html'] = 0;
   $handler->display->display_options['path'] = 'civihr_report_export_people';
   $translatables['civihr_report_people'] = array(
     t('Master'),

--- a/civihr_employee_portal/views/views_export/views_civihr_report_leave_and_absence.inc
+++ b/civihr_employee_portal/views/views_export/views_civihr_report_leave_and_absence.inc
@@ -922,6 +922,14 @@ $handler = $view->new_display('views_data_export', 'Data export', 'views_data_ex
 $handler->display->display_options['pager']['type'] = 'none';
 $handler->display->display_options['pager']['options']['offset'] = '0';
 $handler->display->display_options['style_plugin'] = 'views_data_export_csv';
+$handler->display->display_options['style_options']['provide_file'] = 1;
+$handler->display->display_options['style_options']['parent_sort'] = 0;
+$handler->display->display_options['style_options']['quote'] = 1;
+$handler->display->display_options['style_options']['trim'] = 0;
+$handler->display->display_options['style_options']['replace_newlines'] = 0;
+$handler->display->display_options['style_options']['newline_token'] = '1';
+$handler->display->display_options['style_options']['header'] = 1;
+$handler->display->display_options['style_options']['keep_html'] = 0;
 $handler->display->display_options['path'] = 'civihr_report_export_leave_and_absence';
 $translatables['civihr_report_leave_and_absence'] = array(
   t('Master'),

--- a/civihr_employee_portal/views/views_export/views_civihr_report_people.inc
+++ b/civihr_employee_portal/views/views_export/views_civihr_report_people.inc
@@ -887,6 +887,14 @@ $handler = $view->new_display('views_data_export', 'Data export', 'views_data_ex
 $handler->display->display_options['pager']['type'] = 'none';
 $handler->display->display_options['pager']['options']['offset'] = '0';
 $handler->display->display_options['style_plugin'] = 'views_data_export_csv';
+$handler->display->display_options['style_options']['provide_file'] = 1;
+$handler->display->display_options['style_options']['parent_sort'] = 0;
+$handler->display->display_options['style_options']['quote'] = 1;
+$handler->display->display_options['style_options']['trim'] = 0;
+$handler->display->display_options['style_options']['replace_newlines'] = 0;
+$handler->display->display_options['style_options']['newline_token'] = '1';
+$handler->display->display_options['style_options']['header'] = 1;
+$handler->display->display_options['style_options']['keep_html'] = 0;
 $handler->display->display_options['path'] = 'civihr_report_export_people';
 $translatables['civihr_report_people'] = array(
   t('Master'),


### PR DESCRIPTION
## Overview
When the Leave Report and People Report on the SSP are exported on a Windows machine, the exported format is not in CSV and as such can not be readily opened. This PR fixes the issue.

## Before
When the Leave Reports and People Reports on the SSP are exported on a Windows machine, the exported format is not in CSV and as such can not be readily opened.

## After
- Ticking the Provide as File option in the Data Export settings for the respective view fixes this issue. In order for this fix to be applied for all affected sites, the Views and Features for the Leave report and People report were re-exported after ticking this option via the UI.

![screenshot-1 1](https://user-images.githubusercontent.com/6951813/37842637-e70ac5e0-2ec2-11e8-9016-dc92d7567026.png)


- [X] Tests Pass
