### PR TITLE
PCHR-3508: Alter Meta viewport tag

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -6192,6 +6192,34 @@ function _get_task_filter_by_date($date, $normalize = false) {
 }
 
 /**
+ * Sets the maximum viewport scale to 1 to prevent auto zooming on input focus
+ * @see https://stackoverflow.com/questions/11064237/prevent-iphone-from-zooming-form
+ *
+ * @param object $head_elements
+ */
+function _set_maximum_scale_to_viewport_meta_tag(&$head_elements) {
+  foreach ($head_elements as $key => $tag) {
+    if (isset($tag['#attributes']['name']) && $tag['#attributes']['name'] === 'viewport') {
+      $head_elements[$key]['#attributes']['content'] .= ', maximum-scale=1';
+    }
+  }
+}
+
+/**
+ * Sets theme favicon
+ *
+ * @param object $head_elements
+ */
+function _set_favicon(&$head_elements) {
+  global $base_url;
+
+  $default_favicon_element = 'drupal_add_html_head_link:shortcut icon:' . $base_url . '/misc/favicon.ico';
+  $icoPath = drupal_get_path('module', 'civihr_employee_portal') . "/images/favicon.ico";
+
+  $head_elements[$default_favicon_element]['#attributes']['href'] = "{$base_url}/{$icoPath}";
+}
+
+/**
  * This method handle user redirection for special use cases
  *
  * The redirection is made by manually setting the Location header,
@@ -6375,12 +6403,8 @@ function civihr_employee_portal_delete_report_configuration_json($reportName, $c
  * Changes the favicon for both the SSP and CiviHR admin
  */
 function civihr_employee_portal_html_head_alter(&$head_elements) {
-  global $base_url;
-
-  $default_favicon_element = 'drupal_add_html_head_link:shortcut icon:' . $base_url . '/misc/favicon.ico';
-  $icoPath = drupal_get_path('module', 'civihr_employee_portal') . "/images/favicon.ico";
-
-  $head_elements[$default_favicon_element]['#attributes']['href'] = "{$base_url}/{$icoPath}";
+  _set_favicon($head_elements);
+  _set_maximum_scale_to_viewport_meta_tag($head_elements);
 }
 
 /**


### PR DESCRIPTION
## Overview

This PR fixes viewport auto-zooming on inputs focusing on iOS devices. It still allows users to pinch and zoom with 2 fingers.

## Before

![1](https://user-images.githubusercontent.com/3973243/38414940-d6bfa474-3987-11e8-9e8b-9626c65a79ce.gif)

## After

![2](https://user-images.githubusercontent.com/3973243/38414943-da584ca8-3987-11e8-900a-a581dae6a5cf.gif)

## Technical Details

Please see https://api.drupal.org/api/drupal/modules%21system%21system.api.php/function/hook_html_head_alter/7.x

```php
// hook_html_head_alter
function civihr_employee_portal_html_head_alter(&$head_elements) {
  // ...
  _set_maximum_scale_to_viewport_meta_tag($head_elements);

function _set_maximum_scale_to_viewport_meta_tag(&$head_elements) {
  // bruteforcing is the only secure way to get the Meta Viewport tag in this case
  foreach ($head_elements as $key => $tag) {
    if (isset($tag['#attributes']['name']) && $tag['#attributes']['name'] === 'viewport') {
      $head_elements[$key]['#attributes']['content'] .= ', maximum-scale=1';
```

---

✅Manual Tests - passed
