### PR TITLE
PCHR-3573: Fix Staff Directory View (round 2)

### DIFF
--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -996,24 +996,25 @@ function _civihr_employee_portal_decode_vacancy_description_html(&$view, &$outpu
 }
 
 function removeAdditionalCommas($view) {
-  $fieldsToClean = array();
+  $replacements = [];
 
   foreach ($view->style_plugin->rendered_fields as $renderedField) {
-    $managerFieldValues = !empty($renderedField['last_name_1']) ? $renderedField['last_name_1'] : NULL;
-    $departmentFieldValues = !empty($renderedField['department']) ? $renderedField['department'] : NULL;
+    $fieldsToClean = [
+      'title', // role titles
+      'department', // departments
+      'display_name_2' // managers
+    ];
 
-    if ($managerFieldValues != NULL && trim($managerFieldValues) != "") {
-      $cleanedValue = preg_replace('/,( *,)+/', ',', trim($managerFieldValues, ', '));
-      $fieldsToClean[$managerFieldValues] = $cleanedValue;
-    }
-
-    if ($departmentFieldValues != NULL) {
-      $cleanedValue = preg_replace('/,( *,)+/', ',', trim($departmentFieldValues, ', '));
-      $fieldsToClean[$departmentFieldValues] = $cleanedValue;
+    foreach ($fieldsToClean as $fieldToClean) {
+      $fieldValue = CRM_Utils_Array::value($fieldToClean, $renderedField);
+      if (trim($fieldValue)) {
+        $cleanedValue = preg_replace('/,( *,)+/', ',', trim($fieldValue, ', '));
+        $replacements[$fieldValue] = $cleanedValue;
+      }
     }
   }
 
-  return $fieldsToClean;
+  return $replacements;
 }
 
 /**

--- a/civihr_employee_portal/views/views_export/views_hr_staff_directory.inc
+++ b/civihr_employee_portal/views/views_export/views_hr_staff_directory.inc
@@ -390,13 +390,6 @@ $handler->display->display_options['fields']['display_name_2']['link_to_civicrm_
 $handler->display->display_options['sorts']['id']['id'] = 'id';
 $handler->display->display_options['sorts']['id']['table'] = 'civicrm_contact';
 $handler->display->display_options['sorts']['id']['field'] = 'id';
-$handler->display->display_options['filter_groups']['groups'] = array(
-  1 => 'AND',
-  2 => 'OR',
-  3 => 'OR',
-  4 => 'OR',
-  5 => 'OR',
-);
 /* Filter criterion: CiviCRM Contacts: Contact Type */
 $handler->display->display_options['filters']['contact_type']['id'] = 'contact_type';
 $handler->display->display_options['filters']['contact_type']['table'] = 'civicrm_contact';
@@ -578,70 +571,6 @@ $handler->display->display_options['filters']['is_deleted']['table'] = 'civicrm_
 $handler->display->display_options['filters']['is_deleted']['field'] = 'is_deleted';
 $handler->display->display_options['filters']['is_deleted']['value'] = '0';
 $handler->display->display_options['filters']['is_deleted']['group'] = 1;
-/* Filter criterion: HRJobContract Role entity: Role end date */
-$handler->display->display_options['filters']['role_end_date']['id'] = 'role_end_date';
-$handler->display->display_options['filters']['role_end_date']['table'] = 'hrjc_role';
-$handler->display->display_options['filters']['role_end_date']['field'] = 'role_end_date';
-$handler->display->display_options['filters']['role_end_date']['relationship'] = 'role_jobcontract_id';
-$handler->display->display_options['filters']['role_end_date']['operator'] = '>=';
-$handler->display->display_options['filters']['role_end_date']['value']['value'] = '+0';
-$handler->display->display_options['filters']['role_end_date']['value']['type'] = 'offset';
-$handler->display->display_options['filters']['role_end_date']['group'] = 2;
-/* Filter criterion: HRJobContract Role entity: Role end date */
-$handler->display->display_options['filters']['role_end_date_1']['id'] = 'role_end_date_1';
-$handler->display->display_options['filters']['role_end_date_1']['table'] = 'hrjc_role';
-$handler->display->display_options['filters']['role_end_date_1']['field'] = 'role_end_date';
-$handler->display->display_options['filters']['role_end_date_1']['relationship'] = 'role_jobcontract_id';
-$handler->display->display_options['filters']['role_end_date_1']['operator'] = 'empty';
-$handler->display->display_options['filters']['role_end_date_1']['group'] = 2;
-/* Filter criterion: HRJobContract Role entity: Role start date */
-$handler->display->display_options['filters']['role_start_date']['id'] = 'role_start_date';
-$handler->display->display_options['filters']['role_start_date']['table'] = 'hrjc_role';
-$handler->display->display_options['filters']['role_start_date']['field'] = 'role_start_date';
-$handler->display->display_options['filters']['role_start_date']['relationship'] = 'role_jobcontract_id';
-$handler->display->display_options['filters']['role_start_date']['operator'] = '<=';
-$handler->display->display_options['filters']['role_start_date']['value']['value'] = '+0';
-$handler->display->display_options['filters']['role_start_date']['value']['type'] = 'offset';
-$handler->display->display_options['filters']['role_start_date']['group'] = 3;
-/* Filter criterion: HRJobContract Role entity: Role start date */
-$handler->display->display_options['filters']['role_start_date_1']['id'] = 'role_start_date_1';
-$handler->display->display_options['filters']['role_start_date_1']['table'] = 'hrjc_role';
-$handler->display->display_options['filters']['role_start_date_1']['field'] = 'role_start_date';
-$handler->display->display_options['filters']['role_start_date_1']['relationship'] = 'role_jobcontract_id';
-$handler->display->display_options['filters']['role_start_date_1']['operator'] = 'empty';
-$handler->display->display_options['filters']['role_start_date_1']['group'] = 3;
-/* Filter criterion: CiviCRM Relationships: End Date */
-$handler->display->display_options['filters']['end_date']['id'] = 'end_date';
-$handler->display->display_options['filters']['end_date']['table'] = 'civicrm_relationship';
-$handler->display->display_options['filters']['end_date']['field'] = 'end_date';
-$handler->display->display_options['filters']['end_date']['relationship'] = 'relationship_id_a_1';
-$handler->display->display_options['filters']['end_date']['operator'] = '>=';
-$handler->display->display_options['filters']['end_date']['value']['value'] = '+0';
-$handler->display->display_options['filters']['end_date']['value']['type'] = 'offset';
-$handler->display->display_options['filters']['end_date']['group'] = 4;
-/* Filter criterion: CiviCRM Relationships: End Date */
-$handler->display->display_options['filters']['end_date_1']['id'] = 'end_date_1';
-$handler->display->display_options['filters']['end_date_1']['table'] = 'civicrm_relationship';
-$handler->display->display_options['filters']['end_date_1']['field'] = 'end_date';
-$handler->display->display_options['filters']['end_date_1']['relationship'] = 'relationship_id_a_1';
-$handler->display->display_options['filters']['end_date_1']['operator'] = 'empty';
-$handler->display->display_options['filters']['end_date_1']['group'] = 4;
-/* Filter criterion: CiviCRM Relationships: Start Date */
-$handler->display->display_options['filters']['start_date']['id'] = 'start_date';
-$handler->display->display_options['filters']['start_date']['table'] = 'civicrm_relationship';
-$handler->display->display_options['filters']['start_date']['field'] = 'start_date';
-$handler->display->display_options['filters']['start_date']['relationship'] = 'relationship_id_a_1';
-$handler->display->display_options['filters']['start_date']['operator'] = '<=';
-$handler->display->display_options['filters']['start_date']['value']['value'] = '+0';
-$handler->display->display_options['filters']['start_date']['value']['type'] = 'offset';
-$handler->display->display_options['filters']['start_date']['group'] = 5;
-/* Filter criterion: CiviCRM Relationships: Start Date */
-$handler->display->display_options['filters']['start_date_1']['id'] = 'start_date_1';
-$handler->display->display_options['filters']['start_date_1']['table'] = 'civicrm_relationship';
-$handler->display->display_options['filters']['start_date_1']['field'] = 'start_date';
-$handler->display->display_options['filters']['start_date_1']['relationship'] = 'relationship_id_a_1';
-$handler->display->display_options['filters']['start_date_1']['operator'] = 'empty';
-$handler->display->display_options['filters']['start_date_1']['group'] = 5;
 
 /* Display: Staff directory list page */
 $handler = $view->new_display('page', 'Staff directory list page', 'page');


### PR DESCRIPTION
## Overview

Contacts with only a single inactive role or only a single inactive relationship were not displayed in the staff directory view

## Before

- Contacts with only inactive roles did not show in the staff directory view
- Contacts with only inactive relationships did not show in the staff directory view

![image](https://user-images.githubusercontent.com/6374064/39125061-a95310ea-46f5-11e8-994e-79995849eb1b.png)

## After

- All contacts with active contracts are shown regardless of role or relationship status

![image](https://user-images.githubusercontent.com/6374064/39125172-fe3bcc5a-46f5-11e8-9dc7-dd85c49003d9.png)

## Technical Details

The issue with filtering by role end was originally dealt with in PCHR-1890 by [removing](https://github.com/compucorp/civihr-employee-portal/commit/cd15baf1ed35d1530e08f65baf3b64bdd95acb54) the filter.

[This commit re-added a role filter](https://github.com/compucorp/civihr-employee-portal/commit/7f1b3d142c731198943e4c285db02ee3ad2e0150) and [this commit added a relationship filter](https://github.com/compucorp/civihr-employee-portal/commit/9d72c2669d7b0a161b84df17fc353d231a23f14c), which caused contacts with only inactive roles / relationships not to be displayed in the staff directory. 

It might seem that filtering out inactive roles and relationships seems like a good idea, but our staff directory is not for showing contacts with _only_ active roles and relationships. Active role and relationship data should be added to the view if it is available, but if it isn't the the contact should still be visible.

To fix this I reverted both commits mentioned above. These commits were part of a ticket to remove extra commas. We already had a function for this (added in [2015](https://github.com/compucorp/civihr-employee-portal/commit/57870a78029574241915c2427f96f3f68db20127#diff-16cb90fad42c8d4f2a7159c43f614960R358)) but since some of the fields were changed it wasn't working properly. This PR also fixes that function.

---

- [x] Tests Pass
