### PR TITLE
PCHR-3496: Hide Contract Type column from the SSP staff directory View

### DIFF
--- a/civihr_employee_portal/views/views_export/views_hr_staff_directory.inc
+++ b/civihr_employee_portal/views/views_export/views_hr_staff_directory.inc
@@ -318,12 +318,6 @@ $handler->display->display_options['fields']['role_location']['field'] = 'role_l
 $handler->display->display_options['fields']['role_location']['relationship'] = 'role_jobcontract_id';
 $handler->display->display_options['fields']['role_location']['label'] = 'Location';
 $handler->display->display_options['fields']['role_location']['element_label_colon'] = FALSE;
-/* Field: HRJobContract Details entity: Contract_type */
-$handler->display->display_options['fields']['contract_type']['id'] = 'contract_type';
-$handler->display->display_options['fields']['contract_type']['table'] = 'hrjc_details';
-$handler->display->display_options['fields']['contract_type']['field'] = 'contract_type';
-$handler->display->display_options['fields']['contract_type']['relationship'] = 'details_revision_id';
-$handler->display->display_options['fields']['contract_type']['label'] = ' Contract Type ';
 /* Field: HRJobContract Role entity: Role_department */
 $handler->display->display_options['fields']['department']['id'] = 'department';
 $handler->display->display_options['fields']['department']['table'] = 'hrjc_role';
@@ -785,7 +779,6 @@ $translatables['civihr_staff_directory'] = array(
   t('Job Title'),
   t('Email'),
   t('Location'),
-  t(' Contract Type '),
   t('Role Department'),
   t('Departments'),
   t('End Date'),


### PR DESCRIPTION
## Overview
We need to hide the Contract type column on the SSP staff directory view.
![staff directory _ staging17 2018-04-23 14-15-28](https://user-images.githubusercontent.com/6951813/39129696-0dfe89ae-4703-11e8-841c-826ae0ce6714.png)

## Before
- The Contract type column shows on the  SSP staff directory view
![staff directory _ staging17 2018-04-23 14-26-55](https://user-images.githubusercontent.com/6951813/39129713-18d4f9d0-4703-11e8-9320-11978f0f0f75.png)


- [X] Tests Pass
