### PR TITLE
PCHR-3627: Include URL fragment in redirection

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -4939,6 +4939,11 @@ function civihr_employee_portal_user_login_validate(&$form, &$form_state) {
 function civihr_employee_portal_user_login_submit(&$form, &$form_state) {
   $destination = !empty($_REQUEST['destination']) ? rawurldecode($_REQUEST['destination']) : '';
 
+  if (!empty($_REQUEST['redirect_hash'])) {
+    $destination .= $_REQUEST['redirect_hash'];
+    $_GET['destination'] = $destination;
+  }
+
   if ($form_state['input']['forgot-password']) {
     user_pass_submit($form, $form_state);
     _drupal_session_write('custom_login_success_message', t('Details sent!'));

--- a/civihr_employee_portal/templates/civihr-employee-portal-user-login.tpl.php
+++ b/civihr_employee_portal/templates/civihr-employee-portal-user-login.tpl.php
@@ -24,6 +24,7 @@ $errors = form_get_errors();
         <?php print drupal_render($form['form_build_id']); ?>
         <?php print drupal_render($form['form_id']); ?>
         <?php print drupal_render($form['actions']); ?>
+        <input type="hidden" id="redirect_hash" name="redirect_hash"/>
     </div>
 </div>
 <?php
@@ -63,7 +64,7 @@ $errors = form_get_errors();
                 e.stopImmediatePropagation();
                 return false;
             });
-
+            $('#redirect_hash').val(window.location.hash);
         });
     }(CRM.$));
 </script>


### PR DESCRIPTION
## Overview

When redirecting a user to the login form the fragment part of the URL was lost, this meant that someone coming to `mysite.civihr.org/reports#my-report` would be redirected to `mysite.civihr.org/reports`.

## Before

The fragment was not included in the URL when redirecting

![fix_fragment_before](https://user-images.githubusercontent.com/6374064/39253059-e8a1677e-489e-11e8-8f2a-4582e5543b1f.gif)

## After

The fragment is included in the URL when redirecting

![fix_fragment](https://user-images.githubusercontent.com/6374064/39253072-ef6a8932-489e-11e8-8496-7ecd41266125.gif)

## Technical Details

We're accessing the fragment _after_ being redirected to the login page. This relies on the fragment being retained after a redirect. According to an answer on [Stack overflow](https://stackoverflow.com/questions/2286402/url-fragment-and-302-redirects)

> IE10+, Chrome 11+, Firefox 4+, and Opera will all "reattach" the original URI's fragment after following a 3xx redirection.

Which meet the minimum requirements for CiviHR. This means the process will be

1. Try to access `mysite.civihr.org/foo#bar`
1. Get redirected to `mysite.civihr.org/welcome-page?destination=foo#bar`
1. The fragment from the URL is included in the login form
1. When you log in the fragment is re-attached to the destination URL

---

- [x] Tests Pass
