### PR TITLE
PCHR-3569: Update user guide link. Remove sentence.

### DIFF
--- a/civihr_employee_portal/features/civihr_default_mail_content/civihr_default_mail_content.strongarm.inc
+++ b/civihr_employee_portal/features/civihr_default_mail_content/civihr_default_mail_content.strongarm.inc
@@ -15,7 +15,7 @@ function civihr_default_mail_content_strongarm() {
   $strongarm->api_version = 1;
   $strongarm->name = 'user_mail_password_reset_body';
   $strongarm->value = '<p>
-        A request has been made to reset your CiviHR password. To reset your password, please click the button below. The link will take you to your CiviHR user account page where you can enter a new password.
+        A request has been made to reset your CiviHR password. To reset your password, please click the button below.
       </p>
       <p>
         Please note: the button below expires after one day and can only be used once. Nothing will happen if it\'s not used - your password will remain unchanged.
@@ -40,7 +40,7 @@ function civihr_default_mail_content_strongarm() {
     Once you have set your password, you can access CiviHR via the logon page at <a href="[site:url]">[site:url]</a> - your username is [user:name]</p>
   </p>
   <p>
-    For instructions on how to use the system, please read the online <a href="https://civihr-documentation.readthedocs.io/en/latest/initial-setup-and-configuration/staff-managers-quickstart/">user guide</a>.
+    For instructions on how to use the system, please read the online <a href="http://userguide.civihr.org">user guide</a>.
   </p>';
   $export['user_mail_register_admin_created_body'] = $strongarm;
 
@@ -62,7 +62,7 @@ function civihr_default_mail_content_strongarm() {
     Once you have set your password, you can access CiviHR via the logon page at <a href="[site:url]">[site:url]</a> - your username is [user:name]</p>
   </p>
   <p>
-    For instructions on how to use the system, please read the online <a href="https://civihr-documentation.readthedocs.io/en/latest/initial-setup-and-configuration/staff-managers-quickstart/">user guide</a>.
+    For instructions on how to use the system, please read the online <a href="http://userguide.civihr.org">user guide</a>.
   </p>';
   $export['user_mail_status_activated_body'] = $strongarm;
 


### PR DESCRIPTION
## Overview

After originally merging #467 some additional changes were requests

## Before

- The user guide link pointed to https://civihr-documentation.readthedocs.io/en/latest/initial-setup-and-configuration/staff-managers-quickstart/

## After

- The user guide link points to http://userguide.civihr.org
- A sentence was removed

---

- [x] Tests Pass
