### PR TITLE
PCHR-3730: Replace "Home" location type with "Personal"

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.install
+++ b/civihr_employee_portal/civihr_employee_portal.install
@@ -255,23 +255,23 @@ function civihr_employee_portal_update_7016() {
   civicrm_initialize();
   $locationTypes = civicrm_api3('LocationType', 'get')['values'];
   $locationTypes = array_column($locationTypes, 'name', 'id');
-  $homeTypeID = array_search('Home', $locationTypes);
+  $personalTypeID = array_search('Personal', $locationTypes);
   $workTypeID = array_search('Work', $locationTypes);
 
   $workPhone = &$phoneData[1];
   $homePhone = &$phoneData[2];
-  $homeEmail = &$emailData[2];
+  $personalEmail = &$emailData[2];
   $workEmail = &$emailData[1];
-  $homeAddress = &$addressData[1];
+  $personalAddress = &$addressData[1];
   $workInstantMessenger = &$instantMessengerData[1];
 
   $locationKey = 'location_type_id';
 
   $workPhone[$locationKey] = $workTypeID;
-  $homePhone[$locationKey] = $homeTypeID;
+  $homePhone[$locationKey] = $personalTypeID;
   $workEmail[$locationKey] = $workTypeID;
-  $homeEmail[$locationKey] = $homeTypeID;
-  $homeAddress[$locationKey] = $homeTypeID;
+  $personalEmail[$locationKey] = $personalTypeID;
+  $personalAddress[$locationKey] = $personalTypeID;
   $workInstantMessenger[$locationKey] = $workTypeID;
 
   drupal_write_record('webform_civicrm_forms', $civicrmWebform, 'nid');

--- a/civihr_employee_portal/civihr_employee_portal.install
+++ b/civihr_employee_portal/civihr_employee_portal.install
@@ -241,43 +241,6 @@ function civihr_employee_portal_update_7011() {
 }
 
 /**
- * Fixes location type IDs in the onboarding form.
- */
-function civihr_employee_portal_update_7016() {
-  $onboardingForm = WebformHelper::findOneByTitle(OnboardingWebForm::NAME);
-  $civicrmWebform = &$onboardingForm->webform_civicrm;
-  $contactData = &$civicrmWebform['data']['contact'][1];
-  $phoneData = &$contactData['phone'];
-  $addressData = &$contactData['address'];
-  $emailData = &$contactData['email'];
-  $instantMessengerData = &$contactData['im'];
-
-  civicrm_initialize();
-  $locationTypes = civicrm_api3('LocationType', 'get')['values'];
-  $locationTypes = array_column($locationTypes, 'name', 'id');
-  $personalTypeID = array_search('Personal', $locationTypes);
-  $workTypeID = array_search('Work', $locationTypes);
-
-  $workPhone = &$phoneData[1];
-  $homePhone = &$phoneData[2];
-  $personalEmail = &$emailData[2];
-  $workEmail = &$emailData[1];
-  $personalAddress = &$addressData[1];
-  $workInstantMessenger = &$instantMessengerData[1];
-
-  $locationKey = 'location_type_id';
-
-  $workPhone[$locationKey] = $workTypeID;
-  $homePhone[$locationKey] = $personalTypeID;
-  $workEmail[$locationKey] = $workTypeID;
-  $personalEmail[$locationKey] = $personalTypeID;
-  $personalAddress[$locationKey] = $personalTypeID;
-  $workInstantMessenger[$locationKey] = $workTypeID;
-
-  drupal_write_record('webform_civicrm_forms', $civicrmWebform, 'nid');
-}
-
-/**
  * Refreshes the node export files since the onboarding form file upload limit
  * was increased.
  */

--- a/civihr_hrjobcontract_entities/civihr_hrjobcontract_entities.module
+++ b/civihr_hrjobcontract_entities/civihr_hrjobcontract_entities.module
@@ -262,29 +262,29 @@ function civihr_hrjobcontract_entities_init() {
             GROUP_CONCAT(DISTINCT CASE WHEN email_location.name = 'Work' THEN c_email.email ELSE '' END 
               ORDER BY c_email.email DESC SEPARATOR ' ') AS work_email,
 
-            GROUP_CONCAT(DISTINCT CASE WHEN phone_location.name = 'Home' THEN c_phone.phone ELSE '' END
+            GROUP_CONCAT(DISTINCT CASE WHEN phone_location.name = 'Personal' THEN c_phone.phone ELSE '' END
               ORDER BY c_phone.phone DESC SEPARATOR ' ') AS home_phone,
-            GROUP_CONCAT(DISTINCT CASE WHEN phone_location.name = 'Home' THEN c_phone.phone_ext ELSE '' END 
+            GROUP_CONCAT(DISTINCT CASE WHEN phone_location.name = 'Personal' THEN c_phone.phone_ext ELSE '' END 
               ORDER BY c_phone.phone_ext DESC SEPARATOR ' ') AS home_phone_ext,
-            GROUP_CONCAT(DISTINCT CASE WHEN email_location.name = 'Home' THEN c_email.email ELSE '' END 
+            GROUP_CONCAT(DISTINCT CASE WHEN email_location.name = 'Personal' THEN c_email.email ELSE '' END 
               ORDER BY c_email.email DESC SEPARATOR ' ') AS home_email
 
           FROM {$civi_db_name}.civicrm_contact c
           LEFT JOIN {$civi_db_name}.civicrm_phone c_phone ON c_phone.contact_id = c.id
           LEFT JOIN {$civi_db_name}.civicrm_location_type phone_location ON (
             c_phone.location_type_id = phone_location.id
-            AND (phone_location.name = 'Work' OR phone_location.name = 'Home')
+            AND (phone_location.name = 'Work' OR phone_location.name = 'Personal')
           )
           LEFT JOIN {$civi_db_name}.civicrm_email c_email ON c_email.contact_id = c.id
           LEFT JOIN {$civi_db_name}.civicrm_location_type email_location ON (
             c_email.location_type_id = email_location.id
-            AND (email_location.name = 'Work' OR email_location.name = 'Home')
+            AND (email_location.name = 'Work' OR email_location.name = 'Personal')
           )
 
           WHERE phone_location.name = 'Work'
           OR email_location.name = 'Work'
-          OR phone_location.name = 'Home'
-          OR email_location.name = 'Home'
+          OR phone_location.name = 'Personal'
+          OR email_location.name = 'Personal'
           GROUP BY contact_id
         ");
 


### PR DESCRIPTION
## Overview

We want to remove usages of the "Home", "Main" and "Other" location types as they will be deleted by an upgrader in CiviHR. These location types are in use in this repo and should be replaced or removed.

## Before

- An upgrader existed to fix location type IDs in the onboarding form
- The `hrjc_contact_details` view used the "Home" location type for email and phone 

## After

- The upgrader is not required and has been removed
- The `hrjc_contact_details` view uses the "Personal" location type for email and phone

---

- [x] Tests Pass
