### PR TITLE
FAR-265: Fix Date Filter Issue On Leave Reports and People Reports

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.info
+++ b/civihr_employee_portal/civihr_employee_portal.info
@@ -61,6 +61,7 @@ files[] = views/includes/civihr_employee_portal_handler_appraisal_due_date.inc
 files[] = views/includes/civihr_employee_portal_handler_tasks_date.inc
 files[] = views/includes/civihr_employee_portal_handler_documents_date.inc
 files[] = views/includes/views_between_dates_filter_handler.inc
+files[] = views/includes/views_between_operation_dates_filter_handler.inc
 
 ; Reports Views handlers
 

--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.views_default.inc
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.views_default.inc
@@ -502,10 +502,10 @@ function civihr_employee_portal_features_views_default_views() {
   $handler->display->display_options['filters']['period_end_date']['relationship'] = 'details_revision_id';
   $handler->display->display_options['filters']['period_end_date']['operator'] = 'empty';
   $handler->display->display_options['filters']['period_end_date']['group'] = 3;
-  /* Filter criterion: Date: Date (absence_activity) */
+  /* Filter criterion: Absence Activity entity: Absence date */
   $handler->display->display_options['filters']['date_filter']['id'] = 'date_filter';
   $handler->display->display_options['filters']['date_filter']['table'] = 'absence_activity';
-  $handler->display->display_options['filters']['date_filter']['field'] = 'date_filter';
+  $handler->display->display_options['filters']['date_filter']['field'] = 'absence_date';
   $handler->display->display_options['filters']['date_filter']['relationship'] = 'absence_activity';
   $handler->display->display_options['filters']['date_filter']['operator'] = 'between';
   $handler->display->display_options['filters']['date_filter']['exposed'] = TRUE;
@@ -520,13 +520,6 @@ function civihr_employee_portal_features_views_default_views() {
     55120974 => 0,
     17087012 => 0,
     57573969 => 0,
-  );
-  $handler->display->display_options['filters']['date_filter']['form_type'] = 'date_popup';
-  $handler->display->display_options['filters']['date_filter']['default_date'] = 'now -10 year';
-  $handler->display->display_options['filters']['date_filter']['default_to_date'] = 'now +10 year';
-  $handler->display->display_options['filters']['date_filter']['year_range'] = '-10:+10';
-  $handler->display->display_options['filters']['date_filter']['date_fields'] = array(
-    'absence_activity.absence_date' => 'absence_activity.absence_date',
   );
   /* Filter criterion: Absence Activity entity: Absence activity entity ID */
   $handler->display->display_options['filters']['absence_activity_id']['id'] = 'absence_activity_id';

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -407,6 +407,25 @@
   };
 
   /**
+   * Gets the default query parameters for fetching results for the
+   * Leave and absence report. It basically defaults to parameters
+   * for fetching results for the last 30 days starting from current
+   * date.
+   *
+   * @returns {String}
+   */
+  HRReport.prototype.getDefaultFilterQueryForLeaveReport = function () {
+    var toDate = moment().format("YYYY-MM-DD");
+    var fromDate = moment().subtract(1, 'months').format("YYYY-MM-DD");
+    var defaultFilterValues = [
+      { name: "absence_date_filter[min]", value: fromDate },
+      { name: "absence_date_filter[max]", value: toDate }
+    ];
+
+    return '?' + $.param(defaultFilterValues);
+  }
+
+  /**
    * Refresh JSON data and Pivot Tables using provided filter values
    *
    * @param string filterValues
@@ -416,6 +435,12 @@
     if (!this.jsonUrl) {
       return;
     }
+
+    //On load of page the form values are not appended to query string.
+    if(filterValues === '?' && that.reportName === 'leave_and_absence') {
+      filterValues = that.getDefaultFilterQueryForLeaveReport()
+    }
+
     $.ajax({
       url: this.jsonUrl + filterValues,
       error: function () {
@@ -454,6 +479,12 @@
     if (!this.tableUrl) {
       return;
     }
+
+    //On load of page the form values are not appended to query string.
+    if(filterValues === '?' && that.reportName === 'leave_and_absence') {
+      filterValues = that.getDefaultFilterQueryForLeaveReport()
+    }
+
     var tableDomId = this.getReportTableDomID();
     $.ajax({
       url: that.tableUrl + filterValues,
@@ -851,7 +882,9 @@
               }
 
               if (REPORT_NAME === 'leave_and_absence') {
-                initCurrentAbsencePeriodFilterDates().then(resolve, reject);
+                formFiltersStore.values.fromDate = moment().subtract(1, 'months').toDate();
+                formFiltersStore.values.toDate = moment().toDate();
+                resolve();
               } else {
                 formFiltersStore.values.date = new Date();
                 resolve();

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -415,11 +415,11 @@
    * @returns {String}
    */
   HRReport.prototype.getDefaultFilterQueryForLeaveReport = function () {
-    var toDate = moment().format("YYYY-MM-DD");
-    var fromDate = moment().subtract(1, 'months').format("YYYY-MM-DD");
+    var toDate = moment().dayOfYear(1).add(1, 'year').subtract(1, 'day').format('YYYY-MM-DD');
+    var fromDate = moment().dayOfYear(1).format('YYYY-MM-DD');
     var defaultFilterValues = [
-      { name: "absence_date_filter[min]", value: fromDate },
-      { name: "absence_date_filter[max]", value: toDate }
+      { name: 'absence_date_filter[min]', value: fromDate },
+      { name: 'absence_date_filter[max]', value: toDate }
     ];
 
     return '?' + $.param(defaultFilterValues);
@@ -875,8 +875,8 @@
               }
 
               if (REPORT_NAME === 'leave_and_absence') {
-                formFiltersStore.values.fromDate = moment().subtract(1, 'months').toDate();
-                formFiltersStore.values.toDate = moment().toDate();
+                formFiltersStore.values.fromDate = moment().dayOfYear(1).toDate();
+                formFiltersStore.values.toDate = moment().dayOfYear(1).add(1, 'year').subtract(1, 'day').toDate();
                 resolve();
               } else {
                 formFiltersStore.values.date = new Date();

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -409,8 +409,7 @@
   /**
    * Gets the default query parameters for fetching results for the
    * Leave and absence report. It basically defaults to parameters
-   * for fetching results for the last 30 days starting from current
-   * date.
+   * for fetching results for the current year
    *
    * @return {String}
    */
@@ -425,11 +424,26 @@
     return '?' + $.param(defaultFilterValues);
   }
 
+  /**
+   * Gets the default query parameters for fetching results for the
+   * People report. It basically defaults the date parameter to the
+   * current date.
+   *
+   * @return {String}
+   */
+  HRReport.prototype.getDefaultFilterQueryForPeopleReport = function () {
+    var currentDate = moment().format('YYYY-MM-DD');
+    var defaultFilterValues = [
+      { name: 'between_date_filter[value]', value: currentDate }
+    ];
+
+    return '?' + $.param(defaultFilterValues);
+  }
 
   /**
    * Processes the filter values and replaces with default values
-   * for the leave reports when the filter values does not have a
-   * query parameter appended.
+   * for the people and leave reports when the filter values does
+   * not have a query parameter appended.
    * On load of page the form values are not appended to query string
    * hence filterValues has a value of '?'
    *
@@ -439,6 +453,10 @@
   HRReport.prototype.processFilterValues = function (filterValues) {
     if (filterValues === '?' && this.reportName === 'leave_and_absence') {
       return this.getDefaultFilterQueryForLeaveReport()
+    }
+
+    if (filterValues === '?' && this.reportName === 'people') {
+      return this.getDefaultFilterQueryForPeopleReport()
     }
 
     return filterValues;

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -412,11 +412,11 @@
    * for fetching results for the last 30 days starting from current
    * date.
    *
-   * @returns {String}
+   * @return {String}
    */
   HRReport.prototype.getDefaultFilterQueryForLeaveReport = function () {
-    var toDate = moment().dayOfYear(1).add(1, 'year').subtract(1, 'day').format('YYYY-MM-DD');
     var fromDate = moment().dayOfYear(1).format('YYYY-MM-DD');
+    var toDate = moment().dayOfYear(1).add(1, 'year').subtract(1, 'day').format('YYYY-MM-DD');
     var defaultFilterValues = [
       { name: 'absence_date_filter[min]', value: fromDate },
       { name: 'absence_date_filter[max]', value: toDate }
@@ -430,14 +430,15 @@
    * Processes the filter values and replaces with default values
    * for the leave reports when the filter values does not have a
    * query parameter appended.
+   * On load of page the form values are not appended to query string
+   * hence filterValues has a value of '?'
    *
-   * @returns string {String}
+   * @param  {String} filterValues
+   * @return {String}
    */
   HRReport.prototype.processFilterValues = function (filterValues) {
-    var that = this;
-    //On load of page the form values are not appended to query string.
-    if (filterValues === '?' && that.reportName === 'leave_and_absence') {
-      return that.getDefaultFilterQueryForLeaveReport()
+    if (filterValues === '?' && this.reportName === 'leave_and_absence') {
+      return this.getDefaultFilterQueryForLeaveReport()
     }
 
     return filterValues;

--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -425,6 +425,24 @@
     return '?' + $.param(defaultFilterValues);
   }
 
+
+  /**
+   * Processes the filter values and replaces with default values
+   * for the leave reports when the filter values does not have a
+   * query parameter appended.
+   *
+   * @returns string {String}
+   */
+  HRReport.prototype.processFilterValues = function (filterValues) {
+    var that = this;
+    //On load of page the form values are not appended to query string.
+    if (filterValues === '?' && that.reportName === 'leave_and_absence') {
+      return that.getDefaultFilterQueryForLeaveReport()
+    }
+
+    return filterValues;
+  }
+
   /**
    * Refresh JSON data and Pivot Tables using provided filter values
    *
@@ -436,10 +454,7 @@
       return;
     }
 
-    //On load of page the form values are not appended to query string.
-    if(filterValues === '?' && that.reportName === 'leave_and_absence') {
-      filterValues = that.getDefaultFilterQueryForLeaveReport()
-    }
+    filterValues = that.processFilterValues(filterValues);
 
     $.ajax({
       url: this.jsonUrl + filterValues,
@@ -480,10 +495,7 @@
       return;
     }
 
-    //On load of page the form values are not appended to query string.
-    if(filterValues === '?' && that.reportName === 'leave_and_absence') {
-      filterValues = that.getDefaultFilterQueryForLeaveReport()
-    }
+    filterValues = that.processFilterValues(filterValues);
 
     var tableDomId = this.getReportTableDomID();
     $.ajax({
@@ -848,25 +860,6 @@
                 vm.loading.dates = false;
               });
           })();
-
-          /**
-           * Loads and sets the dates in the date filters using the start and
-           * end dates for the current absence period.
-           *
-           * @return {Promise} - Resolves to an empty promise after the current
-           * period dates have been initialized.
-           */
-          function initCurrentAbsencePeriodFilterDates () {
-            return AbsencePeriod.getCurrent()
-              .then(function (currentPeriod) {
-                if (!currentPeriod) {
-                  return;
-                }
-
-                formFiltersStore.values.fromDate = moment(currentPeriod.start_date).toDate();
-                formFiltersStore.values.toDate = moment(currentPeriod.end_date).toDate();
-              });
-          }
 
           /**
            * If form filters have not been initialized, they'll get their default

--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -209,7 +209,7 @@ function civihr_employee_portal_views_data_alter(&$data) {
       'handler' => 'views_handler_sort_date',
     ),
     'filter' => array(
-      'handler' => 'views_handler_filter_date',
+      'handler' => 'views_between_operation_dates_filter_handler',
     ),
   );
 

--- a/civihr_employee_portal/views/includes/views_between_operation_dates_filter_handler.inc
+++ b/civihr_employee_portal/views/includes/views_between_operation_dates_filter_handler.inc
@@ -10,15 +10,13 @@ class views_between_operation_dates_filter_handler extends views_handler_filter_
   function op_between($field) {
     // Use the substitutions to ensure a consistent timestamp.
     $query_substitutions = views_views_query_substitutions($this->view);
-    $a = intval(strtotime($this->value['min'], $query_substitutions['***CURRENT_TIME***']));
-    $b = intval(strtotime($this->value['max'], $query_substitutions['***CURRENT_TIME***']));
+    $from = intval(strtotime($this->value['min'], $query_substitutions['***CURRENT_TIME***']));
+    $to = intval(strtotime($this->value['max'], $query_substitutions['***CURRENT_TIME***']));
 
-    $a = date('Y-m-d', $a);
-    $b = date('Y-m-d', $b);
+    $from = date('Y-m-d', $from);
+    $to = date('Y-m-d', $to);
 
-    // This is safe because we are manually scrubbing the values.
-    // It is necessary to do it this way because $a and $b are formulas when using an offset.
     $operator = strtoupper($this->operator);
-    $this->query->add_where_expression($this->options['group'], "$field $operator '$a' AND '$b'");
+    $this->query->add_where_expression($this->options['group'], "$field $operator '$from' AND '$to'");
   }
 }

--- a/civihr_employee_portal/views/includes/views_between_operation_dates_filter_handler.inc
+++ b/civihr_employee_portal/views/includes/views_between_operation_dates_filter_handler.inc
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @file
+ * A filter that allows the between operator to compare dates in 'Y-m-d' format
+ * rather than the default timestamp comparison since absence dates are stored
+ * in 'Y-m-d' format in the db.
+ */
+
+class views_between_operation_dates_filter_handler extends views_handler_filter_date {
+  function op_between($field) {
+    // Use the substitutions to ensure a consistent timestamp.
+    $query_substitutions = views_views_query_substitutions($this->view);
+    $a = intval(strtotime($this->value['min'], $query_substitutions['***CURRENT_TIME***']));
+    $b = intval(strtotime($this->value['max'], $query_substitutions['***CURRENT_TIME***']));
+
+    $a = date('Y-m-d', $a);
+    $b = date('Y-m-d', $b);
+
+    // This is safe because we are manually scrubbing the values.
+    // It is necessary to do it this way because $a and $b are formulas when using an offset.
+    $operator = strtoupper($this->operator);
+    $this->query->add_where_expression($this->options['group'], "$field $operator '$a' AND '$b'");
+  }
+}

--- a/civihr_employee_portal/views/views_export/views_civihr_report_leave_and_absence.inc
+++ b/civihr_employee_portal/views/views_export/views_civihr_report_leave_and_absence.inc
@@ -497,10 +497,10 @@ $handler->display->display_options['filters']['period_end_date']['field'] = 'per
 $handler->display->display_options['filters']['period_end_date']['relationship'] = 'details_revision_id';
 $handler->display->display_options['filters']['period_end_date']['operator'] = 'empty';
 $handler->display->display_options['filters']['period_end_date']['group'] = 3;
-/* Filter criterion: Date: Date (absence_activity) */
+/* Filter criterion: Absence Activity entity: Absence date */
 $handler->display->display_options['filters']['date_filter']['id'] = 'date_filter';
 $handler->display->display_options['filters']['date_filter']['table'] = 'absence_activity';
-$handler->display->display_options['filters']['date_filter']['field'] = 'date_filter';
+$handler->display->display_options['filters']['date_filter']['field'] = 'absence_date';
 $handler->display->display_options['filters']['date_filter']['relationship'] = 'absence_activity';
 $handler->display->display_options['filters']['date_filter']['operator'] = 'between';
 $handler->display->display_options['filters']['date_filter']['exposed'] = TRUE;
@@ -515,13 +515,6 @@ $handler->display->display_options['filters']['date_filter']['expose']['remember
   55120974 => 0,
   17087012 => 0,
   57573969 => 0,
-);
-$handler->display->display_options['filters']['date_filter']['form_type'] = 'date_popup';
-$handler->display->display_options['filters']['date_filter']['default_date'] = 'now -10 year';
-$handler->display->display_options['filters']['date_filter']['default_to_date'] = 'now +10 year';
-$handler->display->display_options['filters']['date_filter']['year_range'] = '-10:+10';
-$handler->display->display_options['filters']['date_filter']['date_fields'] = array(
-  'absence_activity.absence_date' => 'absence_activity.absence_date',
 );
 /* Filter criterion: Absence Activity entity: Absence activity entity ID */
 $handler->display->display_options['filters']['absence_activity_id']['id'] = 'absence_activity_id';


### PR DESCRIPTION
## Overview
Recently, We have been having some performance issues with the Leave and Absence Reports on sites with particularly large leave data. On closer investigation, it was discovered that the Leave filters for this report does not work and it fetches the data set all at once and does not allow to fetch the data in chunks. 
The date filter for the people report works but the whole data is fetched on initial page load.

## Before
- The date filters on the Leave and Absence report does not work.
- The date filter for the people report works but the whole data is fetched on initial page load.

## After
- The date filters on the Leave and Absence reports was fixed and also on first load, the pivot table fetches result for the current year so as not to fetch the result set at once. The whole result set can still be fetched by clearing out the date filters.

- The date filter was not working because the filter parameter was added on the wrong field in the Leave and Absence report view. This was fixed by adding the correct `absence_date` field.

- The date filter parameter was added to the people report and defaulted to the current date so that the initial data fetched is for contracts active in the current date only.

![datefilterafter](https://user-images.githubusercontent.com/6951813/40787491-a112d754-64e5-11e8-96b8-837c1d43429f.gif)

## Technical details

On initial report load, the whole result set was being fetched initially, but a new function was added that allows to fetch result set for current year for the leave and absence report. For the people report the report is fetched for contacts having active contracts at the current date.

```php

  HRReport.prototype.processFilterValues = function (filterValues) {
    if (filterValues === '?' && this.reportName === 'leave_and_absence') {
      return this.getDefaultFilterQueryForLeaveReport()
    }

    if (filterValues === '?' && this.reportName === 'people') {
      return this.getDefaultFilterQueryForPeopleReport()
    }

    return filterValues;
  }
```

The `initCurrentAbsencePeriodFilterDates` function was previously used to default the filter date values to the current period for the leave and absence report but it was removed since its no longer needed.

A new handler was added for the date filter for the leave and absence report since Drupal does the date comparison using timestamp by default. This handler allows to compare dates in `Y-m-d` format.
```php
class views_between_operation_dates_filter_handler extends views_handler_filter_date {
  function op_between($field) {
    // Use the substitutions to ensure a consistent timestamp.
    $query_substitutions = views_views_query_substitutions($this->view);
    $a = intval(strtotime($this->value['min'], $query_substitutions['***CURRENT_TIME***']));
    $b = intval(strtotime($this->value['max'], $query_substitutions['***CURRENT_TIME***']));
    $a = date('Y-m-d', $a);
    $b = date('Y-m-d', $b);
    // This is safe because we are manually scrubbing the values.
    // It is necessary to do it this way because $a and $b are formulas when using an offset.
    $operator = strtoupper($this->operator);
    $this->query->add_where_expression($this->options['group'], "$field $operator '$a' AND '$b'");
  }
}
```
The changes does not affect any Tests.
- [ ] Tests Pass
