### PR TITLE
PCHR-3537: Change "Home" location type on onboarding form to "Personal"

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.install
+++ b/civihr_employee_portal/civihr_employee_portal.install
@@ -397,6 +397,14 @@ function civihr_employee_portal_update_7028() {
 }
 
 /**
+ * Refresh the node files as onboarding form node was altered
+ */
+function civihr_employee_portal_update_7029() {
+  civicrm_initialize();
+  drush_civihr_employee_portal_refresh_node_export_files();
+}
+
+/**
  * Function to determine whether menu link exists or not.
  *
  * @param string $path

--- a/civihr_employee_portal/features/node_export_files/onboarding_form.export
+++ b/civihr_employee_portal/features/node_export_files/onboarding_form.export
@@ -4730,7 +4730,7 @@ array(
             'number_of_cg99999' => '7',
             'address' => array(
               1 => array(
-                'location_type_id' => '1',
+                'location_type_id' => '6',
               ),
             ),
             'phone' => array(
@@ -4740,7 +4740,7 @@ array(
               ),
               2 => array(
                 'phone_type_id' => '1',
-                'location_type_id' => '1',
+                'location_type_id' => '6',
               ),
             ),
             'email' => array(
@@ -4748,7 +4748,7 @@ array(
                 'location_type_id' => '2',
               ),
               2 => array(
-                'location_type_id' => '1',
+                'location_type_id' => '6',
               ),
             ),
             'im' => array(
@@ -4828,8 +4828,8 @@ array(
         99999 => 'Emergency_Contacts',
       ),
       'locationTypes' => array(
-        1 => 'Home',
         2 => 'Work',
+        6 => 'Personal',
       ),
     ),
   ),


### PR DESCRIPTION
## Overview

The onboarding form used the "Home" location type for phone, email and address. This PR changes that to "Personal" location type

## Before

The onboarding form phone, email and address inputs referenced the "Home" location type

## After

The onboarding form phone, email and address inputs reference the "Personal" location type

---

- [x] Tests Pass
