### PR TITLE
PCHR-3705: Hide Relations and Description from HR Resource type adds screen

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -4683,7 +4683,7 @@ function civihr_employee_portal_form_alter(&$form, &$form_state, $form_id) {
   }
 
   // Hide Relations and Description from hr_resource_type add screen
-  if($form_id == 'taxonomy_form_term' && $form['#term']['vocabulary_machine_name'] == "hr_resource_type") {
+  if ($form_id == 'taxonomy_form_term' && $form['#term']['vocabulary_machine_name'] == "hr_resource_type") {
     $form['relations']['#access'] = FALSE;
     $form['description']['#access'] = FALSE;
   }

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -4681,6 +4681,12 @@ function civihr_employee_portal_form_alter(&$form, &$form_state, $form_id) {
     $onboardingForm = new OnboardingWebForm();
     $onboardingForm->alter($form);
   }
+
+  // Hide Relations and Description from hr_resource_type add screen
+  if($form_id == 'taxonomy_form_term' && $form['#term']['vocabulary_machine_name'] == "hr_resource_type") {
+    $form['relations']['#access'] = FALSE;
+    $form['description']['#access'] = FALSE;
+  }
 }
 
 /**


### PR DESCRIPTION
## Overview
As part of this PR Relations, Description and Text Format has been hidden from document types add/edit screen.

## Before
<img width="1680" alt="screen shot 2018-06-06 at 1 02 31 pm" src="https://user-images.githubusercontent.com/5058867/41023415-fb37671a-6989-11e8-88bf-20f0d60c17a0.png">

## After
<img width="1680" alt="screen shot 2018-06-06 at 1 02 08 pm" src="https://user-images.githubusercontent.com/5058867/41023453-1b280264-698a-11e8-833d-20bdca573281.png">

