### PR TITLE
PCHR-3792: Set Leave And Absence Report filter to Current Month

### DIFF
--- a/civihr_employee_portal/js/reports.js
+++ b/civihr_employee_portal/js/reports.js
@@ -414,8 +414,8 @@
    * @return {String}
    */
   HRReport.prototype.getDefaultFilterQueryForLeaveReport = function () {
-    var fromDate = moment().dayOfYear(1).format('YYYY-MM-DD');
-    var toDate = moment().dayOfYear(1).add(1, 'year').subtract(1, 'day').format('YYYY-MM-DD');
+    var fromDate = moment().startOf('month').format('YYYY-MM-DD');
+    var toDate = moment().endOf('month').format('YYYY-MM-DD');
     var defaultFilterValues = [
       { name: 'absence_date_filter[min]', value: fromDate },
       { name: 'absence_date_filter[max]', value: toDate }
@@ -894,8 +894,8 @@
               }
 
               if (REPORT_NAME === 'leave_and_absence') {
-                formFiltersStore.values.fromDate = moment().dayOfYear(1).toDate();
-                formFiltersStore.values.toDate = moment().dayOfYear(1).add(1, 'year').subtract(1, 'day').toDate();
+                formFiltersStore.values.fromDate = moment().startOf('month').toDate();
+                formFiltersStore.values.toDate = moment().endOf('month').toDate();
                 resolve();
               } else {
                 formFiltersStore.values.date = new Date();


### PR DESCRIPTION
## Overview
The current default date filter values for the Leave and Absence reports is for the current year, However some sites with large data still find it difficult to load this data at once, so this PR changes the default filter values and data fetch to be for the current month.

## Before
- The date filter for the leave and absence report is defaulted to current year and data is fetched for current year as well.

## After
- The date filter for the leave and absence report is now defaulted to current month and data is fetched for current month as well.

Changes does not affect tests.
- [ ] Tests Pass
