### PR TITLE
PCHR-3802: Fix Duplicate Data Issue in Leave Reports When After Saving A New Job Contract Revision

### DIFF
--- a/civihr_hrjobcontract_entities/civihr_hrjobcontract_entities.module
+++ b/civihr_hrjobcontract_entities/civihr_hrjobcontract_entities.module
@@ -33,8 +33,7 @@ function civihr_hrjobcontract_entities_init() {
                     r.overrided
                     FROM {$civi_db_name}.civicrm_hrjobcontract_revision AS r
                     LEFT JOIN {$civi_db_name}.civicrm_hrjobcontract c ON r.jobcontract_id = c.id
-
-                    WHERE c.deleted = 0");
+                    WHERE c.deleted = 0 AND r.id IN (SELECT MAX(id) FROM {$civi_db_name}.civicrm_hrjobcontract_revision t GROUP BY t.jobcontract_id)");
 
         db_query('DROP VIEW IF EXISTS hrjc_details');
         // ov_location.label AS location, => t.location


### PR DESCRIPTION
## Overview
Currently when a the contract details for a contact is edited and saved and a new contract revision is created, this leads to duplicate data for that contact in Leave reports and the leave count for the contact also increases and becomes inaccurate. Basically as more revisions are made, the data becomes more duplicated.

## Before
- The `hrjc_revision` VIEW is part of the table the Leave and Absence reports pull data from, It contains all the current and past revisions for a contract. In reality what we actually need is the latest revision for the contract.

<img width="600" alt="reports _ staging17 2018-06-11 16-18-25" src="https://user-images.githubusercontent.com/6951813/41240760-2ba0dd98-6d93-11e8-8c22-f999e2ee7942.png">


## After
- The query for generating the `hrjc_revision` VIEW is modified to create the view to contain only the latest revision for a contract.

<img width="599" alt="reports _ staging17 2018-06-11 16-07-37" src="https://user-images.githubusercontent.com/6951813/41240802-40e385c0-6d93-11e8-979b-cb2fc53d1c18.png">



changes does not affect tests.
- [ ] Tests Pass
