### PR TITLE
PCHR-3537: Re-add missing upgrader

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.install
+++ b/civihr_employee_portal/civihr_employee_portal.install
@@ -387,7 +387,6 @@ function civihr_employee_portal_update_7027() {
   features_revert(['civihr_default_permissions' => ['user_permission']]);
 }
 
-
 /**
  * Refresh the node files as onboarding form node was altered
  */
@@ -416,6 +415,14 @@ function civihr_employee_portal_update_7030() {
  */
 function civihr_employee_portal_update_7031() {
   features_revert(['civihr_default_mail_content' => ['variable']]);
+}
+
+/**
+ * Refresh the node files as onboarding form node was altered
+ */
+function civihr_employee_portal_update_7032() {
+  civicrm_initialize();
+  drush_civihr_employee_portal_refresh_node_export_files();
 }
 
 /**


### PR DESCRIPTION
## Overview

During a merge conflict one of the upgraders was dropped which meant the node export files were not re-imported

## Before

There was no upgrader to migrate changes from staging to the location types changes

## After

An ugprader has been added to refresh the nodes and apply changes from the location types feature
---

- [x] Tests Pass
