### PR TITLE
PCHR-3835: Manage Resources Page elated bug fixes

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -4578,7 +4578,7 @@ function civihr_employee_portal_node_presave($node) {
 }
 
 /**
- * Checks if oublish status checkbox is visible
+ * Checks if publish status checkbox is visible
  */
 function isPublishStatusCheckBoxVisible () {
   return !user_access('administer-nodes') && _user_has_role(['HR Admin']);

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -4572,9 +4572,16 @@ function civihr_employee_portal_node_view($node, $view_mode, $langcode) {
  * @param object $node
  */
 function civihr_employee_portal_node_presave($node) {
-  if($node->type === 'hr_documents') {
+  if(isPublishStatusCheckBoxVisible() && $node->type === 'hr_documents') {
     $node->status = $node->publish_status;
   }
+}
+
+/**
+ * Checks if oublish status checkbox is visible
+ */
+function isPublishStatusCheckBoxVisible () {
+  return !user_access('administer-nodes') && _user_has_role(['HR Admin']);
 }
 
 // Note: Under "Redirection location" NO redirect option should be select to get
@@ -4606,7 +4613,7 @@ function civihr_employee_portal_form_alter(&$form, &$form_state, $form_id) {
   if ($form_id == 'hr_documents_node_form') {
     $form['publish_status'] = array(
       '#type' => 'checkbox',
-      '#access' => !user_access('administer-nodes') && _user_has_role(['HR Admin']),
+      '#access' => isPublishStatusCheckBoxVisible(),
       '#title' => t('Published'),
       '#default_value' => $form['options']['status']['#default_value'],
       '#weight' => 3

--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.views_default.inc
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.views_default.inc
@@ -2068,8 +2068,11 @@ return date(\'Y-m-d\');';
   $handler->display->display_options['fields']['title']['id'] = 'title';
   $handler->display->display_options['fields']['title']['table'] = 'node';
   $handler->display->display_options['fields']['title']['field'] = 'title';
+  $handler->display->display_options['fields']['title']['alter']['make_link'] = TRUE;
+  $handler->display->display_options['fields']['title']['alter']['path'] = '/node/[nid]/edit';
   $handler->display->display_options['fields']['title']['alter']['word_boundary'] = FALSE;
   $handler->display->display_options['fields']['title']['alter']['ellipsis'] = FALSE;
+  $handler->display->display_options['fields']['title']['link_to_node'] = FALSE;
   /* Field: Content: Resource type */
   $handler->display->display_options['fields']['field_resource_type']['id'] = 'field_resource_type';
   $handler->display->display_options['fields']['field_resource_type']['table'] = 'field_data_field_resource_type';


### PR DESCRIPTION
## Overview
The following bugs related to the Manage Resource Page has been fixed
1. The Custom Publish checkbox's value should be saved only when its visible.
2. The Title in the Manage Resource page should link to the edit page of the node.

## Technical Details
1. `isPublishStatusCheckBoxVisible()` function has been created, and the logic to show the checkbox is moved here. The same is used in `civihr_employee_portal_node_presave()` and in `civihr_employee_portal_form_alter`.