### PR TITLE
PCHR-3861: Fill data layer container on module init

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -552,12 +552,12 @@ function civihr_employee_portal_init() {
 function _civihr_employee_portal_set_up_google_analytics_data_layer() {
   global $user;
 
-  datalayer_add(array(
+  datalayer_add([
     // The list of roles of the current user
     'userRoles' => join(';', array_filter($user->roles, function ($role) {
       return $role != 'authenticated user';
     })),
-  ));
+  ]);
 }
 
 /**

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -494,6 +494,7 @@ function civihr_employee_portal_init() {
   // calling this inside hook_init so we could access
   // some drupal functions such as user_access
   _user_redirection();
+  _civihr_employee_portal_set_up_google_analytics_data_layer();
 
   $query = drupal_get_query_parameters();
   if (isset($query['source']) && $query['source'] == 'onboarding') {
@@ -543,6 +544,20 @@ function civihr_employee_portal_init() {
       _load_ta_settings();
     }
   }
+}
+
+/**
+ * Sets up the content of GA's data layer container
+ */
+function _civihr_employee_portal_set_up_google_analytics_data_layer() {
+  global $user;
+
+  datalayer_add(array(
+    // The list of roles of the current user
+    'userRoles' => join(';', array_filter($user->roles, function ($role) {
+      return $role != 'authenticated user';
+    })),
+  ));
 }
 
 /**


### PR DESCRIPTION
The ssp module will now populate Google Analytic's `dataLayer` with the user's roles (minus the "authenticated user", which is a given).

The user roles, stored in the `userRoles` property, will be then used as custom dimension to create GA reports