### PR TITLE
PCHR-3886: Assign the Can Administer Calendar Feeds permission.

### DIFF
--- a/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
+++ b/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
@@ -992,6 +992,16 @@ function civihr_default_permissions_user_default_permissions() {
     'module' => 'rules',
   );
 
+  // Exported permission: 'can administer calendar feeds'.
+  $permissions['can administer calendar feeds'] = array(
+    'name' => 'can administer calendar feeds',
+    'roles' => array(
+      'HR Admin' => 'HR Admin',
+      'Regional HR Admin' => 'Regional HR Admin',
+    ),
+    'module' => 'civicrm',
+  );
+
   // Exported permission: 'can create and edit tasks'.
   $permissions['can create and edit tasks'] = array(
     'name' => 'can create and edit tasks',

--- a/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.info
+++ b/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.info
@@ -139,6 +139,7 @@ features[user_permission][] = assign all roles
 features[user_permission][] = block IP addresses
 features[user_permission][] = bypass node access
 features[user_permission][] = bypass rules access
+features[user_permission][] = can administer calendar feeds
 features[user_permission][] = can create and edit tasks
 features[user_permission][] = cancel account
 features[user_permission][] = cancel users with role 17087012


### PR DESCRIPTION
## Overview
This PR assigns the `Can Administer Calendar Feeds` created in [#2404](https://github.com/compucorp/civihr/pull/2704/files) to the CiviHR Admin and CiviHR Local Admin roles.

## Before
- This Permission is not assigned to any role

## After
- The `Can Administer Calendar Feeds` is assigned to the CiviHR Admin and CiviHR Local Admin roles.




- [ ] Tests Pass
Changes made does not affect tests.