### PR TITLE
PCHR-3835: Fix url for title in Manage HR Resources Page

### DIFF
--- a/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.views_default.inc
+++ b/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.views_default.inc
@@ -2069,7 +2069,7 @@ return date(\'Y-m-d\');';
   $handler->display->display_options['fields']['title']['table'] = 'node';
   $handler->display->display_options['fields']['title']['field'] = 'title';
   $handler->display->display_options['fields']['title']['alter']['make_link'] = TRUE;
-  $handler->display->display_options['fields']['title']['alter']['path'] = '/node/[nid]/edit';
+  $handler->display->display_options['fields']['title']['alter']['path'] = '/node/[nid]/edit?destination=manage-hr-resources';
   $handler->display->display_options['fields']['title']['alter']['word_boundary'] = FALSE;
   $handler->display->display_options['fields']['title']['alter']['ellipsis'] = FALSE;
   $handler->display->display_options['fields']['title']['link_to_node'] = FALSE;


### PR DESCRIPTION
## Overview
When HR Resources are edited using the title link, and saved, page should be redirected to the Manage HR Resources Page. This PR fixes that bug.

## Before
![before](https://user-images.githubusercontent.com/5058867/41722014-f82bc7ee-7584-11e8-99f9-9cc740a84529.gif)

## After
![after](https://user-images.githubusercontent.com/5058867/41721858-a05f0bac-7584-11e8-828c-f8391cc9615b.gif)

## Comments
This ticket is a subtask of PCHR-3674, so ideally I should be creating a PR to 3674 branch, and once merged, create another PR to staging. But as PCHR-3674 already got merged and then this ticket got reopened, I am creating PR directly to staging.