### PR TITLE
PCHR-3925: Check if datalayer module exists before using it

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -552,6 +552,10 @@ function civihr_employee_portal_init() {
 function _civihr_employee_portal_set_up_google_analytics_data_layer() {
   global $user;
 
+  if (!function_exists('datalayer_add')) {
+    return;
+  }
+
   datalayer_add([
     // The list of roles of the current user
     'userRoles' => join(';', array_filter($user->roles, function ($role) {

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -552,7 +552,7 @@ function civihr_employee_portal_init() {
 function _civihr_employee_portal_set_up_google_analytics_data_layer() {
   global $user;
 
-  if (!function_exists('datalayer_add')) {
+  if (!module_exists('datalayer')) {
     return;
   }
 


### PR DESCRIPTION
## Overview
The SSP module tried to use the `datalayer_add` regardless of the presence and/or status of the "datalayer" module, resulting in the SSP breaking if the module was disabled or non existing

## Technical Details
The PR simply adds a check to determine if the "datalayer" module exists, before using its function