### PR TITLE
PCHR-3870: Make Calendar Feed Generation URL Public

### DIFF
--- a/civihr_employee_portal/src/Security/PublicFirewall.php
+++ b/civihr_employee_portal/src/Security/PublicFirewall.php
@@ -21,7 +21,8 @@ class PublicFirewall {
     '@^user((?!\/register).)*$@', // user* except user/register
     'yoti', // yoti login plugin
     '@^yoti\/.*@', // anything under yoti
-    '@^yoti-connect*@' // also yoti login plugin, where the user is redirected after login
+    '@^yoti-connect*@', // also yoti login plugin, where the user is redirected after login
+    'civicrm/calendar-feed' //Leave request Calendar feed URL
   ];
 
   /**

--- a/civihr_employee_portal/tests/Security/PublicFirewallTest.php
+++ b/civihr_employee_portal/tests/Security/PublicFirewallTest.php
@@ -64,6 +64,7 @@ class PublicFirewallTest extends \PHPUnit_Framework_TestCase {
       ['yoti/anything'],
       ['yoti-connect'],
       ['yoti-connect/lorem-ipsum'],
+      ['civicrm/calendar-feed']
     ];
   }
 


### PR DESCRIPTION
## Overview
This PR adds the leave calendar feed generation URL to the `PublicFirewall` class so that it can be publicly accessible.

## Before
The `civicrm/calendar-feed` URL was not publicly accessible.

## After
- The `civicrm/calendar-feed` URL is now publicly accessible.
