### PR TITLE
PCHR-3950: Onbarding Wizard - Change Option Add Later to Skip this Step

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.install
+++ b/civihr_employee_portal/civihr_employee_portal.install
@@ -434,6 +434,14 @@ function civihr_employee_portal_update_7033() {
 }
 
 /**
+ * Renames onboarding wizard payroll option from "Add Later" to "Skip this step"
+ */
+function civihr_employee_portal_update_7034() {
+  civicrm_initialize();
+  drush_civihr_employee_portal_refresh_node_export_files();
+}
+
+/**
  * Function to determine whether menu link exists or not.
  *
  * @param string $path

--- a/civihr_employee_portal/features/node_export_files/onboarding_form.export
+++ b/civihr_employee_portal/features/node_export_files/onboarding_form.export
@@ -874,7 +874,7 @@ array(
               'wrapper_classes' => '',
               'css_classes' => 'onboarding_wizard_payroll_skip_radio',
               'aslist' => 0,
-              'items' => "2|Add Now\n1|Add Later\n",
+              'items' => "2|Add Now\n1|Skip this step\n",
               'multiple' => 0,
               'custom_keys' => 0,
               'empty_option' => '',


### PR DESCRIPTION
## Overview
Currently the `Payroll` section of `Onboarding Wizard` provides two options - 
* Add Now
* Add Later

This PR renames the `Add Later` option to `Skip this step`

## Before
<img width="688" alt="before_payroll" src="https://user-images.githubusercontent.com/1507645/42628427-045ae3f8-85c8-11e8-85c2-80eb1d24adcf.png">

## After
<img width="696" alt="after_payroll" src="https://user-images.githubusercontent.com/1507645/42628414-f8195ee4-85c7-11e8-92e5-27db740bd471.png">

## Technical Details
The display text of the option group was changed