### PR TITLE
PCHR-3965: Job Roles Layout fixes

### DIFF
--- a/civihr_employee_portal/views/views_export/views_mydetails_myrole.inc
+++ b/civihr_employee_portal/views/views_export/views_mydetails_myrole.inc
@@ -13,7 +13,6 @@ $view->disabled = FALSE; /* Edit this to true to make a default view disabled in
 /* Display: Master */
 $handler = $view->new_display('default', 'Master', 'default');
 $handler->display->display_options['title'] = 'My Roles';
-$handler->display->display_options['css_class'] = 'chr_panel--my-details__view__panel';
 $handler->display->display_options['use_more_always'] = FALSE;
 $handler->display->display_options['access']['type'] = 'perm';
 $handler->display->display_options['access']['perm'] = 'view my details';
@@ -119,7 +118,7 @@ $handler->display->display_options['fields']['nothing_1']['id'] = 'nothing_1';
 $handler->display->display_options['fields']['nothing_1']['table'] = 'views';
 $handler->display->display_options['fields']['nothing_1']['field'] = 'nothing';
 $handler->display->display_options['fields']['nothing_1']['label'] = '';
-$handler->display->display_options['fields']['nothing_1']['alter']['text'] = '<div class="panel-panel">
+$handler->display->display_options['fields']['nothing_1']['alter']['text'] = '<div class="panel-panel chr_panel--my-details__view__panel">
   <div class="panel-panel-inner">
     <div class="panel-pane pane-block">
       <h2 class="pane-title">


### PR DESCRIPTION
## Overview
This PR fixes the styles for Job Roles section of My Details page.

## Before
![2018-07-13 at 10 21 pm](https://user-images.githubusercontent.com/5058867/42703743-141e7470-86eb-11e8-837c-0a2b672924bf.png)

## After
![2018-07-13 at 10 20 pm](https://user-images.githubusercontent.com/5058867/42703701-eb2ffff2-86ea-11e8-9191-bd25f731ab92.png)

## Technical Details
1. If a class with underscore's are specified in drupal, it gets converted to dash. So moved the class `chr_panel--my-details__view__panel` to the template. 