### PR TITLE
PCHR-3969: Move City Above Postal Code in My Home Address Webform

### DIFF
--- a/civihr_employee_portal/features/node_export_files/mydetails_home_address.export
+++ b/civihr_employee_portal/features/node_export_files/mydetails_home_address.export
@@ -1,7 +1,7 @@
 array(
   (object) array(
       'vid' => '13',
-      'uid' => '1',
+      'uid' => '0',
       'title' => 'My Home Address',
       'log' => '',
       'status' => '1',
@@ -12,12 +12,12 @@ array(
       'nid' => '13',
       'type' => 'webform',
       'language' => 'en',
-      'created' => '1529441885',
-      'changed' => '1529705674',
+      'created' => '1531151531',
+      'changed' => '1531710739',
       'tnid' => '0',
       'translate' => '0',
       'uuid' => 'c12cadd6-eab6-4f80-a6e7-e2053129a96d',
-      'revision_timestamp' => '1529705674',
+      'revision_timestamp' => '1531710739',
       'revision_uid' => '1',
       'rdf_mapping' => array(
         'rdftype' => array(
@@ -76,7 +76,7 @@ array(
       ),
       'webform' => array(
         'nid' => '13',
-        'next_serial' => '5',
+        'next_serial' => '6',
         'confirmation' => '',
         'confirmation_format' => 'filtered_html',
         'redirect_url' => '<none>',
@@ -241,16 +241,16 @@ array(
             'weight' => '5',
             'page_num' => 1,
           ),
-          6 => array(
+          5 => array(
             'nid' => 13,
-            'cid' => '6',
+            'cid' => '5',
             'pid' => '0',
-            'form_key' => 'civicrm_1_contact_1_address_postal_code',
-            'name' => 'Postal Code',
+            'form_key' => 'civicrm_1_contact_1_address_city',
+            'name' => 'City',
             'type' => 'textfield',
             'value' => '',
             'extra' => array(
-              'width' => 7,
+              'width' => 20,
               'private' => 0,
               'maxlength' => '',
               'field_prefix' => '',
@@ -268,16 +268,16 @@ array(
             'weight' => '6',
             'page_num' => 1,
           ),
-          5 => array(
+          6 => array(
             'nid' => 13,
-            'cid' => '5',
+            'cid' => '6',
             'pid' => '0',
-            'form_key' => 'civicrm_1_contact_1_address_city',
-            'name' => 'City',
+            'form_key' => 'civicrm_1_contact_1_address_postal_code',
+            'name' => 'Postal Code',
             'type' => 'textfield',
             'value' => '',
             'extra' => array(
-              'width' => 20,
+              'width' => 7,
               'private' => 0,
               'maxlength' => '',
               'field_prefix' => '',
@@ -359,9 +359,9 @@ array(
       'last_comment_name' => NULL,
       'last_comment_uid' => '1',
       'comment_count' => '0',
-      'name' => 'admin',
+      'name' => '',
       'picture' => '0',
-      'data' => 'a:1:{s:17:"mimemail_textonly";i:0;}',
+      'data' => NULL,
       'webform_civicrm' => array(
         'nid' => '13',
         'data' => array(


### PR DESCRIPTION
## Overview
In Home Address webform from My Details page Postal code is showing above city. It should be the opposite, City must be above Postal Code.

## Before
![image](https://user-images.githubusercontent.com/3916979/42742002-d14024bc-887c-11e8-9866-5817abb918f3.png)

## After
![image](https://user-images.githubusercontent.com/3916979/42741996-c2769222-887c-11e8-96a6-394cc2c627b7.png)
