### PR TITLE
PCHR-4010: Update path for reqangular.min.js

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5189,7 +5189,7 @@ function civihr_employee_portal_hrreport_landing_page() {
   $jsOptions = ['type' => 'file', 'scope' => 'footer'];
 
   if (_civihr_employee_portal_is_extension_enabled('org.civicrm.reqangular')) {
-    drupal_add_js(CRM_Core_Resources::singleton()->getUrl('org.civicrm.reqangular') . "dist/reqangular.min.js", $jsOptions);
+    drupal_add_js(CRM_Core_Resources::singleton()->getUrl('org.civicrm.reqangular') . "js/dist/reqangular.min.js", $jsOptions);
   }
 
   drupal_add_css(drupal_get_path('module', 'civihr_employee_portal') . '/css/reports.css');
@@ -5554,7 +5554,7 @@ function _civihr_employee_portal_add_report_scripts() {
   drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . '/lib/moment/moment.min.js', $jsOptions);
 
   if (_civihr_employee_portal_is_extension_enabled('org.civicrm.reqangular')) {
-    drupal_add_js(CRM_Core_Resources::singleton()->getUrl('org.civicrm.reqangular') . "dist/reqangular.min.js", $jsOptions);
+    drupal_add_js(CRM_Core_Resources::singleton()->getUrl('org.civicrm.reqangular') . "js/dist/reqangular.min.js", $jsOptions);
   }
 
   // Base reports.js script


### PR DESCRIPTION
## Overview
As part of this PR the path for `reqangular.min.js` is updated for the Reports page.

## Before
![2018-07-23 at 3 10 pm](https://user-images.githubusercontent.com/5058867/43069386-8de41232-8e8a-11e8-9477-2d55fd90f870.png)

![2018-07-23 at 3 10 pm](https://user-images.githubusercontent.com/5058867/43069424-a7e53f76-8e8a-11e8-8342-44209cf6380d.png)


## After
![2018-07-23 at 3 06 pm](https://user-images.githubusercontent.com/5058867/43069158-0cc564bc-8e8a-11e8-8ebb-059a21a5e110.png)

![2018-07-23 at 3 07 pm](https://user-images.githubusercontent.com/5058867/43069185-18a64c6a-8e8a-11e8-96a6-a0df17945d62.png)

## Technical Details
In PCHR-3942 (https://github.com/compucorp/civihr/pull/2772) the path for `reqangular.min.js` was changed, but the same was not updated in `civihr_employee_portal.module`, which broke the Reports pages.
The path has been fixed.

---

- [x] Manual Tests Pass
