### PR TITLE
PCHR-3424: Remove Bootstrapcivihr theme inclusion from SSP

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -47,6 +47,7 @@ function civihr_employee_portal_css_alter(&$css) {
     _remove_resources($css, $removeFiles);
   } else {
     _remove_extension_resources('org.civicrm.shoreditch', $css);
+    _remove_extension_resources('org.civicrm.bootstrapcivihr', $css);
   }
 }
 

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -46,7 +46,7 @@ function civihr_employee_portal_css_alter(&$css) {
 
     _remove_resources($css, $removeFiles);
   } else {
-    _remove_shoreditch_resources($css);
+    _remove_extension_resources('org.civicrm.shoreditch', $css);
   }
 }
 
@@ -81,7 +81,7 @@ function civihr_employee_portal_js_alter(&$javascript) {
 
     _remove_resources($javascript, $removeFiles);
   } else {
-    _remove_shoreditch_resources($javascript);
+    _remove_extension_resources('org.civicrm.shoreditch', $javascript);
   }
 }
 
@@ -105,15 +105,16 @@ function _remove_resources(&$resourcesList, $blacklist = []) {
 }
 
 /**
- * Removes any resource related to the shoreditch extension
+ * Removes any resource related to the specified extension
  *
+ * @param string $extension e.g. 'org.civicrm.shoreditch'
  * @param array
  *   &$resourcesList variable contains all the references to loaded
  *   js/css array from alter.
  */
-function _remove_shoreditch_resources(&$resourcesList) {
+function _remove_extension_resources($extension, &$resourcesList) {
   foreach ($resourcesList as $path => $resource) {
-    if (strpos($path, 'org.civicrm.shoreditch')) {
+    if (strpos($path, $extension)) {
       unset($resourcesList[$path]);
     }
   }


### PR DESCRIPTION
## Overview

This PR removes the inclusion of Bootstrapcivihr CSS resource files from all SSP pages. This PR is tightly related with https://github.com/compucorp/civihr-employee-portal-theme/pull/377.

## Before

Every SSP page source HTML contains:

```html
<link type="text/css" rel="stylesheet" href="http://localhost:8888/sites/all/modules/civicrm/tools/extensions/civihr/org.civicrm.bootstrapcivihr/css/civihr.css?r=7B2iE" media="all" />
```

## After

None of SSP pages source HTML contain the CSS file inclusion link mentioned in the Before section.

## Technical Details

Same method as seen at https://github.com/compucorp/civihr/pull/2166/files#diff-121b31ed9140681ebf2bf197b1aa8821R124 is used. However, the resource removal function is now universal and accepts an `$extension` parameter:

```php
function _remove_extension_resources($extension, &$resourcesList) {
  foreach ($resourcesList as $path => $resource) {
    if (strpos($path, $extension)) { // you can specify an extension
      unset($resourcesList[$path]);
```

So now we specify the extensions to remove from non-civicrm pages (like SSP pages):

```php
function civihr_employee_portal_css_alter(&$css) {
  // ...

  if (_isCiviCRM()) {
    // not related to this PR
  } else {
    _remove_extension_resources('org.civicrm.shoreditch', $css);
    _remove_extension_resources('org.civicrm.bootstrapcivihr', $css);
```

---

✅Manual Tests - passed
⏹Jasmine Tests - not needed
⏹JS distributive files - not needed
⏹CSS distributive files - not needed
⚠️Backstop tests - diffs spotted, but fixed in https://github.com/compucorp/civihr-employee-portal-theme/pull/377
⏹PHP Unit Tests - not needed
