### PR TITLE
PCHR-4037: fix views import of custom fields at the creation of views

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -15,6 +15,7 @@ use Drupal\civihr_employee_portal\Page\HRDetailsPage;
 use Drupal\civihr_employee_portal\Webform\WebformTransferService;
 use Drupal\civihr_employee_portal\Helpers\LinkProvider;
 use Drupal\civihr_employee_portal\Helpers\TaxonomyHelper;
+use Drupal\civihr_employee_portal\View\CustomFieldsMappingFixer;
 
 /**
  * Implements hook_install().
@@ -854,6 +855,7 @@ function civihr_employee_portal_views_default_views() {
 
     if (isset($view)) {
       $views[$view->name] = $view;
+      CustomFieldsMappingFixer::fixMapping($view);
     }
   }
 

--- a/civihr_employee_portal/src/View/CustomFieldsMappingFixer.php
+++ b/civihr_employee_portal/src/View/CustomFieldsMappingFixer.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Drupal\civihr_employee_portal\View;
+
+/**
+ * To match unknown table names and field names when importing views
+ * with custom fields and custom groups from CiviCRM.
+ * Replaces unknown fields names and unknown tables like:
+ * - exported [name_of_the_field]_[ID1] with existing [name_of_the_field]_[ID2]
+ * - exported [name_of_the_table]_[ID3] with existing [name_of_the_table]_[ID4]
+ * ... where ID1, ID2, ID3 & ID4 are different numbers created by different
+ * mechanisms thus producing different IDs.
+ */
+class CustomFieldsMappingFixer {
+
+  /**
+   * To fix mapping on Views import of CiviCRM custom fields
+   *
+   * @param view $view
+   *     the view that is being imported / recreated
+   */
+  public static function fixMapping($view) {
+    foreach ($view->display as $display) {
+      foreach ($display->display_options as &$displayOption) {
+        if (!is_array($displayOption)) {
+          continue;
+        }
+
+        self::processDisplayOptions($displayOption);
+      }
+    }
+  }
+
+  /**
+   * Process all display options for an exported view only when it is related
+   * to a field and the field has a number at the end of its name, which is
+   * the pattern for custom fields from CiviCRM
+   *
+   * @var array
+   *     Display option a exported view structure
+   */
+  private static function processDisplayOptions(&$displayOption) {
+    foreach ($displayOption as &$option) {
+      // only continue if this option is about a field
+      if (!isset($option['field'])) {
+        continue;
+      }
+
+      $optionIdParts = explode('_', $option['field']);
+      $finalIdPart = array_pop($optionIdParts);
+      if (count($optionIdParts) === 0 || !intval($finalIdPart)) {
+        continue;
+      }
+
+      self::processOption($option);
+    }
+  }
+
+  /**
+   * To process a display option for a field in view
+   *
+   * @var array $option
+   *     structure that contains an option for a field in view
+   */
+  private static function processOption(&$option) {
+    // checking if this table is part of the civicrm views integration
+    $tableName = self::getCiviCRMtableName($option['table']);
+    $prefix = $tableName ? self::getPrefix($tableName) : false;
+    if ( $prefix ) {
+      $option['table'] = $tableName;
+      $columns = self::getColumnsFromTable($prefix . $tableName);
+      // if the table where the current field belongs exists does not have it
+      // then we can search for similar fields in the same table and make replacements
+      if (!isset($columns[$option['field']])) {
+        $fieldNameBase = self::removeLastNumberOfString($option['field']);
+        $pos = array_search($fieldNameBase, $columns);
+        if ($pos !== FALSE) {
+          $option['field'] = array_search($columns[$pos], $columns);
+        }
+      }
+    }
+  }
+
+  /**
+   * Removes the number in end of a string
+   * In this context that number is always separated by an underscore
+   *
+   * @param  string $string
+   *     the string which could have underscores or not
+   *
+   * @return string
+   *     the string without the number at the end,
+   *     if no number found at the end returns the same string
+   */
+  private static function removeLastNumberOfString($string) {
+    $pieces = explode('_', $string);
+    $lastIndex = count($pieces) - 1;
+    return $lastIndex > 0 && intval(array_pop($pieces)) ? implode('_', $pieces) : $string;
+  }
+
+  /**
+   * Return an existing CiviCRM table based on the base name of the table,
+   * where "base name of the table" is the name of the table without the number
+   * at the end
+   *
+   * @param string $tableName
+   *     this is the table name exported by views
+   *
+   * @return string
+   *     the name of the existing table if found or an empty string
+   */
+  private static function getCiviCRMtableName($tableName) {
+    global $databases;
+    static $tableNamesMap = [];
+    // creates a map with table names without IDs to existing table names with IDs
+    if (!$tableNamesMap) {
+      $tablesWithIds = array_keys($databases['default']['default']['prefix']);
+      foreach ($tablesWithIds as $tableWithId) {
+        $tableNamesMap[self::removeLastNumberOfString($tableWithId)] = $tableWithId;
+      }
+    }
+
+    $exportedTableBaseName = self::removeLastNumberOfString($tableName);
+    $tableFound = isset($tableNamesMap[$exportedTableBaseName]);
+    return $tableFound ? $tableNamesMap[$exportedTableBaseName] : '';
+  }
+
+  /**
+   * To obtain the prefix for a table in the current installation
+   *
+   * @param string $tableName
+   *     the name of the table
+   *
+   * @return string
+   *     the prefix for the table
+   */
+  private static function getPrefix($tableName) {
+    global $databases;
+    return $databases['default']['default']['prefix'][$tableName];
+  }
+
+  /**
+   * Gets the columns from a table keyed by the name of the column without
+   * the sequential at the end
+   *
+   * @param string $table
+   *     the name of the table
+   *
+   * @return array
+   *     the names of the columns of the table
+   */
+  private static function getColumnsFromTable($table) {
+    static $columns = [];
+    if (!isset( $columns[$table])) {
+      $columns[$table] = [];
+      $res = db_query('SHOW COLUMNS FROM ' . $table)->fetchAll();
+      foreach ($res as $field) {
+        $columns[$table][$field->Field] = self::removeLastNumberOfString($field->Field);
+      }
+    }
+
+    return $columns[$table];
+  }
+}


### PR DESCRIPTION
## Overview
Depending on the creation of CiviCRM custom fields and CiviCRM custom tables their names may vary on different installations. Examples:

- From `custom_field_25` to `custom_field_10001`
- From `custom_table_38` (exported table name from another site) to `custom_table_51` (existing table on current site)
 
When these fields/tables names change it may produce bad references when importing views that use these names, which generates empty queries due to missing fields or tables, which in turn causes views not showing the expected results.

## When it happens
It happens when a Custom Group/Field is created using the CiviCRM API. The table and field names will get the next ID available at the moment the API call is made and there's no way to guarantee that this next ID will be the same in all sites. This is why different sites have different IDs.

## Solution

This PR proposes a work around to fix this issue by altering the structure of the view that is going to be imported to match existing names of fields and tables based on the names of the missing fields and tables.

Implementing `hook_views_default_views` the view structure can be altered previous import. 

- Every table not found in current installation is searched against the CiviCRM views intergration array defined in `settings.php`, to find a similar table name, if found, the view structure values are changed accordingly.

- Every field not found in current installation is searched in the table where the field belongs, to find a similar field name, if found, the view structure values are changed accordingly.