### PR TITLE
PCHR-3941: Detach require.min.js from reqangular

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -6691,13 +6691,9 @@ function _civihr_employee_portal_create_default_reports_configuration() {
 function civihr_employee_portal_get_markup_for_extension($resource = '', $scriptExtensionKey, $markupModuleName) {
   $script = CRM_Core_Config::singleton()->debug ? "{$resource}.js" : "{$resource}.min.js";
 
-  // Adds RequireJS library only once
+  // Adds RequireJS + AngularJS dependencies only once
   if (!strpos(drupal_get_js('footer'), 'require.min.js')) {
     civicrm_resources_load('org.civicrm.reqangular', ['require.min.js']);
-  }
-
-  // Adds AngularJS dependencies only once
-  if (!strpos(drupal_get_js('footer'), 'reqangular.min.js')) {
     civicrm_resources_load('org.civicrm.reqangular', ['reqangular.min.js']);
   }
 

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -531,8 +531,8 @@ function civihr_employee_portal_init() {
       '/lib/sweetalert/sweetalert.min.js'
     ]);
 
-    _add_script_to_page(['reqangular.min.js'], 'org.civicrm.reqangular', 'dashboard');
-    _add_script_to_page(['reqangular.min.js'], 'org.civicrm.reqangular', 'tasks-and-documents');
+    _add_script_to_page(['require.min.js', 'reqangular.min.js'], 'org.civicrm.reqangular', 'dashboard');
+    _add_script_to_page(['require.min.js', 'reqangular.min.js'], 'org.civicrm.reqangular', 'tasks-and-documents');
     _add_script_to_page(['/js/tasks.js'], NULL, 'tasks-and-documents', 'header');
     _add_script_to_page(['/js/ta-documents-app.js'], NULL, 'tasks-and-documents');
     _add_script_to_page(['tasks-assignments.min.js'], 'uk.co.compucorp.civicrm.tasksassignments', 'tasks-and-documents');
@@ -5189,6 +5189,7 @@ function civihr_employee_portal_hrreport_landing_page() {
   $jsOptions = ['type' => 'file', 'scope' => 'footer'];
 
   if (_civihr_employee_portal_is_extension_enabled('org.civicrm.reqangular')) {
+    drupal_add_js(CRM_Core_Resources::singleton()->getUrl('org.civicrm.reqangular') . "js/src/common/vendor/require.min.js", $jsOptions);
     drupal_add_js(CRM_Core_Resources::singleton()->getUrl('org.civicrm.reqangular') . "js/dist/reqangular.min.js", $jsOptions);
   }
 
@@ -5554,6 +5555,7 @@ function _civihr_employee_portal_add_report_scripts() {
   drupal_add_js(drupal_get_path('module', 'civihr_employee_portal') . '/lib/moment/moment.min.js', $jsOptions);
 
   if (_civihr_employee_portal_is_extension_enabled('org.civicrm.reqangular')) {
+    drupal_add_js(CRM_Core_Resources::singleton()->getUrl('org.civicrm.reqangular') . "js/src/common/vendor/require.min.js", $jsOptions);
     drupal_add_js(CRM_Core_Resources::singleton()->getUrl('org.civicrm.reqangular') . "js/dist/reqangular.min.js", $jsOptions);
   }
 
@@ -6689,7 +6691,12 @@ function _civihr_employee_portal_create_default_reports_configuration() {
 function civihr_employee_portal_get_markup_for_extension($resource = '', $scriptExtensionKey, $markupModuleName) {
   $script = CRM_Core_Config::singleton()->debug ? "{$resource}.js" : "{$resource}.min.js";
 
-  // Adds RequireJS + AngularJS dependencies only once
+  // Adds RequireJS library only once
+  if (!strpos(drupal_get_js('footer'), 'require.min.js')) {
+    civicrm_resources_load('org.civicrm.reqangular', ['require.min.js']);
+  }
+
+  // Adds AngularJS dependencies only once
   if (!strpos(drupal_get_js('footer'), 'reqangular.min.js')) {
     civicrm_resources_load('org.civicrm.reqangular', ['reqangular.min.js']);
   }


### PR DESCRIPTION
## Overview
In https://github.com/compucorp/civihr/pull/2775, the `require.min.js` has been detached from `reqangular.min.js`. In this PR the 'require.min.js' is attached to the DOM