### PR TITLE
PCHR-4034: Settings to Send Notifications on Contact Details Changes

### DIFF
--- a/civihr_employee_portal/src/Forms/OnboardingWizardCustomizationForm.php
+++ b/civihr_employee_portal/src/Forms/OnboardingWizardCustomizationForm.php
@@ -226,4 +226,27 @@ class OnboardingWizardCustomizationForm {
       '#weight' => -10,
     ];
   }
+
+  /**
+   * To validate the email which will receive the updates
+   *
+   * @param array $element
+   *    The email input field
+   * @param array $form_state
+   *    the state of the onboarding form
+   */
+  public function validateEmail($element, &$form_state) {
+    $value = $element['#value'];
+    $send_updates = $form_state['input']['civihr_onboarding_send_updates'];
+    // only validate if admin has chosen to send updates
+    if ($send_updates) {
+      // no empty value
+      if ($value == '') {
+        form_error($element, t('If you choose to receive updates then email field is mandatory'));
+        // checking email address is valid
+      } else if (!valid_email_address($value)) {
+        form_error($element, t('The entered email address which will receive the updates is not valid'));
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Overview
Add settings to let HR Admin to configure notifications when a contact changes its details.
Settings added to the Onboarding Wizard config form.

## Before
![peek 2018-07-26 23-43](https://user-images.githubusercontent.com/3916979/43301984-c0a08caa-912d-11e8-9bdb-974bf80734e0.gif)

## After
![peek 2018-07-26 23-41](https://user-images.githubusercontent.com/3916979/43301957-a82d2566-912d-11e8-849f-9a68f6376263.gif)


