### PR TITLE
PCHR-4073: Fix SSP Filter on Staff Directory

### DIFF
--- a/civihr_employee_portal/src/View/StaffDirectoryView.php
+++ b/civihr_employee_portal/src/View/StaffDirectoryView.php
@@ -16,13 +16,17 @@ class StaffDirectoryView extends AbstractView {
     $queryParts = [];
     $this->getWhereFields($query->where, $queryParts);
     $departmentField = 'hrjc_role_hrjc_revision.role_department';
+    $titleField = 'hrjc_role_hrjc_revision.role_title';
     $roleEndField = 'hrjc_role_hrjc_revision.role_end_date';
+    $roleStartField = 'hrjc_role_hrjc_revision.role_start_date';
 
-    // if department is set we must limit to only current roles
-    if (!empty($queryParts[$departmentField])) {
-      $group = $query->set_where_group('OR'); // add a new WHERE group
-      $query->add_where($group, $roleEndField, date('Y-m-d'), '>=');
-      $query->add_where($group, $roleEndField, NULL, 'IS');
+    // if department or title is set we must limit to only current roles
+    if (!empty($queryParts[$departmentField]) || !empty($queryParts[$titleField])) {
+      $roleEndGroup = $query->set_where_group('OR'); // add a new WHERE group
+      $query->add_where($roleEndGroup, $roleEndField, date('Y-m-d'), '>=');
+      $query->add_where($roleEndGroup, $roleEndField, NULL, 'IS');
+      $roleStartGroup = $query->set_where_group();
+      $query->add_where($roleStartGroup, $roleStartField, date('Y-m-d'), '<=');
     }
   }
 }


### PR DESCRIPTION
## Overview
Filtering staff records in SSP have some issue with job roles that are not active. This PR fixes the issue by applying additional filter condition to job role start date. Date filtering is now applied to filter requests containing department and job title.

## Before
Staff with job roles starting in the future or past end dates show up when running filter.

## After
Staff with job roles starting in the future or past end dates no longer show up in filter result.

## Technical Details
In [Staff Details View](https://github.com/compucorp/civihr-employee-portal/blob/staging/civihr_employee_portal/src/View/StaffDirectoryView.php#L15) the query was altered to cater for `job title` and `role start date` field in addition to `department` and `role end date` fields.
```
$titleField = 'hrjc_role_hrjc_revision.role_title';
$roleStartField = 'hrjc_role_hrjc_revision.role_start_date';
```

Additional query grouping was added.
```
$andGroup = $query->set_where_group();
$query->add_where($andGroup, $roleStartField, date('Y-m-d'), '<=');
```