### PR TITLE
PCHR-3952: Intro text for Onboarding Wizard

### DIFF
--- a/civihr_employee_portal/src/Forms/OnboardingWebForm.php
+++ b/civihr_employee_portal/src/Forms/OnboardingWebForm.php
@@ -211,26 +211,13 @@ class OnboardingWebForm {
   }
 
   /**
-   * Gets the help text to show the user at the beginning of the onboarding
-   * form. Differs depending on whether they've been created before the
-   * onboarding feature was released.
+   * Gets the help text to show the user at the beginning of the onboarding form.
    *
    * @return string
    */
   private function getHelpText() {
-    if ($this->userCreatedAfterOnboardingReleased()) {
-      return 'Please complete your details using the onboarding wizard.<br/>'
-        . 'The data is saved directly onto your profile. You can always update '
-        . 'your details at a later date using the self service portal.'
-        . '<br/><br/>You can optionally skip this wizard and be reminded next '
-        . 'time you login.';
-    } else {
-      return 'CiviHR users can now complete a quick and easy'
-        . ' wizard to enter their details into the system.<br/>Any information '
-        . 'that you have already provided to the system will be shown in the '
-        . 'wizard and can be updated.<br/><br/>You can optionally skip this '
-        . 'wizard and be reminded next time you login.';
-    }
+    return 'Please start by entering your details below.'
+      . '<br/><br/> You can always update these details later.';
   }
 
   /**


### PR DESCRIPTION
## Overview
Previously, onboarding wizard shows two different message based on when site was created (before or after onboarding feature). This PR unifies the intro text for all users. 

## Before
##### Before Onboarding Feature
<img width="356" alt="intro_text_1" src="https://user-images.githubusercontent.com/1507645/44523999-df54ff80-a6d3-11e8-96d2-0c653db4eac7.png">

##### After Onboarding Feature
<img width="392" alt="intro_text_2" src="https://user-images.githubusercontent.com/1507645/44524042-f8f64700-a6d3-11e8-9579-dd99beb77fe6.png">


## After
<img width="155" alt="after_intro_text" src="https://user-images.githubusercontent.com/1507645/44524251-a79a8780-a6d4-11e8-83d6-07cc2e4ac037.png">


## Technical Details
Conditional checks were removed and single intro response returned for all setup.
```
...
return 'Please start by entering your details below.'
  . '<br/><br/> You can always update these details later.';
...
```