### PR TITLE
PCHR-4152: Webform Logging Switch

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5154,6 +5154,8 @@ function civihr_employee_portal_webform_submission_insert($node, $submission) {
   $onboardingTitle = OnboardingWebForm::NAME;
   $isOnboardingForm = $nodeTitle === $onboardingTitle;
 
+  LoggingStreamSwitcher::disableLogging($nodeTitle);
+
   if ($isOnboardingForm) {
     $form = new OnboardingWebForm();
     $form->onSubmit($node, $submission);
@@ -6732,5 +6734,16 @@ function civihr_employee_portal_page_build(&$page) {
   if (drupal_get_path_alias() == 'hr-details') {
       ctools_include('modal');
       ctools_modal_add_js();
+  }
+}
+
+function civihr_employee_portal_webform_submission_presave($node, &$submission) {
+  $webformsToLog = [
+    'My details - edit',
+  ];
+
+  $title = $node->title;
+  if (in_array($title, $webformsToLog)) {
+    LoggingStreamSwitcher::enableLogging($title);
   }
 }

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -15,6 +15,8 @@ use Drupal\civihr_employee_portal\Page\HRDetailsPage;
 use Drupal\civihr_employee_portal\Webform\WebformTransferService;
 use Drupal\civihr_employee_portal\Helpers\LinkProvider;
 use Drupal\civihr_employee_portal\Helpers\TaxonomyHelper;
+use Drupal\civihr_employee_portal\Helpers\LoggingStreamSwitcher;
+use Drupal\civihr_employee_portal\Hook\ModuleImplementsAlter\ViewsDataAlterImplementationReorderer;
 
 /**
  * Implements hook_install().
@@ -6019,36 +6021,15 @@ function civihr_employee_portal_tokens($type, $tokens, array $data = [], array $
  * Implements hook_module_implements_alter()
  */
 function civihr_employee_portal_module_implements_alter(&$implementations, $hook) {
+  $alterers = [
+    new ViewsDataAlterImplementationReorderer(),
+  ];
 
-    if ($hook != 'views_data_alter') {
-        return;
+  foreach ($alterers as $alterer) {
+    if ($alterer->shouldAlter($hook)) {
+      $alterer->alter($implementations);
     }
-
-  watchdog('alter default order', print_r($implementations, TRUE));
-
-  $group = [];
-
-  // Check if the module exists and it's installed
-  if (module_exists('views_autocomplete_filters')) {
-    // Put the views autocomplete filters after civicrm
-    $module = 'views_autocomplete_filters';
-    $group += [$module => $implementations[$module]];
-    unset($implementations[$module]);
   }
-
-    /**
-   * Put the civihr employee portal module after civicrm module . The civicrm
-   * module will ruthlessly replace all changes from views_data_alter hook
-   * @see civicrm_views_data_alter
-   */
-     $module = 'civihr_employee_portal';
-     $group += array($module => $implementations[$module]);
-     unset($implementations[$module]);
-
-  // Make sure some modules are after civicrm to avoid error with autocomplete search or drush cc all
-  $implementations = $implementations + $group;
-
-  watchdog('alter modified order', print_r($implementations, TRUE));
 }
 
 function civihr_employee_portal_civicrm_post($op, $objectName, $objectId, &$objectRef) {

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -6737,6 +6737,15 @@ function civihr_employee_portal_page_build(&$page) {
   }
 }
 
+/**
+ * Implements hook_webform_submission_presave().
+ *
+ * Switches logging on for certain webform changes. The logging will be done
+ * in CiviHR and used to trigger an email to notify admins of changes.
+ *
+ * @param \stdClass $node
+ * @param array $submission
+ */
 function civihr_employee_portal_webform_submission_presave($node, &$submission) {
   $webformsToLog = [
     'My details - edit',

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -6023,6 +6023,7 @@ function civihr_employee_portal_tokens($type, $tokens, array $data = [], array $
 function civihr_employee_portal_module_implements_alter(&$implementations, $hook) {
   $alterers = [
     new ViewsDataAlterImplementationReorderer(),
+    new WebformSubmissionPreSaveReorderer(),
   ];
 
   foreach ($alterers as $alterer) {

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -17,6 +17,8 @@ use Drupal\civihr_employee_portal\Helpers\LinkProvider;
 use Drupal\civihr_employee_portal\Helpers\TaxonomyHelper;
 use Drupal\civihr_employee_portal\Helpers\LoggingStreamSwitcher;
 use Drupal\civihr_employee_portal\Hook\ModuleImplementsAlter\ViewsDataAlterImplementationReorderer;
+use Drupal\civihr_employee_portal\Hook\ModuleImplementsAlter\WebformSubmissionPreSaveReorderer;
+use Drupal\civihr_employee_portal\Hook\ModuleImplementsAlter\WebformSubmissionInsertReorderer;
 
 /**
  * Implements hook_install().
@@ -6024,6 +6026,7 @@ function civihr_employee_portal_module_implements_alter(&$implementations, $hook
   $alterers = [
     new ViewsDataAlterImplementationReorderer(),
     new WebformSubmissionPreSaveReorderer(),
+    new WebformSubmissionInsertReorderer(),
   ];
 
   foreach ($alterers as $alterer) {

--- a/civihr_employee_portal/src/Forms/OnboardingWebForm.php
+++ b/civihr_employee_portal/src/Forms/OnboardingWebForm.php
@@ -238,18 +238,4 @@ class OnboardingWebForm {
     return sprintf('<a href="%s">%s</a>', $link, $buttonMarkup);
   }
 
-  /**
-   * Checks if the current logged in user was created after the onboarding
-   * feature was released.
-   *
-   * @return bool
-   */
-  private function userCreatedAfterOnboardingReleased() {
-    global $user;
-    $onboardingForm = WebformHelper::findOneByTitle(self::NAME);
-    $onboardingRelease = $onboardingForm->created;
-
-    return $user->created > $onboardingRelease;
-  }
-
 }

--- a/civihr_employee_portal/src/Helpers/LoggingStreamSwitcher.php
+++ b/civihr_employee_portal/src/Helpers/LoggingStreamSwitcher.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\civihr_employee_portal\Helpers;
+
+/**
+ * Handles enabling and disabling of logging streams. The actual logging is
+ * handled elsewhere - see the CiviHR hrcore extension.
+ */
+class LoggingStreamSwitcher {
+
+  /**
+   * @param string $streamName
+   */
+  public static function enableLogging($streamName) {
+    global $civihrChangeLogStreams;
+    $civihrChangeLogStreams[$streamName] = TRUE;
+  }
+
+  /**
+   * @param string $streamName
+   */
+  public static function disableLogging($streamName) {
+    global $civihrChangeLogStreams;
+    $civihrChangeLogStreams[$streamName] = FALSE;
+  }
+
+}

--- a/civihr_employee_portal/src/Helpers/LoggingStreamSwitcher.php
+++ b/civihr_employee_portal/src/Helpers/LoggingStreamSwitcher.php
@@ -9,6 +9,8 @@ namespace Drupal\civihr_employee_portal\Helpers;
 class LoggingStreamSwitcher {
 
   /**
+   * Sets a logging stream status to enabled
+   *
    * @param string $streamName
    */
   public static function enableLogging($streamName) {
@@ -17,11 +19,26 @@ class LoggingStreamSwitcher {
   }
 
   /**
+   * Sets a logging stream status to disabled
+   *
    * @param string $streamName
    */
   public static function disableLogging($streamName) {
     global $civihrChangeLogStreams;
     $civihrChangeLogStreams[$streamName] = FALSE;
+  }
+
+  /**
+   * Checks whether a given logging stream is enabled
+   *
+   * @param string $streamName
+   *
+   * @return bool
+   */
+  public static function isEnabled($streamName) {
+    global $civihrChangeLogStreams;
+
+    return \CRM_Utils_Array::value($streamName, $civihrChangeLogStreams, FALSE);
   }
 
 }

--- a/civihr_employee_portal/src/Hook/ModuleImplementsAlter/ImplementationAlterer.php
+++ b/civihr_employee_portal/src/Hook/ModuleImplementsAlter/ImplementationAlterer.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\civihr_employee_portal\Hook\ModuleImplementsAlter;
+
+interface ImplementationAlterer {
+
+  /**
+   * Check whether this class should act on the implementation array
+   *
+   * @param string $hookName
+   *
+   * @return bool
+   */
+  public function shouldAlter($hookName);
+
+  /**
+   * Make changes to the implementations
+   *
+   * @param array $implementations
+   *
+   * @return void
+   */
+  public function alter(array &$implementations);
+
+}

--- a/civihr_employee_portal/src/Hook/ModuleImplementsAlter/ImplementationAlterer.php
+++ b/civihr_employee_portal/src/Hook/ModuleImplementsAlter/ImplementationAlterer.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\civihr_employee_portal\Hook\ModuleImplementsAlter;
 
-interface ImplementationAlterer {
+abstract class ImplementationAlterer {
 
   /**
    * Check whether this class should act on the implementation array
@@ -11,7 +11,7 @@ interface ImplementationAlterer {
    *
    * @return bool
    */
-  public function shouldAlter($hookName);
+  abstract public function shouldAlter($hookName);
 
   /**
    * Make changes to the implementations
@@ -20,6 +20,22 @@ interface ImplementationAlterer {
    *
    * @return void
    */
-  public function alter(array &$implementations);
+  abstract public function alter(array &$implementations);
 
+  /**
+   * @param array $implementations
+   * @param string $moduleName
+   */
+  protected function moveToEnd(array &$implementations, $moduleName) {
+    if (!isset($implementations[$moduleName])) {
+      $serr = sprintf('Cannot re-order as module "%s" is not set', $moduleName);
+      throw new \RuntimeException($serr);
+    }
+
+    $tmp = [$moduleName => $implementations[$moduleName]];
+    unset($implementations[$moduleName]);
+    $implementations += $tmp;
+  }
 }
+
+

--- a/civihr_employee_portal/src/Hook/ModuleImplementsAlter/ImplementationAlterer.php
+++ b/civihr_employee_portal/src/Hook/ModuleImplementsAlter/ImplementationAlterer.php
@@ -23,6 +23,9 @@ abstract class ImplementationAlterer {
   abstract public function alter(array &$implementations);
 
   /**
+   * Moves the specified module name to the end of the implementations array.
+   * Will fail if the specified name is not present.
+   *
    * @param array $implementations
    * @param string $moduleName
    */

--- a/civihr_employee_portal/src/Hook/ModuleImplementsAlter/ViewsDataAlterImplementationReorderer.php
+++ b/civihr_employee_portal/src/Hook/ModuleImplementsAlter/ViewsDataAlterImplementationReorderer.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\civihr_employee_portal\Hook\ModuleImplementsAlter;
 
-class ViewsDataAlterImplementationReorderer implements ImplementationAlterer {
+class ViewsDataAlterImplementationReorderer extends ImplementationAlterer {
 
   /**
    * @inheritdoc

--- a/civihr_employee_portal/src/Hook/ModuleImplementsAlter/ViewsDataAlterImplementationReorderer.php
+++ b/civihr_employee_portal/src/Hook/ModuleImplementsAlter/ViewsDataAlterImplementationReorderer.php
@@ -37,4 +37,5 @@ class ViewsDataAlterImplementationReorderer extends ImplementationAlterer {
   public function shouldAlter($hookName) {
     return $hookName === 'views_data_alter';
   }
+
 }

--- a/civihr_employee_portal/src/Hook/ModuleImplementsAlter/ViewsDataAlterImplementationReorderer.php
+++ b/civihr_employee_portal/src/Hook/ModuleImplementsAlter/ViewsDataAlterImplementationReorderer.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\civihr_employee_portal\Hook\ModuleImplementsAlter;
+
+class ViewsDataAlterImplementationReorderer implements ImplementationAlterer {
+
+  /**
+   * @inheritdoc
+   */
+  public function alter(array &$implementations) {
+    $group = [];
+
+    // Check if the module exists and it's installed
+    if (module_exists('views_autocomplete_filters')) {
+      // Put the views autocomplete filters after civicrm
+      $module = 'views_autocomplete_filters';
+      $group += [$module => $implementations[$module]];
+      unset($implementations[$module]);
+    }
+
+    /**
+     * Put the civihr employee portal module after civicrm module . The civicrm
+     * module will ruthlessly replace all changes from views_data_alter hook
+     * @see civicrm_views_data_alter
+     */
+    $module = 'civihr_employee_portal';
+    $group += [$module => $implementations[$module]];
+    unset($implementations[$module]);
+
+    // Make sure some modules are after civicrm to avoid error with autocomplete search or drush cc all
+    $implementations = $implementations + $group;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function shouldAlter($hookName) {
+    return $hookName === 'views_data_alter';
+  }
+}

--- a/civihr_employee_portal/src/Hook/ModuleImplementsAlter/WebformSubmissionInsertReorderer.php
+++ b/civihr_employee_portal/src/Hook/ModuleImplementsAlter/WebformSubmissionInsertReorderer.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Drupal\civihr_employee_portal\Hook\ModuleImplementsAlter;
+
+class WebformSubmissionInsertReorderer extends ImplementationAlterer {
+
+  /**
+   * @inheritdoc
+   */
+  public function shouldAlter($hookName) {
+    return $hookName === 'webform_submission_insert';
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function alter(array &$implementations) {
+    $this->moveToEnd($implementations, 'civihr_employee_portal');
+  }
+
+}

--- a/civihr_employee_portal/src/Hook/ModuleImplementsAlter/WebformSubmissionPreSaveReorderer.php
+++ b/civihr_employee_portal/src/Hook/ModuleImplementsAlter/WebformSubmissionPreSaveReorderer.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Drupal\civihr_employee_portal\Hook\ModuleImplementsAlter;
+
+class WebformSubmissionPreSaveReorderer extends ImplementationAlterer {
+
+  /**
+   * @inheritdoc
+   */
+  public function shouldAlter($hookName) {
+    return $hookName === 'webform_submission_presave';
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function alter(array &$implementations) {
+    $this->moveToEnd($implementations, 'civihr_employee_portal');
+  }
+
+}

--- a/civihr_employee_portal/tests/Helpers/LoggingStreamSwitcherTest.php
+++ b/civihr_employee_portal/tests/Helpers/LoggingStreamSwitcherTest.php
@@ -4,25 +4,22 @@ use Drupal\civihr_employee_portal\Helpers\LoggingStreamSwitcher;
 
 class LoggingStreamSwitcherTest extends \PHPUnit_Framework_TestCase {
 
-  public function testSwitchingOnWillChangeGlobalVariable() {
+  public function testEnabling() {
     LoggingStreamSwitcher::enableLogging('foo');
-    global $civihrChangeLogStreams;
 
-    $this->assertTrue($civihrChangeLogStreams['foo']);
+    $this->assertTrue(LoggingStreamSwitcher::isEnabled('foo'));
   }
 
-  public function testDisablingWillSetGlobalVariableToFalse() {
+  public function testDisabling() {
     LoggingStreamSwitcher::disableLogging('foo');
-    global $civihrChangeLogStreams;
 
-    $this->assertFalse($civihrChangeLogStreams['foo']);
+    $this->assertFalse(LoggingStreamSwitcher::isEnabled('foo'));
   }
 
-  public function testSwitchingWillChangeGlobalVariable() {
+  public function testSwitching() {
     LoggingStreamSwitcher::enableLogging('foo');
     LoggingStreamSwitcher::disableLogging('foo');
-    global $civihrChangeLogStreams;
 
-    $this->assertFalse($civihrChangeLogStreams['foo']);
+    $this->assertFalse(LoggingStreamSwitcher::isEnabled('foo'));
   }
 }

--- a/civihr_employee_portal/tests/Helpers/LoggingStreamSwitcherTest.php
+++ b/civihr_employee_portal/tests/Helpers/LoggingStreamSwitcherTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Drupal\civihr_employee_portal\Helpers\LoggingStreamSwitcher;
+
+class LoggingStreamSwitcherTest extends \PHPUnit_Framework_TestCase {
+
+  public function testSwitchingOnWillChangeGlobalVariable() {
+    LoggingStreamSwitcher::enableLogging('foo');
+    global $civihrChangeLogStreams;
+
+    $this->assertTrue($civihrChangeLogStreams['foo']);
+  }
+
+  public function testDisablingWillSetGlobalVariableToFalse() {
+    LoggingStreamSwitcher::disableLogging('foo');
+    global $civihrChangeLogStreams;
+
+    $this->assertFalse($civihrChangeLogStreams['foo']);
+  }
+
+  public function testSwitchingWillChangeGlobalVariable() {
+    LoggingStreamSwitcher::enableLogging('foo');
+    LoggingStreamSwitcher::disableLogging('foo');
+    global $civihrChangeLogStreams;
+
+    $this->assertFalse($civihrChangeLogStreams['foo']);
+  }
+}

--- a/civihr_employee_portal/tests/Hook/ModuleImplementsAlter/WebformSubmissionPreSaveReordererTest.php
+++ b/civihr_employee_portal/tests/Hook/ModuleImplementsAlter/WebformSubmissionPreSaveReordererTest.php
@@ -1,0 +1,46 @@
+<?php
+
+
+use Drupal\civihr_employee_portal\Hook\ModuleImplementsAlter\WebformSubmissionPreSaveReorderer;
+
+class WebformSubmissionPreSaveReordererTest extends \PHPUnit_Framework_TestCase {
+
+  public function testAlterWillPutCiviHREmployeePortalToEnd() {
+    $reorderer = new WebformSubmissionPreSaveReorderer();
+    $implementations = [
+      'yet_another_module' => FALSE,
+      'civihr_employee_portal' => FALSE,
+      'some_other_module' => FALSE,
+      'another_module' => FALSE,
+    ];
+    $reorderer->alter($implementations);
+    $lastEntry = end(array_keys($implementations));
+    $this->assertEquals('civihr_employee_portal', $lastEntry);
+  }
+
+  public function testAlterWillThrowExceptionIfModuleNotSet() {
+    $reorderer = new WebformSubmissionPreSaveReorderer();
+    $implementations = [
+      'yet_another_module' => FALSE,
+    ];
+    $this->setExpectedException(
+      \RuntimeException::class,
+      'Cannot re-order as module "civihr_employee_portal" is not set'
+    );
+    $reorderer->alter($implementations);
+  }
+
+  public function testShouldAlterWillBeTrueForTargetHook() {
+    $reorderer = new WebformSubmissionPreSaveReorderer();
+    $hook = 'webform_submission_presave';
+
+    $this->assertTrue($reorderer->shouldAlter($hook));
+  }
+
+  public function testShouldAlterWillBeFalseForAnotherHook() {
+    $reorderer = new WebformSubmissionPreSaveReorderer();
+    $hook = 'some_other_hook';
+
+    $this->assertFalse($reorderer->shouldAlter($hook));
+  }
+}


### PR DESCRIPTION
## Overview

We want to switch logging on when a user submits certain webforms, and off again after everything is saved. We will do this using webform hooks from the SSP. The actual logging will be handled in CiviHR in a separate PR.

## Before

There was no variable to track whether CiviHR logging was enabled or not.

## After

Logging for certain webform is enabled before webform data is saved and disabled after saving is complete.

## Technical Details

We use two hooks that `webform_civicrm` also uses. One is `webform_submission_presave` which is where CiviCRM saves most of the data. However it also saves some entity data in `webform_submission_insert` so the order of the hook firing should be as follows:

1. In SSP implementation of `webform_submission_presave` logging is enabled
1. In `webform_civicrm` implementation of `webform_submission_presave` some data is saved
1. In  `webform_civicrm` implementation of `webform_submission_insert` some more data is saved
1. In SSP implementation of `webform_submission_insert` logging is disabled

We control the order using the `module_implements_order` hook. This was already implemented in SSP but to reduce LOC in the module file and encapsulate the logic dedicated classes were created for this re-ordering of implementation.

The switch uses a global variable which will be accessed in CiviHR to do the actual logging. The reason we separate this is because we needed to use the Drupal hooks, but the logging is for CiviCRM changes which belongs more in a CiviCRM extension than a Drupal module.

The variable allows for separate streams, which allows you to start and stop logging for more than one event, for example during a single request with changes A, B, C and D we can log all changes from A -> C in one stream, but log changes B -> D in a separate stream.

---

- [x] Tests Pass
