### PR TITLE
PCHR-4155: Notification Mails for SSP Edit and Onboarding Form

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -768,18 +768,8 @@ function civihr_employee_portal_mail_alter(&$message) {
   }
 
   $smarty = CRM_Core_Smarty::singleton();
-  $smarty->addTemplateDir(__DIR__ . '/templates/smarty');
-
-  $variables = $replacementMail->getVariables($message);
-  $headers = $replacementMail->getHeaders();
-  $templateName = $replacementMail->getTemplateName();
-
-  // allow use of original content
-  $variables['body'] = $message['body'][0];
-  $body = $smarty->fetchWith($templateName, $variables);
-
-  $message['headers'] = array_merge($message['headers'], $headers);
-  $message['body'] = [$body];
+  $replacer = new MailContentReplacer($smarty);
+  $replacer->replaceContent($message, $replacementMail);
 }
 
 /**

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -15,6 +15,10 @@ use Drupal\civihr_employee_portal\Page\HRDetailsPage;
 use Drupal\civihr_employee_portal\Webform\WebformTransferService;
 use Drupal\civihr_employee_portal\Helpers\LinkProvider;
 use Drupal\civihr_employee_portal\Helpers\TaxonomyHelper;
+use Drupal\civihr_employee_portal\Mail\MailContentReplacer;
+use Drupal\civihr_employee_portal\Mail\WebformSubmissionNotificationMail;
+use Drupal\civihr_employee_portal\Mail\WebformSubmissionNotifier;
+use Drupal\civihr_employee_portal\Mail\OnboardingFormEditNotificationMail;
 use Drupal\civihr_employee_portal\View\CustomFieldsMappingFixer;
 
 /**
@@ -5141,10 +5145,39 @@ function civihr_employee_portal_webform_submission_insert($node, $submission) {
   $nodeTitle = property_exists($node, 'title') ? $node->title : NULL;
   $onboardingTitle = OnboardingWebForm::NAME;
   $isOnboardingForm = $nodeTitle === $onboardingTitle;
+  $notifier = new WebformSubmissionNotifier();
 
   if ($isOnboardingForm) {
     $form = new OnboardingWebForm();
     $form->onSubmit($node, $submission);
+  }
+
+  $notifier->sendNotification($node, $submission);
+}
+
+/**
+ * Implements hook_mail().
+ *
+ * @param string $key
+ * @param array $message
+ * @param array $params
+ */
+function civihr_employee_portal_mail($key, &$message, $params) {
+  $smarty = CRM_Core_Smarty::singleton();
+  $replacer = new MailContentReplacer($smarty);
+  $mail = NULL;
+
+  switch ($key) {
+    case 'civihr_webform_submission':
+      $mail = new WebformSubmissionNotificationMail();
+      break;
+    case 'civihr_onboarding_form_submission':
+      $mail = new OnboardingFormEditNotificationMail();
+      break;
+  }
+
+  if ($mail) {
+    $replacer->replaceContent($message, $mail);
   }
 }
 

--- a/civihr_employee_portal/src/Forms/OnboardingWizardCustomizationForm.php
+++ b/civihr_employee_portal/src/Forms/OnboardingWizardCustomizationForm.php
@@ -284,7 +284,7 @@ class OnboardingWizardCustomizationForm {
       '#suffix' => '<hr/>',
     ];
 
-    // snippet to add markup suport to style a toggle button
+    // snippet to add markup support to style a toggle button
     $sendUpdatesSelector = '"[name=\'' . self::SEND_UPDATES_KEY . '\']"';
     $toggleButtonHTML = "\"<span class='$toggleClass'> toggle </span>\"";
     $addToggleButton = "$($sendUpdatesSelector).after($toggleButtonHTML);";

--- a/civihr_employee_portal/src/Helpers/WebformHelper.php
+++ b/civihr_employee_portal/src/Helpers/WebformHelper.php
@@ -46,7 +46,8 @@ class WebformHelper {
     });
 
     if (count($components) !== 1) {
-      throw new \Exception('Webform component title is not unique');
+      $err = sprintf('Webform component title "%s" is not unique', $title);
+      throw new \Exception($err);
     }
 
     return array_shift($components);
@@ -66,11 +67,118 @@ class WebformHelper {
    */
   public static function getValueByTitle($node, $submission, $title) {
     $component = WebformHelper::getComponentByTitle($node, $title);
+
+    return self::getValueForComponent($component, $submission);
+  }
+
+  /**
+   * Fetches the submitted value for a component
+   *
+   * @param array $component
+   * @param \stdClass $submission
+   *
+   * @return mixed
+   */
+  public static function getValueForComponent($component, $submission) {
     $cid = \CRM_Utils_Array::value('cid', $component);
     $submission = isset($submission->data) ? $submission->data : [];
     $value = \CRM_Utils_Array::value($cid, $submission, []);
 
     return array_shift($value);
+  }
+
+  /**
+   * Gets all the submitted values, replacing options with their labels. The
+   * values will be grouped by page and fieldset. If page and fieldset names
+   * are available they will be used instead of a numeric index
+   *
+   * @param \stdClass $node
+   * @param \stdClass $submission
+   *
+   * @return array
+   */
+  public static function getSubmittedValues($node, $submission) {
+    $submittedValues = [];
+    $components = $node->webform['components'];
+    $typesToSkip = ['markup', 'pagebreak', 'fieldset'];
+    $pageTitles = self::getPageTitles($components);
+    $fieldsetTitles = self::getFieldsetTitles($components);
+
+    foreach ($components as $component) {
+      if (in_array($component['type'], $typesToSkip)) {
+        continue;
+      }
+
+      $value = self::getValueForComponent($component, $submission);
+
+      // Replace ID with label for select options
+      $options = self::getComponentOptions($component);
+      if (!empty($options[$value])) {
+        $value = $options[$value];
+      }
+
+      // Use page title if it exists
+      $pageIndex = $component['page_num'];
+      if (isset($pageTitles[$pageIndex])) {
+        $pageIndex = $pageTitles[$pageIndex];
+      }
+
+      // Use fieldset title if it exists, default to parent ID
+      $fieldsetIndex = $component['pid'];
+      if (isset($fieldsetTitles[$component['pid']])) {
+        $fieldsetIndex = $fieldsetTitles[$component['pid']];
+      }
+
+      $submittedValues[$pageIndex][$fieldsetIndex][$component['name']] = $value;
+    }
+
+    return $submittedValues;
+  }
+
+  /**
+   * Gets the titles for all markup components assuming they have the h2 tag.
+   *
+   * @param array $components
+   *
+   * @return array
+   *   The title names stripped of HTML tags and indexed by page number
+   */
+  private static function getPageTitles($components) {
+    $titles = [];
+
+    foreach ($components as $component) {
+      if ($component['type'] !== 'markup') {
+        continue;
+      }
+
+      $doc = new \DOMDocument();
+      $doc->loadXML($component['value']);
+      $title = $doc->getElementsByTagName('h2')->item(0)->nodeValue;
+      $titles[$component['page_num']] = $title;
+    }
+
+    return $titles;
+  }
+
+  /**
+   * Gets the titles for all fieldset components indexed by component ID
+   *
+   * @param array $components
+   *
+   * @return array
+   */
+  private static function getFieldsetTitles($components) {
+    $titles = [];
+
+    foreach ($components as $component) {
+      if ($component['type'] !== 'fieldset') {
+        continue;
+      }
+
+      $titles[$component['cid']] = $component['name'];
+    }
+
+    return $titles;
   }
 
   /**
@@ -98,4 +206,34 @@ class WebformHelper {
 
     return $targetFormSubmissions;
   }
+
+  /**
+   * Returns a list of options from the component indexed by their ID (value
+   * for OptionValues)
+   *
+   * @param array $component
+   *
+   * @return array
+   */
+  public static function getComponentOptions($component) {
+    $options = [];
+
+    $extra = ArrayHelper::value('extra', $component, []);
+    $items = ArrayHelper::value('items', $extra);
+
+    if (!$items) {
+      return $options;
+    }
+
+    $items = explode("\n", $items);
+    foreach ($items as $item) {
+      if (strpos($item, '|') !== FALSE) {
+        list($id, $label) = explode('|', $item);
+        $options[$id] = $label;
+      }
+    }
+
+    return $options;
+  }
+
 }

--- a/civihr_employee_portal/src/Mail/AbstractDrupalSystemMail.php
+++ b/civihr_employee_portal/src/Mail/AbstractDrupalSystemMail.php
@@ -3,6 +3,7 @@
 namespace Drupal\civihr_employee_portal\Mail;
 
 abstract class AbstractDrupalSystemMail {
+
   /**
    * @return string
    */
@@ -15,6 +16,15 @@ abstract class AbstractDrupalSystemMail {
    */
   public function getVariables($message) {
     return [];
+  }
+
+  /**
+   * @param array $message
+   *
+   * @return string
+   */
+  public function getSubject($message) {
+    return $message['subject'];
   }
 
   /**

--- a/civihr_employee_portal/src/Mail/MailContentReplacer.php
+++ b/civihr_employee_portal/src/Mail/MailContentReplacer.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\civihr_employee_portal\Mail;
+
+class MailContentReplacer {
+
+  /**
+   * @var \CRM_Core_Smarty
+   */
+  private $smarty;
+
+  /**
+   * @param \CRM_Core_Smarty $smarty
+   */
+  public function __construct(\CRM_Core_Smarty $smarty) {
+    $moduleRoot = drupal_get_path('module', 'civihr_employee_portal');
+    $smarty->addTemplateDir($moduleRoot . '/templates/smarty');
+
+    $this->smarty = $smarty;
+  }
+
+  /**
+   * @param $message
+   * @param AbstractDrupalSystemMail $replacement
+   */
+  public function replaceContent(
+    &$message,
+    AbstractDrupalSystemMail $replacement
+  ) {
+    $variables = $replacement->getVariables($message);
+    $headers = $replacement->getHeaders();
+    $templateName = $replacement->getTemplateName();
+
+    // allow use of original content inside smarty template
+    if (isset($message['body'][0])) {
+      $variables['body'] = $message['body'][0];
+    }
+
+    $body = $this->smarty->fetchWith($templateName, $variables);
+
+    $message['subject'] = $replacement->getSubject($message);
+    $message['headers'] = array_merge($message['headers'], $headers);
+    $message['body'] = [$body];
+  }
+
+}

--- a/civihr_employee_portal/src/Mail/OnboardingFormEditNotificationMail.php
+++ b/civihr_employee_portal/src/Mail/OnboardingFormEditNotificationMail.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Drupal\civihr_employee_portal\Mail;
+
+use Drupal\civihr_employee_portal\Helpers\WebformHelper;
+
+class OnboardingFormEditNotificationMail extends WebformSubmissionNotificationMail {
+
+  /**
+   * @param array $message
+   *
+   * @return array
+   */
+  public function getVariables($message) {
+    $variables =  parent::getVariables($message);
+    // Replace the title
+    $variables['webformTitle'] = 'the onboarding form';
+
+    return $variables;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected function formatSubmittedValues($node, $submission) {
+    $submittedValues = WebformHelper::getSubmittedValues($node, $submission);
+
+    $this->formatPersonalDetails($submittedValues);
+    $this->formatPayroll($submittedValues);
+    $this->formatEmergencyContacts($submittedValues);
+    $this->formatDependants($submittedValues);
+
+    // We don't want this info in the email
+    unset($submittedValues['Profile Picture']);
+
+    return $submittedValues;
+  }
+
+  /**
+   * @param array $submittedValues
+   */
+  private function formatPersonalDetails(&$submittedValues) {
+    $personalDetails = &$submittedValues['Personal Details'];
+    unset($personalDetails[0]['Existing Contact']);
+
+    // The options for this are not stored correctly and need manual replacement
+    $ssnApplicationKey = 'I am currently applying for a NI/ SSN';
+    $value = $personalDetails[0][$ssnApplicationKey];
+    $replacement = $value ? 'Yes' : 'No';
+    $personalDetails[0][$ssnApplicationKey] = $replacement;
+  }
+
+  /**
+   * @param $submittedValues
+   */
+  protected function formatPayroll(&$submittedValues) {
+    $payroll = &$submittedValues['Payroll'];
+    $skipStepOption = 'Add Now (Payroll)';
+    if ($this->skippedStep($payroll, $skipStepOption)) {
+      $this->formatSkippedStep($payroll);
+    }
+    unset($payroll[0][$skipStepOption]);
+  }
+
+  /**
+   * @param $submittedValues
+   */
+  private function formatEmergencyContacts(&$submittedValues) {
+    $emergencyContacts = &$submittedValues['Emergency Contact'];
+    $skipStepOption = 'Add Now (Emergency Contacts)';
+
+    if ($this->skippedStep($emergencyContacts, $skipStepOption)) {
+      $this->formatSkippedStep($emergencyContacts);
+      return;
+    }
+    unset($emergencyContacts[0][$skipStepOption]);
+
+    $addSecondOption = 'Add another emergency contact?';
+    $firstContactKey = 'Emergency Contact';
+    $secondContactKey = 'Second Emergency Contact';
+
+    unset($emergencyContacts[$firstContactKey]['Is a dependant?']);
+    unset($emergencyContacts[$secondContactKey]['Is a dependant?']);
+
+    // Check if a second contact was added and remove the value for conditional
+    $addedSecondContact = $emergencyContacts[0][$addSecondOption] === 'Yes';
+    unset($emergencyContacts[0][$addSecondOption]);
+
+    // Remove the second emergency contact if it wasn't added
+    if (!$addedSecondContact) {
+      unset($emergencyContacts[$secondContactKey]);
+    }
+  }
+
+  /**
+   * @param array $submittedValues
+   */
+  private function formatDependants(&$submittedValues) {
+    $dependants = &$submittedValues['Dependants'];
+    $skipStepOption = 'Add Now (Dependants)';
+    if ($this->skippedStep($dependants, $skipStepOption)) {
+      $this->formatSkippedStep($dependants);
+      return;
+    }
+    // Unset unused data
+    unset($dependants[0]);
+    // Remove unused dependant entries
+    $dependantsKeys = ['Fifth', 'Fourth', 'Third', 'Second', 'First'];
+    foreach ($dependantsKeys as $index => $dependantKey) {
+      if (!isset($dependantKey[$index + 1])) {
+        continue;
+      }
+
+      // Get the answer to the question "Add a dependant" for previous element
+      $key = $dependantKey . ' Dependant';
+      $previousElementKey = $dependantsKeys[$index + 1] . ' Dependant';
+      $previousElementValues = &$dependants[$previousElementKey];
+      $addNextKey = 'Add a ' . strtolower($dependantKey) . ' dependant?';
+      $nextDependentAdded = $previousElementValues[$addNextKey];
+
+      // If no, then unset the current dependant
+      if (empty($nextDependentAdded) || $nextDependentAdded === 'No') {
+        unset($dependants[$key]);
+      }
+
+      // Remove conditional field
+      unset($previousElementValues[$addNextKey]);
+    }
+
+    // Remove hidden field
+    foreach ($dependants as &$dependant) {
+      unset($dependant['Is a Dependant?']);
+    }
+  }
+
+  /**
+   * Formats a step values that has been skipped
+   *
+   * @param array $stepValues
+   */
+  private function formatSkippedStep(&$stepValues) {
+    $stepValues = [0 => ['Skipped' => 'The user skipped this step']];
+  }
+
+  /**
+   * Checks whether a step has been skipped by the user
+   *
+   * @param array $stepValues
+   * @param string $skipStepOption
+   *
+   * @return bool
+   */
+  private function skippedStep($stepValues, $skipStepOption) {
+    return $stepValues[0][$skipStepOption] !== 'Add Now';
+  }
+
+}

--- a/civihr_employee_portal/src/Mail/OnboardingFormEditNotificationMail.php
+++ b/civihr_employee_portal/src/Mail/OnboardingFormEditNotificationMail.php
@@ -51,7 +51,7 @@ class OnboardingFormEditNotificationMail extends WebformSubmissionNotificationMa
   }
 
   /**
-   * @param $submittedValues
+   * @param array $submittedValues
    */
   protected function formatPayroll(&$submittedValues) {
     $payroll = &$submittedValues['Payroll'];
@@ -63,7 +63,7 @@ class OnboardingFormEditNotificationMail extends WebformSubmissionNotificationMa
   }
 
   /**
-   * @param $submittedValues
+   * @param array $submittedValues
    */
   private function formatEmergencyContacts(&$submittedValues) {
     $emergencyContacts = &$submittedValues['Emergency Contact'];
@@ -109,15 +109,19 @@ class OnboardingFormEditNotificationMail extends WebformSubmissionNotificationMa
     unset($dependants[0]);
 
     // Remove unused dependant entries
-    $dependantsKeys = ['Fifth', 'Fourth', 'Third', 'Second', 'First'];
-    foreach ($dependantsKeys as $index => $dependantKey) {
-      if (!isset($dependantKey[$index + 1])) {
+    $dependantKeys = ['Fifth', 'Fourth', 'Third', 'Second', 'First'];
+    foreach ($dependantKeys as $index => $dependantKey) {
+
+      // We check in reverse order if the previous dependant ticked the "Add
+      // another" box so we only go as far as the "Second" dependant since
+      // there is no possibility to hide the first dependant input
+      if (!isset($dependantKeys[$index + 1])) {
         continue;
       }
 
       // Get the answer to the question "Add a dependant?" for previous element
       $key = $dependantKey . ' Dependant';
-      $previousElementKey = $dependantsKeys[$index + 1] . ' Dependant';
+      $previousElementKey = $dependantKeys[$index + 1] . ' Dependant';
       $previousElementValues = &$dependants[$previousElementKey];
       $addNextKey = 'Add a ' . strtolower($dependantKey) . ' dependant?';
       $nextDependentWasAdded = $previousElementValues[$addNextKey];

--- a/civihr_employee_portal/src/Mail/OnboardingFormEditNotificationMail.php
+++ b/civihr_employee_portal/src/Mail/OnboardingFormEditNotificationMail.php
@@ -12,7 +12,7 @@ class OnboardingFormEditNotificationMail extends WebformSubmissionNotificationMa
    * @return array
    */
   public function getVariables($message) {
-    $variables =  parent::getVariables($message);
+    $variables = parent::getVariables($message);
     // Replace the title
     $variables['webformTitle'] = 'the onboarding form';
 
@@ -79,6 +79,7 @@ class OnboardingFormEditNotificationMail extends WebformSubmissionNotificationMa
     $firstContactKey = 'Emergency Contact';
     $secondContactKey = 'Second Emergency Contact';
 
+    // Remove hidden fields
     unset($emergencyContacts[$firstContactKey]['Is a dependant?']);
     unset($emergencyContacts[$secondContactKey]['Is a dependant?']);
 
@@ -98,12 +99,15 @@ class OnboardingFormEditNotificationMail extends WebformSubmissionNotificationMa
   private function formatDependants(&$submittedValues) {
     $dependants = &$submittedValues['Dependants'];
     $skipStepOption = 'Add Now (Dependants)';
+
     if ($this->skippedStep($dependants, $skipStepOption)) {
       $this->formatSkippedStep($dependants);
       return;
     }
-    // Unset unused data
+
+    // Unset unused values such as "Add Now" question
     unset($dependants[0]);
+
     // Remove unused dependant entries
     $dependantsKeys = ['Fifth', 'Fourth', 'Third', 'Second', 'First'];
     foreach ($dependantsKeys as $index => $dependantKey) {
@@ -111,15 +115,16 @@ class OnboardingFormEditNotificationMail extends WebformSubmissionNotificationMa
         continue;
       }
 
-      // Get the answer to the question "Add a dependant" for previous element
+      // Get the answer to the question "Add a dependant?" for previous element
       $key = $dependantKey . ' Dependant';
       $previousElementKey = $dependantsKeys[$index + 1] . ' Dependant';
       $previousElementValues = &$dependants[$previousElementKey];
       $addNextKey = 'Add a ' . strtolower($dependantKey) . ' dependant?';
-      $nextDependentAdded = $previousElementValues[$addNextKey];
+      $nextDependentWasAdded = $previousElementValues[$addNextKey];
 
-      // If no, then unset the current dependant
-      if (empty($nextDependentAdded) || $nextDependentAdded === 'No') {
+      // If no, then unset the current dependant, i.e. if answer was no for
+      // "Fourth Dependant" then unset "Fifth Dependant"
+      if (empty($nextDependentWasAdded) || $nextDependentWasAdded === 'No') {
         unset($dependants[$key]);
       }
 
@@ -139,7 +144,7 @@ class OnboardingFormEditNotificationMail extends WebformSubmissionNotificationMa
    * @param array $stepValues
    */
   private function formatSkippedStep(&$stepValues) {
-    $stepValues = [0 => ['Skipped' => 'The user skipped this step']];
+    $stepValues = [0 => ['Skipped:' => 'The user skipped this step']];
   }
 
   /**

--- a/civihr_employee_portal/src/Mail/OnboardingFormEditNotificationMail.php
+++ b/civihr_employee_portal/src/Mail/OnboardingFormEditNotificationMail.php
@@ -144,7 +144,7 @@ class OnboardingFormEditNotificationMail extends WebformSubmissionNotificationMa
    * @param array $stepValues
    */
   private function formatSkippedStep(&$stepValues) {
-    $stepValues = [0 => ['Skipped:' => 'The user skipped this step']];
+    $stepValues = [0 => ['Skipped' => 'The user skipped this step']];
   }
 
   /**

--- a/civihr_employee_portal/src/Mail/WebformSubmissionNotificationMail.php
+++ b/civihr_employee_portal/src/Mail/WebformSubmissionNotificationMail.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Drupal\civihr_employee_portal\Mail;
+
+use Drupal\civihr_employee_portal\Helpers\WebformHelper;
+
+class WebformSubmissionNotificationMail extends AbstractDrupalSystemMail {
+
+  /**
+   * @inheritdoc
+   */
+  public function getVariables($message) {
+    $node = $message['params']['node'];
+    $submission = $message['params']['submission'];
+
+    $contactId = WebformHelper::getValueByTitle($node, $submission, 'Existing Contact');
+    $contact = civicrm_api3('Contact', 'getsingle', ['id' => $contactId]);
+
+    $contactEmail = $this->getContactWorkEmail($contactId);
+    $profileLink = $this->getLinkToContractProfile($contactId);
+    $submittedValues = $this->formatSubmittedValues($node, $submission);
+
+    return [
+      'submittedValues' => $submittedValues,
+      'workEmail' => $contactEmail,
+      'profileLink' => $profileLink,
+      'displayName' => $contact['display_name'],
+      'submissionDate' => date('Y-m-d H:i', $submission->submitted),
+      'webformTitle' => $node->title,
+    ];
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function getTemplateName() {
+    return 'dashboard_edit_details.tpl';
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function getSubject($message) {
+    return 'CiviHR Self Service Data Submission';
+  }
+
+  /**
+   * Fetch the provided contact's work email
+   *
+   * @param int $contactId
+   *
+   * @return string
+   */
+  protected function getContactWorkEmail($contactId) {
+    $contactEmailRes = civicrm_api3('Email', 'get', [
+      'contact_id' => $contactId,
+      'location_type_id' => 'Work',
+      'options' => ['limit' => 1],
+      'sequential' => 1,
+    ]);
+
+    if ($contactEmailRes['count'] == 1) {
+      return $contactEmailRes['values'][0]['email'];
+    }
+
+    return '';
+  }
+
+  /**
+   * Fetch an absolute link to the contact's profile page
+   *
+   * @param int $contactId
+   *
+   * @return string
+   */
+  protected function getLinkToContractProfile($contactId) {
+    $profilePath = 'civicrm/contact/view';
+    $queryParams = ['cid' => $contactId];
+    $profileLink = \CRM_Utils_System::url($profilePath, $queryParams, TRUE);
+
+    return $profileLink;
+  }
+
+  /**
+   * Prepare submitted values for display in the email
+   *
+   * @param \stdClass $node
+   * @param \stdClass $submission
+   *
+   * @return array
+   */
+  protected function formatSubmittedValues($node, $submission) {
+    $submittedValues = WebformHelper::getSubmittedValues($node, $submission);
+
+    // We don't want these fields as they are not user-submitted values
+    $fieldsToRemove = [
+      'Existing Contact',
+      'Emergency Contacts',
+    ];
+
+    foreach ($submittedValues as $pageIndex => $pageValues) {
+      foreach ($pageValues as $fieldSetIndex => $fieldSetValues) {
+        foreach ($fieldsToRemove as $fieldToRemove) {
+          unset($submittedValues[$pageIndex][$fieldSetIndex][$fieldToRemove]);
+        }
+      }
+    }
+
+    return $submittedValues;
+  }
+
+}

--- a/civihr_employee_portal/src/Mail/WebformSubmissionNotifier.php
+++ b/civihr_employee_portal/src/Mail/WebformSubmissionNotifier.php
@@ -3,11 +3,13 @@
 namespace Drupal\civihr_employee_portal\Mail;
 
 use Drupal\civihr_employee_portal\Forms\OnboardingWebForm;
+use Drupal\civihr_employee_portal\Forms\OnboardingWizardCustomizationForm;
 
 class WebformSubmissionNotifier {
 
   /**
    * @var array
+   *   A list of webform titles to send notifications for
    */
   private $webformsToNotifyAbout = [
     'My Personal Details',
@@ -20,35 +22,80 @@ class WebformSubmissionNotifier {
   ];
 
   /**
+   * Sends notifications about the submission of a webform
+   *
    * @param \stdClass $node
    * @param \stdClass $submission
    */
   public function sendNotification($node, $submission) {
-    if (!in_array($node->title, $this->webformsToNotifyAbout)) {
-      return;
+    if ($this->shouldSendMail($node)) {
+      $this->sendMail($node, $submission);
     }
-
-    $this->sendMail($node, $submission);
   }
 
   /**
+   * Sends an email notification about the webform submission
+   *
    * @param \stdClass $node
    * @param \stdClass $submission
    */
   private function sendMail($node, $submission) {
     $params['node'] = $node;
     $params['submission'] = $submission;
-
-    // todo fetch email from settings
-    $email = 'tmp@compucorp.co.uk';
-
-    $key = 'civihr_webform_submission';
-    if ($node->title === OnboardingWebForm::NAME) {
-      // Use a different key for onboarding form handling
-      $key = 'civihr_onboarding_form_submission';
-    }
-
+    $key = $this->getMailKey($node);
     $module = 'civihr_employee_portal';
+    $email = $this->getTargetEmail();
+
     drupal_mail($module, $key, $email, language_default(), $params);
   }
+
+  /**
+   * Checks settings and node title to determine whether emails should be sent
+   *
+   * @param \stdClass $node
+   *
+   * @return bool
+   */
+  private function shouldSendMail($node) {
+    if (!in_array($node->title, $this->webformsToNotifyAbout)) {
+      return FALSE;
+    }
+
+    $targetEmail = $this->getTargetEmail();
+    $shouldSendKey = OnboardingWizardCustomizationForm::SEND_UPDATES_KEY;
+    $shouldSend = variable_get($shouldSendKey);
+
+    return $shouldSend && !empty($targetEmail);
+  }
+
+  /**
+   * Gets the email that notifications should be sent to
+   *
+   * @return string
+   */
+  private function getTargetEmail() {
+    return variable_get(
+      OnboardingWizardCustomizationForm::EMAIL_TO_SEND_UPDATES_KEY
+    );
+  }
+
+  /**
+   * Gets the key to be used when mailing. This key will affect which mail
+   * class is used when sending the mail
+   *
+   * @see civihr_employee_portal_mail()
+   *
+   * @param \stdClass $node
+   *
+   * @return string
+   */
+  private function getMailKey($node) {
+    switch ($node->title) {
+      case OnboardingWebForm::NAME:
+        return 'civihr_onboarding_form_submission';
+      default:
+        return 'civihr_webform_submission';
+    }
+  }
+
 }

--- a/civihr_employee_portal/src/Mail/WebformSubmissionNotifier.php
+++ b/civihr_employee_portal/src/Mail/WebformSubmissionNotifier.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\civihr_employee_portal\Mail;
+
+use Drupal\civihr_employee_portal\Forms\OnboardingWebForm;
+
+class WebformSubmissionNotifier {
+
+  /**
+   * @var array
+   */
+  private $webformsToNotifyAbout = [
+    'My Personal Details',
+    'My Contact Details',
+    'My Home Address',
+    'My Payroll',
+    'Create Emergency Contact',
+    'Create Dependant',
+    OnboardingWebForm::NAME,
+  ];
+
+  /**
+   * @param \stdClass $node
+   * @param \stdClass $submission
+   */
+  public function sendNotification($node, $submission) {
+    if (!in_array($node->title, $this->webformsToNotifyAbout)) {
+      return;
+    }
+
+    $this->sendMail($node, $submission);
+  }
+
+  /**
+   * @param \stdClass $node
+   * @param \stdClass $submission
+   */
+  private function sendMail($node, $submission) {
+    $params['node'] = $node;
+    $params['submission'] = $submission;
+
+    // todo fetch email from settings
+    $email = 'tmp@compucorp.co.uk';
+
+    $key = 'civihr_webform_submission';
+    if ($node->title === OnboardingWebForm::NAME) {
+      // Use a different key for onboarding form handling
+      $key = 'civihr_onboarding_form_submission';
+    }
+
+    $module = 'civihr_employee_portal';
+    drupal_mail($module, $key, $email, language_default(), $params);
+  }
+}

--- a/civihr_employee_portal/templates/smarty/dashboard_edit_details.tpl
+++ b/civihr_employee_portal/templates/smarty/dashboard_edit_details.tpl
@@ -1,0 +1,22 @@
+<p>
+  <a href="{$profileLink}">{$displayName} - {$workEmail}</a><br/>
+  Submitted on: {$submissionDate}<br/>
+  The following information was submitted via "{$webformTitle}"
+</p>
+
+{foreach from=$submittedValues key=pageTitle item=pageValues}
+  {* Most webforms don't have separate pages, so don't non-numeric page titles *}
+  {if !is_numeric($pageTitle)}
+    <h3>{$pageTitle}</h3>
+  {/if}
+  <p>
+  {foreach from=$pageValues key=fieldsetLabel item=fieldSetValues}
+    {if !is_numeric($fieldsetLabel)}
+      <h4>{$fieldsetLabel}</h4>
+    {/if}
+    {foreach from=$fieldSetValues key=label item=value}
+      {$label}: {$value}<br/>
+    {/foreach}
+  {/foreach}
+  </p>
+{/foreach}


### PR DESCRIPTION
## Overview

The purpose of this PR is to send notification mails to a specific user when someone updates their information either via the webforms on the SSP dashboard or via the onboarding form.

## Before

When a user updated their info via the SSP or onboarding form no notifications were sent.

## After

When a user updates their info via the SSP or onboarding form a notification is sent containing the submitted values to a specific email.

#### Edit Personal Details

![image](https://user-images.githubusercontent.com/6374064/45083697-694d9100-b0f4-11e8-90cf-d189dedcbb30.png)

#### Edit Contact Details

![image](https://user-images.githubusercontent.com/6374064/45083763-85513280-b0f4-11e8-96c8-7381676241be.png)

#### Edit My Address

![image](https://user-images.githubusercontent.com/6374064/45083878-c77a7400-b0f4-11e8-825f-91744f80115a.png)

#### Edit Payroll Information

![image](https://user-images.githubusercontent.com/6374064/45083919-e0832500-b0f4-11e8-9e2f-d298be811e24.png)

#### Add Emergency Contact

![image](https://user-images.githubusercontent.com/6374064/45084036-2cce6500-b0f5-11e8-9c51-51d2b28395a7.png)

#### Add Dependant

![image](https://user-images.githubusercontent.com/6374064/45084100-54253200-b0f5-11e8-866e-8558207e585d.png)

#### Onboarding Form (no skipped steps)

![image](https://user-images.githubusercontent.com/6374064/45084326-f9d8a100-b0f5-11e8-9f42-5b1b0ce5c558.png)

#### Onboarding Form (with skipped steps)

![image](https://user-images.githubusercontent.com/6374064/45084510-6eabdb00-b0f6-11e8-9742-872cc1768680.png)

## Technical Details

This PR builds on #528 which added the notification settings.

The flow for the notifications is:

- Inside `hook_webform_submission_insert` call `WebformSubmissionnotifier::sendNotification`
- `sendNotification` checks notification settings to decide whether the mail should be sent
- `WebformSubmissionnotifier` fetches the target email and calls `drupal_mail`
- `civihr_employee_portal_mail` creates a mail class to represent the mail to be sent
- The data from the submission is fetched and formatted using the mail class
- `MailContentReplacer` generates the mail body using smarty and the params from the mail class
- The `dashboard_edit_details.tpl` file is used by smarty to create the mail body
- The mail is sent

## Comments

I refactored `civihr_employee_portal_mail_alter` to use the `MailContentReplacer`. In this function the pre-built mail is already ready to be sent, and we want to replace the body with new content from Smarty. However the logic for generating the mail content is the same and so I used this class to prevent duplication.

---

- [x] Tests Pass
