### PR TITLE
PCHR-4030: Add Fields to "My Details" View

### DIFF
--- a/civihr_employee_portal/src/View/CustomFieldsMappingFixer.php
+++ b/civihr_employee_portal/src/View/CustomFieldsMappingFixer.php
@@ -16,7 +16,7 @@ class CustomFieldsMappingFixer {
   /**
    * To fix mapping on Views import of CiviCRM custom fields
    *
-   * @param view $view
+   * @param \view $view
    *     the view that is being imported / recreated
    */
   public static function fixMapping($view) {
@@ -65,8 +65,8 @@ class CustomFieldsMappingFixer {
   private static function processOption(&$option) {
     // checking if this table is part of the civicrm views integration
     $tableName = self::getCiviCRMtableName($option['table']);
-    $prefix = $tableName ? self::getPrefix($tableName) : false;
-    if ( $prefix ) {
+    $prefix = $tableName ? self::getPrefix($tableName) : FALSE;
+    if ($prefix) {
       $option['table'] = $tableName;
       $columns = self::getColumnsFromTable($prefix . $tableName);
       // if the table where the current field belongs exists does not have it
@@ -79,23 +79,6 @@ class CustomFieldsMappingFixer {
         }
       }
     }
-  }
-
-  /**
-   * Removes the number in end of a string
-   * In this context that number is always separated by an underscore
-   *
-   * @param  string $string
-   *     the string which could have underscores or not
-   *
-   * @return string
-   *     the string without the number at the end,
-   *     if no number found at the end returns the same string
-   */
-  private static function removeLastNumberOfString($string) {
-    $pieces = explode('_', $string);
-    $lastIndex = count($pieces) - 1;
-    return $lastIndex > 0 && intval(array_pop($pieces)) ? implode('_', $pieces) : $string;
   }
 
   /**
@@ -122,7 +105,26 @@ class CustomFieldsMappingFixer {
 
     $exportedTableBaseName = self::removeLastNumberOfString($tableName);
     $tableFound = isset($tableNamesMap[$exportedTableBaseName]);
+
     return $tableFound ? $tableNamesMap[$exportedTableBaseName] : '';
+  }
+
+  /**
+   * Removes the number in end of a string
+   * In this context that number is always separated by an underscore
+   *
+   * @param  string $string
+   *     the string which could have underscores or not
+   *
+   * @return string
+   *     the string without the number at the end,
+   *     if no number found at the end returns the same string
+   */
+  private static function removeLastNumberOfString($string) {
+    $pieces = explode('_', $string);
+    $lastIndex = count($pieces) - 1;
+
+    return $lastIndex > 0 && intval(array_pop($pieces)) ? implode('_', $pieces) : $string;
   }
 
   /**
@@ -136,6 +138,7 @@ class CustomFieldsMappingFixer {
    */
   private static function getPrefix($tableName) {
     global $databases;
+
     return $databases['default']['default']['prefix'][$tableName];
   }
 
@@ -151,7 +154,7 @@ class CustomFieldsMappingFixer {
    */
   private static function getColumnsFromTable($table) {
     static $columns = [];
-    if (!isset( $columns[$table])) {
+    if (!isset($columns[$table])) {
       $columns[$table] = [];
       $res = db_query('SHOW COLUMNS FROM ' . $table)->fetchAll();
       foreach ($res as $field) {
@@ -161,4 +164,5 @@ class CustomFieldsMappingFixer {
 
     return $columns[$table];
   }
+
 }

--- a/civihr_employee_portal/views/views_export/views_my_details_block.inc
+++ b/civihr_employee_portal/views/views_export/views_my_details_block.inc
@@ -163,6 +163,15 @@ $handler->display->display_options['fields']['role_department']['table'] = 'hrjc
 $handler->display->display_options['fields']['role_department']['field'] = 'role_department';
 $handler->display->display_options['fields']['role_department']['relationship'] = 'role_jobcontract_id';
 $handler->display->display_options['fields']['role_department']['label'] = 'Role Department';
+/* Field: CiviCRM Custom: NI/SSN Number: NI / SSN */
+$handler->display->display_options['fields']['ni_ssn_60']['id'] = 'ni_ssn_60';
+$handler->display->display_options['fields']['ni_ssn_60']['table'] = 'civicrm_value_inline_custom_10';
+$handler->display->display_options['fields']['ni_ssn_60']['field'] = 'ni_ssn_60';
+/* Field: CiviCRM Custom: NI/SSN Number: NI/SSN application in progress */
+$handler->display->display_options['fields']['ni_ssn_application_in_progress_61']['id'] = 'ni_ssn_application_in_progress_61';
+$handler->display->display_options['fields']['ni_ssn_application_in_progress_61']['table'] = 'civicrm_value_inline_custom_10';
+$handler->display->display_options['fields']['ni_ssn_application_in_progress_61']['field'] = 'ni_ssn_application_in_progress_61';
+$handler->display->display_options['fields']['ni_ssn_application_in_progress_61']['empty'] = 'No';
 $handler->display->display_options['defaults']['arguments'] = FALSE;
 
 /* Display: Contact Information */
@@ -236,10 +245,12 @@ $translatables['my_details_block'] = array(
   t('Designation'),
   t('Role title'),
   t('Role Department'),
-  t('All'),
+  t('NI / SSN'),
+  t('NI/SSN application in progress'),
+  t('No'),
   t('Contact Information'),
   t('Contact Information Block'),
   t('Personal Phone'),
   t('Personal E-mail'),
-  t('Address'),
+  t('Home Address'),
 );

--- a/civihr_employee_portal/views/views_export/views_my_details_block.inc
+++ b/civihr_employee_portal/views/views_export/views_my_details_block.inc
@@ -167,6 +167,8 @@ $handler->display->display_options['fields']['role_department']['label'] = 'Role
 $handler->display->display_options['fields']['ni_ssn_60']['id'] = 'ni_ssn_60';
 $handler->display->display_options['fields']['ni_ssn_60']['table'] = 'civicrm_value_inline_custom_10';
 $handler->display->display_options['fields']['ni_ssn_60']['field'] = 'ni_ssn_60';
+$handler->display->display_options['fields']['ni_ssn_60']['alter']['trim_whitespace'] = TRUE;
+$handler->display->display_options['fields']['ni_ssn_60']['alter']['strip_tags'] = TRUE;
 /* Field: CiviCRM Custom: NI/SSN Number: NI/SSN application in progress */
 $handler->display->display_options['fields']['ni_ssn_application_in_progress_61']['id'] = 'ni_ssn_application_in_progress_61';
 $handler->display->display_options['fields']['ni_ssn_application_in_progress_61']['table'] = 'civicrm_value_inline_custom_10';


### PR DESCRIPTION
## Overview

We want to show the NI/SSN and "Is applying for NI/SSN" fields in the "My Details" View

## Before

The fields were not present in the view

![image](https://user-images.githubusercontent.com/6374064/45416764-85af7780-b678-11e8-8bc3-787333398d7f.png)

## After

The NI/SSN and "Is applying for NI/SSN" fields are displayed in the view

![image](https://user-images.githubusercontent.com/6374064/45416497-fdc96d80-b677-11e8-85c3-e4fb6c556aa4.png)

## Technical Details

Even without HTML tags in the view field the `<p>` tag was being added to the "NI/SSN" field so I added "strip HTML tags" and "remove whitespace" to this field

## Comments

Since it is possible for the "Is applying field" to be empty I added a default to "No"

There were some formatting issues in the `CustomFieldsMappingFixer.php` file so I ran the PHPStorm code formatter and fixed any issue that `civilint` reported

---

- [x] Tests Pass
