### PR TITLE
PCHR-3930: Fix upgrader numbers

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.install
+++ b/civihr_employee_portal/civihr_employee_portal.install
@@ -455,17 +455,9 @@ function civihr_employee_portal_update_7035() {
 }
 
 /**
- * Disables the HR Vacancies View
- */
-function civihr_employee_portal_update_7036() {
-  $status = variable_get('views_defaults', []);
-  $status['hr-vacancies'] = TRUE;
-  variable_set('views_defaults', $status);
-}
-/**
  * Removes old 'Help' menu link from main menu
  */
-function civihr_employee_portal_update_7037() {
+function civihr_employee_portal_update_7036() {
   db_delete('menu_links')
       ->condition('link_title', 'help')
       ->condition('menu_name', 'main-menu')
@@ -479,6 +471,15 @@ function civihr_employee_portal_update_7037() {
  */
 function civihr_employee_portal_update_7037() {
   features_revert(['civihr_default_permissions' => ['user_permission']]);
+}
+
+/**
+ * Disables the HR Vacancies View
+ */
+function civihr_employee_portal_update_7038() {
+  $status = variable_get('views_defaults', []);
+  $status['hr-vacancies'] = TRUE;
+  variable_set('views_defaults', $status);
 }
 
 /**


### PR DESCRIPTION
On https://github.com/compucorp/civihr-employee-portal/pull/532/, an upgrader was added to remove "Vancacies" from the SSP menu. Originally, this upgrader number was 7036. Before this was merged to `staging`, another PR (https://github.com/compucorp/civihr-employee-portal/pull/536) was merged adding an upgrader with the same number.

This caused a conflict which we tried to fix in https://github.com/compucorp/civihr-employee-portal/pull/532/commits/05cd2c696b25391ef9191e010feded7635d9def6. When fixing conflicts with upgrader coming from staging, the only correct approach is to change the upgrader in our PR to a number higher than whatever we have on staging. The reason is that, if we pick a lower number the upgrader will never be executed. Unfortunately, this is not what happened here. The upgrader was kept with the same name and the number of the one from staging was increased to 7037.

Finally, https://github.com/compucorp/civihr-employee-portal/pull/532/ was kept open for quite a long time. In the meanwhile, Another PR (https://github.com/compucorp/civihr-employee-portal/pull/460) was merged to staging adding an upgrader with the number 7037. This time, git didn't detect the conflict and after https://github.com/compucorp/civihr-employee-portal/pull/532 was merged we ended up with two upgraders with the same number.

To fix this we:
- Reverted the change in https://github.com/compucorp/civihr-employee-portal/pull/532/commits/05cd2c696b25391ef9191e010feded7635d9def6 and renamed the upgrader that removes the old "Help" menu back to 7036
- Renamed the upgrader added by https://github.com/compucorp/civihr-employee-portal/pull/532 to 7038 (one number higher than the latest we have on staging)