### PR TITLE
PCHR-4030: NI/SSN Fields on HR Details Page

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.info
+++ b/civihr_employee_portal/civihr_employee_portal.info
@@ -60,6 +60,7 @@ files[] = views/includes/civihr_employee_portal_handler_appraisal_line_manager.i
 files[] = views/includes/civihr_employee_portal_handler_appraisal_due_date.inc
 files[] = views/includes/civihr_employee_portal_handler_tasks_date.inc
 files[] = views/includes/civihr_employee_portal_handler_documents_date.inc
+files[] = views/includes/civihr_employee_portal_handler_ni_ssn_or_status.inc
 files[] = views/includes/views_between_dates_filter_handler.inc
 files[] = views/includes/views_between_operation_dates_filter_handler.inc
 

--- a/civihr_employee_portal/src/Service/CustomValueService.php
+++ b/civihr_employee_portal/src/Service/CustomValueService.php
@@ -22,7 +22,7 @@ class CustomValueService {
    * @param string $fieldName
    *
    * @return mixed
-   *   The custom value
+   *   The custom value, will be an array if the value is from multi-value group
    */
   public function getValueForEntity($entityId, $groupName, $fieldName) {
     $customField = $this->getCustomField($groupName, $fieldName);

--- a/civihr_employee_portal/src/Service/CustomValueService.php
+++ b/civihr_employee_portal/src/Service/CustomValueService.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Drupal\civihr_employee_portal\Service;
+
+class CustomValueService {
+
+  /**
+   * @var array
+   *   In-memory cache of custom groups
+   */
+  private $customGroups = [];
+
+  /**
+   * @var array
+   *   In-memory cache of custom fields
+   */
+  private $customFields = [];
+
+  /**
+   * @param int $entityId
+   * @param string $groupName
+   * @param string $fieldName
+   *
+   * @return mixed
+   *   The custom value
+   */
+  public function getValueForEntity($entityId, $groupName, $fieldName) {
+    $customField = $this->getCustomField($groupName, $fieldName);
+    $values = \CRM_Core_BAO_CustomValueTable::getEntityValues(
+      $entityId,
+      NULL,
+      [$customField['id']]
+    );
+
+    // return array if multi value custom group, otherwise single value
+    if ($this->isMultiValueGroup($groupName)) {
+      return $values;
+    } else {
+      return reset($values);
+    }
+  }
+
+  /**
+   * Checks whether a given custom group is a multi-value custom group
+   *
+   * @param string $groupName
+   *
+   * @return bool
+   */
+  private function isMultiValueGroup($groupName) {
+    return (bool) $this->getCustomGroup($groupName)['is_multiple'];
+  }
+
+  /**
+   * Fetches custom field data
+   *
+   * @param string $groupName
+   * @param string $fieldName
+   *
+   * @return array
+   */
+  private function getCustomField($groupName, $fieldName) {
+    if (!isset($this->customFields[$groupName][$fieldName])) {
+      $params = ['name' => $fieldName, 'custom_group_id' => $groupName];
+      $field = civicrm_api3('CustomField', 'getsingle', $params);
+      $this->customFields[$groupName][$fieldName] = $field;
+    }
+
+    return $this->customFields[$groupName][$fieldName];
+  }
+
+  /**
+   * Fetches custom group data
+   *
+   * @param string $groupName
+   *
+   * @return array
+   */
+  private function getCustomGroup($groupName) {
+    if (!isset($this->customGroups[$groupName])) {
+      $group = civicrm_api3('CustomGroup', 'getsingle', ['name' => $groupName]);
+      $this->customGroups[$groupName] = $group;
+    }
+
+    return $this->customGroups[$groupName];
+  }
+
+}

--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -47,7 +47,7 @@ function civihr_employee_portal_views_data_alter(&$data) {
     ],
   ];
 
-  $data['civicrm_contact']['ni_ssn_or_in_progress'] = [
+  $data['civicrm_contact']['ni_ssn_or_application_status'] = [
     'title' => t('NI/SSN Or Application Status'),
     'help' => t('Displays the NI/SSN for this contact or a message if application is in progress'),
     'field' => [

--- a/civihr_employee_portal/views/civihr_employee_portal.views.inc
+++ b/civihr_employee_portal/views/civihr_employee_portal.views.inc
@@ -47,6 +47,14 @@ function civihr_employee_portal_views_data_alter(&$data) {
     ],
   ];
 
+  $data['civicrm_contact']['ni_ssn_or_in_progress'] = [
+    'title' => t('NI/SSN Or Application Status'),
+    'help' => t('Displays the NI/SSN for this contact or a message if application is in progress'),
+    'field' => [
+      'handler' => 'civihr_employee_portal_handler_ni_ssn_or_status',
+    ],
+  ];
+
   /**
    * Custom field handler which will create age group based on the contact birth date
    */

--- a/civihr_employee_portal/views/includes/civihr_employee_portal_handler_ni_ssn_or_status.inc
+++ b/civihr_employee_portal/views/includes/civihr_employee_portal_handler_ni_ssn_or_status.inc
@@ -1,0 +1,40 @@
+<?php
+
+use Drupal\civihr_employee_portal\Service\CustomValueService;
+
+/**
+ * Handles aggregation of a contacts different home address fields
+ */
+class civihr_employee_portal_handler_ni_ssn_or_status extends views_handler_field {
+
+  /**
+   * @inheritdoc
+   */
+  public function render($values) {
+    $contactID = isset($values->id) ? $values->id : NULL;
+
+    if (!$contactID) {
+      return '';
+    }
+
+    $ssnField = 'NI_SSN';
+    $statusField = 'has_applied_for_identification';
+    $group = 'Inline_Custom_Data';
+    $service = new CustomValueService();
+    $isApplying = $service->getValueForEntity($contactID, $group, $statusField);
+
+    if ($isApplying) {
+      return 'Pending';
+    }
+
+    return $service->getValueForEntity($contactID, $group, $ssnField);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function query() {
+    // override default behaviour as this handler is not tied to a single field
+  }
+
+}

--- a/civihr_employee_portal/views/includes/civihr_employee_portal_handler_ni_ssn_or_status.inc
+++ b/civihr_employee_portal/views/includes/civihr_employee_portal_handler_ni_ssn_or_status.inc
@@ -24,7 +24,7 @@ class civihr_employee_portal_handler_ni_ssn_or_status extends views_handler_fiel
     $isApplying = $service->getValueForEntity($contactID, $group, $statusField);
 
     if ($isApplying) {
-      return 'Pending';
+      return '<em>Pending</em>';
     }
 
     return $service->getValueForEntity($contactID, $group, $ssnField);

--- a/civihr_employee_portal/views/includes/civihr_employee_portal_handler_ni_ssn_or_status.inc
+++ b/civihr_employee_portal/views/includes/civihr_employee_portal_handler_ni_ssn_or_status.inc
@@ -3,7 +3,8 @@
 use Drupal\civihr_employee_portal\Service\CustomValueService;
 
 /**
- * Handles aggregation of a contacts different home address fields
+ * Handles displaying the NI/SSN number for a contact, or "pending" if
+ * application is in progress
  */
 class civihr_employee_portal_handler_ni_ssn_or_status extends views_handler_field {
 

--- a/civihr_employee_portal/views/views_export/views_mydetails_personal.inc
+++ b/civihr_employee_portal/views/views_export/views_mydetails_personal.inc
@@ -117,11 +117,11 @@ $handler->display->display_options['fields']['nationality_44']['field'] = 'natio
 $handler->display->display_options['fields']['nationality_44']['element_label_colon'] = FALSE;
 $handler->display->display_options['fields']['nationality_44']['hide_empty'] = TRUE;
 /* Field: CiviCRM Contacts: NI/SSN Or Application Status */
-$handler->display->display_options['fields']['ni_ssn_or_in_progress']['id'] = 'ni_ssn_or_in_progress';
-$handler->display->display_options['fields']['ni_ssn_or_in_progress']['table'] = 'civicrm_contact';
-$handler->display->display_options['fields']['ni_ssn_or_in_progress']['field'] = 'ni_ssn_or_in_progress';
-$handler->display->display_options['fields']['ni_ssn_or_in_progress']['label'] = 'NI/SSN';
-$handler->display->display_options['fields']['ni_ssn_or_in_progress']['element_label_colon'] = FALSE;
+$handler->display->display_options['fields']['ni_ssn_or_application_status']['id'] = 'ni_ssn_or_application_status';
+$handler->display->display_options['fields']['ni_ssn_or_application_status']['table'] = 'civicrm_contact';
+$handler->display->display_options['fields']['ni_ssn_or_application_status']['field'] = 'ni_ssn_or_application_status';
+$handler->display->display_options['fields']['ni_ssn_or_application_status']['label'] = 'NI/SSN';
+$handler->display->display_options['fields']['ni_ssn_or_application_status']['element_label_colon'] = FALSE;
 /* Contextual filter: CiviCRM Contacts: Contact ID */
 $handler->display->display_options['arguments']['id']['id'] = 'id';
 $handler->display->display_options['arguments']['id']['table'] = 'civicrm_contact';

--- a/civihr_employee_portal/views/views_export/views_mydetails_personal.inc
+++ b/civihr_employee_portal/views/views_export/views_mydetails_personal.inc
@@ -116,6 +116,12 @@ $handler->display->display_options['fields']['nationality_44']['table'] = 'civic
 $handler->display->display_options['fields']['nationality_44']['field'] = 'nationality_44';
 $handler->display->display_options['fields']['nationality_44']['element_label_colon'] = FALSE;
 $handler->display->display_options['fields']['nationality_44']['hide_empty'] = TRUE;
+/* Field: CiviCRM Contacts: NI/SSN Or Application Status */
+$handler->display->display_options['fields']['ni_ssn_or_in_progress']['id'] = 'ni_ssn_or_in_progress';
+$handler->display->display_options['fields']['ni_ssn_or_in_progress']['table'] = 'civicrm_contact';
+$handler->display->display_options['fields']['ni_ssn_or_in_progress']['field'] = 'ni_ssn_or_in_progress';
+$handler->display->display_options['fields']['ni_ssn_or_in_progress']['label'] = 'NI/SSN';
+$handler->display->display_options['fields']['ni_ssn_or_in_progress']['element_label_colon'] = FALSE;
 /* Contextual filter: CiviCRM Contacts: Contact ID */
 $handler->display->display_options['arguments']['id']['id'] = 'id';
 $handler->display->display_options['arguments']['id']['table'] = 'civicrm_contact';
@@ -165,6 +171,7 @@ $translatables['mydetails_personal'] = array(
   t('External ID'),
   t('Date of Birth'),
   t('Nationality'),
+  t('NI/SSN'),
   t('All'),
   t('My Personal Details'),
 );


### PR DESCRIPTION
## Overview

This PR adds the NI/SSN to the personal details section of the `/hr-details` page.

## Before

The NI/SSN field was not displayed on this page.

![image](https://user-images.githubusercontent.com/6374064/45689710-91a1aa80-bb4c-11e8-8dda-2a90fa4654a3.png)

## After

The field is displayed in the personal details section after the "Nationality" field

![image](https://user-images.githubusercontent.com/6374064/45689761-ad0cb580-bb4c-11e8-8a3d-dd18ab38a955.png)

If the NI/SSN application is in progress the text _pending_ is displayed instead

![image](https://user-images.githubusercontent.com/6374064/45689826-ce6da180-bb4c-11e8-9a6e-aee90c61b195.png)

If NI/SSN is not in progress but there is no NI/SSN number set the field will be hidden (as is default for views fields)

## Technical Details

The decision to add a custom handler was because of the complexity of the logic in the requirements, i.e. we want to re-write the results based on a separate field. 

Another reason for using a custom handler was because views are susceptible to problems related to CustomGroup and CustomField IDs differences between systems. In the custom handler we use a new service which should ignore differences in IDs between systems and instead use the CustomGroup and CustomField name as identifiers.

---

- [x] Tests Pass
