### PR TITLE
PCHR-4173: Local Admin Role is not available

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.install
+++ b/civihr_employee_portal/civihr_employee_portal.install
@@ -505,6 +505,13 @@ function civihr_employee_portal_update_7040() {
 }
 
 /**
+ * Reverts the default CiviHR user permission
+ */
+function civihr_employee_portal_update_7041() {
+  features_revert(['civihr_default_permissions' => ['user_permission']]);
+}
+
+/**
  * Function to determine whether menu link exists or not.
  *
  * @param string $path

--- a/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
+++ b/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.features.user_permission.inc
@@ -935,6 +935,15 @@ function civihr_default_permissions_user_default_permissions() {
     'module' => 'role_delegation',
   );
 
+  // Exported permission: 'assign regional hr admin role'.
+  $permissions['assign Regional HR Admin role'] = array(
+    'name' => 'assign Regional HR Admin role',
+    'roles' => array(
+      'HR Admin' => 'HR Admin',
+    ),
+    'module' => 'role_delegation',
+  );
+
   // Exported permission: 'block IP addresses'.
   $permissions['block IP addresses'] = array(
     'name' => 'block IP addresses',

--- a/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.info
+++ b/civihr_employee_portal/features/civihr_default_permissions/civihr_default_permissions.info
@@ -134,6 +134,7 @@ features[user_permission][] = assign HR Admin role
 features[user_permission][] = assign Manager role
 features[user_permission][] = assign Staff role
 features[user_permission][] = assign all roles
+features[user_permission][] = assign Regional HR Admin role
 features[user_permission][] = block IP addresses
 features[user_permission][] = bypass node access
 features[user_permission][] = bypass rules access


### PR DESCRIPTION
## Overview
When editing a user profile by `HR Admin`, option for assigning `Regional HR Admin` role to edited profile was not available. This PR fixes the issue by assigning required permission to `HR Admin` user.

## Before
<img width="280" alt="before_permission" src="https://user-images.githubusercontent.com/1507645/46300371-82364e80-c59b-11e8-9bc1-8fb943b74844.png">


## After
<img width="329" alt="after_permission" src="https://user-images.githubusercontent.com/1507645/46300380-8a8e8980-c59b-11e8-973d-278e1b680ece.png">


## Technical Details
Permission to `Assign Regional HR Admin role` was added granted `HR Admin`. This makes the option available to grant edited profile permission.
```
$permissions['assign Regional HR Admin role'] = array(
  'name' => 'assign Regional HR Admin role',
  'roles' => array(
    'HR Admin' => 'HR Admin',
  ),
  'module' => 'role_delegation',
);
```

---

- [x] Manual Testing Pass
