### PR TITLE
PCHR-4404: Undefined property error on Create HR Documents Page - SSP

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -3989,7 +3989,7 @@ function civihr_employee_portal_form_alter(&$form, &$form_state, $form_id) {
   }
 
   // Set up Emergency Contact webform ajax fields and callbacks.
-  if (!empty($form['#node']) && $form['#node']->nid === variable_get('emergency_contact_webform_nid')) {
+  if (isset($form['#node']) && isset($form['#node']->nid) && $form['#node']->nid === variable_get('emergency_contact_webform_nid')) {
     $fieldset = _get_emergency_contact_fieldset_list();
 
     for ($contact = 1; $contact < 3; $contact++) {


### PR DESCRIPTION
## Overview
When creating new HR Resource in SSP, a PHP Notice is generated when form alter hook is running. This PR fixes the issue.

## Before
![before_fixes](https://user-images.githubusercontent.com/1507645/49024521-f5260500-f199-11e8-8331-a6bfc7fad130.gif)


## After
![after_fixes](https://user-images.githubusercontent.com/1507645/49024401-a8422e80-f199-11e8-951d-3911e0eb66dc.gif)


## Technical Details
The Notice was due to the fact form node was not set. Attempting to read `nid` on a non-existing form node therefore generates a notice. A check was put in place to ensure the form node exist before checking the node id. Check was also added to ensure `nid` exist before comparing it with 
the value of `variable_get('emergency_contact_webform_nid')`