### PR TITLE
PCHR-4436: Report changes to cater for MTPHL

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -391,12 +391,10 @@ function _rebuild_absence_activity_view() {
   $civi_db_name = trim($civi_settings['path'], '/');
   $calculationUnitOptions = array_flip(AbsenceType::buildOptions('calculation_unit', 'validate'));
   $hoursUnit = $calculationUnitOptions['hours'];
-
-  db_query('DROP VIEW IF EXISTS absence_activity');
-  db_query("CREATE VIEW absence_activity AS
-            SELECT lr.contact_id AS absence_contact_id,
+  $leaveQuery = "SELECT lr.contact_id AS absence_contact_id,
               lr.id AS absence_activity_id,
               at.title as absence_type,
+              lr.request_type as request_type,
               lr.sickness_reason as sickness_reason,
               lrd.date AS absence_date,
               DATE_FORMAT(DATE(lrd.date), '%Y-%m') AS absence_month,
@@ -416,7 +414,11 @@ function _rebuild_absence_activity_view() {
             INNER JOIN {$civi_db_name}.civicrm_hrleaveandabsences_leave_request_date lrd ON lr.id = lrd.leave_request_id
             INNER JOIN {$civi_db_name}.civicrm_hrleaveandabsences_absence_type at ON at.id = lr.type_id
             INNER JOIN {$civi_db_name}.civicrm_hrleaveandabsences_leave_balance_change bc ON bc.source_id = lrd.id and bc.source_type = 'leave_request_day'
-            WHERE lr.is_deleted = 0");
+            WHERE lr.is_deleted = 0
+            GROUP BY lr.contact_id, lr.request_type, lrd.date";
+
+  db_query('DROP VIEW IF EXISTS absence_activity');
+  db_query("CREATE VIEW absence_activity AS {$leaveQuery}");
 
   variable_set('rebuild_absence_activity', 'FALSE');
 


### PR DESCRIPTION
## Overview
Validation to ensure that only one absence type can have `Must Take Public Holiday as Leave` (MTPHL) set to true was removed in https://github.com/compucorp/civihr/pull/2964. This affected the way leave reports are rendered. Previously, only one absence type could have this setting enabled, meaning only one public holiday leave request will be created for each public holiday and each contact. Since this restriction is now removed, all leave type with MTPHL true now have `public_holiday` request type replicated on each. This PR fixes the issue. 

## Before
<img width="1367" alt="replication" src="https://user-images.githubusercontent.com/1507645/49793719-1f4cfa80-fd36-11e8-8884-d8b72b009c88.png">

## After
<img width="649" alt="after_replication" src="https://user-images.githubusercontent.com/1507645/49793889-8a96cc80-fd36-11e8-88d6-4a544b996f72.png">


## Technical Details
The query used in generating absence_activity view was modified to provide some grouping for the replicated records. The grouping was based on `contact id`, `request type` and `leave request date`.

```
GROUP BY lr.contact_id, lr.request_type, lrd.date
```

---

- [x] Manual Test - Passed
