### PR TITLE
PCHR-4456: Redirect to Appropriate Dashboard If Logged In User Tries To Visit Welcome Page

### DIFF
--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5562,15 +5562,15 @@ function _user_redirection() {
 
   $current_path = request_path();
   $requestURI = rawurlencode(request_uri());
+  $pathExists = in_array($current_path, ['', 'civicrm', 'civicrm/dashboard']);
+  $isLoggedInUser = !user_is_anonymous();
+  $isWelcomePage = drupal_get_destination()['destination'] == 'welcome-page';
 
   if (!$publicFirewall->canAccess($user, $current_path)) {
     $query = $current_path ? sprintf('?destination=%s', $requestURI) : '';
     $redirect_path = 'welcome-page' . $query;
   }
-  elseif (in_array($current_path, ['', 'civicrm', 'civicrm/dashboard']) ||
-    !user_is_anonymous() &&
-    drupal_get_destination()['destination'] == 'welcome-page')
-  {
+  elseif ($pathExists || ($isLoggedInUser && $isWelcomePage)) {
     $redirect_path = LinkProvider::getLandingPageLink($user);
   }
 

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5568,7 +5568,8 @@ function _user_redirection() {
     $redirect_path = 'welcome-page' . $query;
   }
   elseif (in_array($current_path, ['', 'civicrm', 'civicrm/dashboard']) ||
-    !user_is_anonymous() && drupal_get_destination()['destination'] == 'welcome-page')
+    !user_is_anonymous() &&
+    drupal_get_destination()['destination'] == 'welcome-page')
   {
     $redirect_path = LinkProvider::getLandingPageLink($user);
   }

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5567,7 +5567,9 @@ function _user_redirection() {
     $query = $current_path ? sprintf('?destination=%s', $requestURI) : '';
     $redirect_path = 'welcome-page' . $query;
   }
-  elseif (in_array($current_path, ['', 'civicrm', 'civicrm/dashboard'])) {
+  elseif (in_array($current_path, ['', 'civicrm', 'civicrm/dashboard']) ||
+    !user_is_anonymous() && drupal_get_destination()['destination'] == 'welcome-page')
+  {
     $redirect_path = LinkProvider::getLandingPageLink($user);
   }
 

--- a/civihr_employee_portal/civihr_employee_portal.module
+++ b/civihr_employee_portal/civihr_employee_portal.module
@@ -5568,8 +5568,7 @@ function _user_redirection() {
     $redirect_path = 'welcome-page' . $query;
   }
   elseif (in_array($current_path, ['', 'civicrm', 'civicrm/dashboard'])) {
-    $tasksDashboard = 'civicrm/tasksassignments/dashboard#/tasks';
-    $redirect_path = user_access('access CiviCRM') ? $tasksDashboard : 'dashboard';
+    $redirect_path = LinkProvider::getLandingPageLink($user);
   }
 
   if (!empty($redirect_path)) {


### PR DESCRIPTION
## Overview
Currently If a logged in user tries to visit the `/welcome-page` or `/welcome-page?destination=welcome-page` URL, an access forbidden page is returned since only the anonymous user is allowed to view this [page](https://github.com/compucorp/civihr-employee-portal/blob/04529d4917c513dbf428e3b5107b85be58082297/civihr_employee_portal/features/civihr_employee_portal_features/civihr_employee_portal_features.pages_default.inc#L676). This PR makes changes such that when a logged in user visits any of the above URL's the user is directed to either the SSP or Admin dashboard based on the user access.

## Before
A logged in user sees an access forbidden page when trying to access any of the following URL's: `/welcome-page` or `/welcome-page?destination=welcome-page`

## After
The logged in user is redirected to either the SSP or Admin dashboard based on the user access when trying to access either `/welcome-page` or `/welcome-page?destination=welcome-page`


---

- [ ] Tests Pass
Not Applicable