### PR TITLE
PCHR-4405: User sees different address when viewing and editing personal details

### DIFF
--- a/civihr_employee_portal/updates/7044.php
+++ b/civihr_employee_portal/updates/7044.php
@@ -21,28 +21,28 @@ function civihr_employee_portal_update_7044() {
       'contact_id' => $address['contact_id']
     ]);
 
-    $addresses = array_values($result['values']);
-    $primaryIndex = array_search('1', array_column($addresses, 'is_primary'));
+    $contactAddresses = array_values($result['values']);
+    $primaryIndex = array_search('1', array_column($contactAddresses, 'is_primary'));
     if ($primaryIndex === FALSE) {
-      $addresses[0]['is_primary'] = 1;
-      civicrm_api3('Address', 'create', $addresses[0]);
+      $contactAddresses[0]['is_primary'] = 1;
+      civicrm_api3('Address', 'create', $contactAddresses[0]);
       $primaryIndex = 0;
     }
 
-    unset($addresses[$primaryIndex]);
-    _update_address_to_works($addresses, $locationType['id']);
+    unset($contactAddresses[$primaryIndex]);
+    _update_address_to_works($contactAddresses, $locationType['id']);
   }
 }
 
 /**
  * Updates addresses to work location type
  *
- * @param array $addresses
+ * @param array $contactAddresses
  * @param int $locationTypeId
  * @throws CiviCRM_API3_Exception
  */
-function _update_address_to_works($addresses, $locationTypeId) {
-  foreach ($addresses as $address) {
+function _update_address_to_works($contactAddresses, $locationTypeId) {
+  foreach ($contactAddresses as $address) {
     $address['location_type_id'] = $locationTypeId;
     $address['is_primary'] = 0;
     civicrm_api3('Address', 'create', $address);

--- a/civihr_employee_portal/updates/7044.php
+++ b/civihr_employee_portal/updates/7044.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Updates contact address, enforcing only one personal address type
+ */
+function civihr_employee_portal_update_7044() {
+  civicrm_initialize();
+  $locationType = civicrm_api3('LocationType', 'get', ['name' => 'Work']);
+  if (!$locationType['count']) {
+    return;
+  }
+
+  $addresses = _get_personal_address_count();
+  foreach ($addresses as $address) {
+    if ($address['total'] < 2) {
+      continue;
+    }
+
+    $result = civicrm_api3('Address', 'get', [
+      'location_type_id' => 'Personal',
+      'contact_id' => $address['contact_id'],
+    ]);
+    $updated = 0;
+    foreach ($result['values'] as $index => $contactAddress) {
+      if ($updated === 0) {
+        $contactAddress['is_primary'] = 1;
+        civicrm_api3('Address', 'create', $contactAddress);
+        $updated++;
+        continue;
+      }
+
+      $contactAddress['is_primary'] = 0;
+      $contactAddress['location_type_id'] = $locationType['id'];
+      civicrm_api3('Address', 'create', $contactAddress);
+    }
+  }
+}
+
+/**
+ * Fetches personal addresses grouped by their contact_id
+ *
+ * @return array
+ */
+function _get_personal_address_count() {
+  $query = "
+    SELECT a.contact_id, COUNT(a.location_type_id) AS total FROM civicrm_address a
+    INNER JOIN civicrm_location_type lt ON (a.location_type_id = lt.id)
+    WHERE lt.name = 'Personal'
+    GROUP BY a.contact_id
+  ";
+
+  $result = CRM_Core_DAO::executeQuery($query);
+
+  return $result->fetchAll();
+}

--- a/civihr_employee_portal/updates/7044.php
+++ b/civihr_employee_portal/updates/7044.php
@@ -12,26 +12,26 @@ function civihr_employee_portal_update_7044() {
 
   $addresses = _get_personal_address_count();
   foreach ($addresses as $address) {
-    if ($address['total'] < 2) {
+    if ($address['total'] != 2) {
       continue;
     }
 
     $result = civicrm_api3('Address', 'get', [
       'location_type_id' => 'Personal',
-      'contact_id' => $address['contact_id'],
+      'contact_id' => $address['contact_id']
     ]);
-    $updated = 0;
-    foreach ($result['values'] as $index => $contactAddress) {
-      if ($updated === 0) {
-        $contactAddress['is_primary'] = 1;
+    $processed = 0;
+    foreach ($result['values'] as $contactAddress) {
+      $updateAnyAddress = $contactAddress['is_primary'] == 0 && $address['primary_count'] == 1;
+      $updateSecondAddress = $address['primary_count'] != 1 && $processed == 1;
+
+      if ($updateAnyAddress || $updateSecondAddress) {
+        $contactAddress['location_type_id'] = $locationType['id'];
+        $contactAddress['is_primary'] = 0;
         civicrm_api3('Address', 'create', $contactAddress);
-        $updated++;
-        continue;
       }
 
-      $contactAddress['is_primary'] = 0;
-      $contactAddress['location_type_id'] = $locationType['id'];
-      civicrm_api3('Address', 'create', $contactAddress);
+      $processed++;
     }
   }
 }
@@ -43,7 +43,8 @@ function civihr_employee_portal_update_7044() {
  */
 function _get_personal_address_count() {
   $query = "
-    SELECT a.contact_id, COUNT(a.location_type_id) AS total FROM civicrm_address a
+    SELECT a.contact_id, COUNT(a.location_type_id) AS total, SUM(a.is_primary) AS primary_count
+    FROM civicrm_address a
     INNER JOIN civicrm_location_type lt ON (a.location_type_id = lt.id)
     WHERE lt.name = 'Personal'
     GROUP BY a.contact_id


### PR DESCRIPTION
## Overview
In SSP, users with two Personal addresses sees one in the view mode of "My Details", and the second while editing. When "My Details" page gets rendered, an API call made to select contact address, limiting to only one record (the first record on the list, irrespective of whether `is_primary` is true). When editing, the Personal address with `is_primary` gets selected. If the second personal address was created with  is_primary TRUE, the first address will have is_primary FALSE. This PR updates the addresses to ensure there is only one personal address by setting the other to work address. There should be only one Personal Address in the system, and that should be the one visible to staff in view and edit modes.

## Before
Contact details in SSP shows different address in viewing and editing mode when contact has two Personal addresses.


## After
Contact details in SSP no longer shows different address in viewing and editing mode.

## Technical Details
An upgrader was implemented to fetch contacts having two Personal Addresses. Results were grouped by their `contact_id` in order to detect affected records.
```
$query = "
  SELECT a.contact_id, COUNT(a.location_type_id) AS total, SUM(a.is_primary) AS primary_count
  FROM civicrm_address a
  INNER JOIN civicrm_location_type lt ON (a.location_type_id = lt.id)
  WHERE lt.name = 'Personal'
  GROUP BY a.contact_id
";
```
Address details for contacts having two personal address were fetched and updated. Updates were carried when one of the two Personal Addresses is having `is_primary` TRUE or the two addresses are both is_primary or otherwise.
```
$contactAddress['location_type_id'] = $locationType['id'];
$contactAddress['is_primary'] = 0;
civicrm_api3('Address', 'create', $contactAddress);
```

---

- [x ] Manual Tests Pass
