### PR TITLE
PCHR-4460: Fix 'Undefined index: role_revision_id' Error on SSP Dashboard

### DIFF
--- a/civihr_employee_portal/src/View/MyDetailsView.php
+++ b/civihr_employee_portal/src/View/MyDetailsView.php
@@ -27,8 +27,8 @@ class MyDetailsView extends AbstractView {
 
     // If no current contract then add an impossible join condition
     $contractID = $revision ? $revision['jobcontract_id'] : 0;
-    $roleRevisionID = $revision ? $revision['role_revision_id'] : 0;
-    $detailsRevisionID = $revision ? $revision['details_revision_id'] : 0;
+    $roleRevisionID = !empty($revision['role_revision_id']) ? $revision['role_revision_id'] : 0;
+    $detailsRevisionID = !empty($revision['details_revision_id']) ? $revision['details_revision_id'] : 0;
 
     $revisionAlias = 'hrjc_revision_civicrm_contact';
 


### PR DESCRIPTION
## Overview
On SSP dashboard, a notice for `undefined  index: role_revision_id` is displayed 

## Before
On SSP dashboard, a notice 'Notice: Undefined index: role_revision_id in Drupal\civihr_employee_portal\View\MyDetailsView->alter() 
(line 30 of /home/compucorp/buildkit/build/test-1/sites/all/modules/civihr-custom/civihr_employee_portal/src/View/MyDetailsView.php).` is displayed.

<img width="1141" alt="dashboard staging57 2019-01-03 11-20-38" src="https://user-images.githubusercontent.com/6951813/50638624-c819fe80-0f5e-11e9-8b72-46f90f973c5f.png">

## After
This notice is not observed for all contacts, only contacts that has the `role_revision_id` column as NULL for the current revision. When the `role_revision_id` is NULL, it is not part of the returned revision result via the Civi [API](https://github.com/compucorp/civihr-employee-portal/blob/f0c8c3bb28fbd63ada576cece444968a6418fc02/civihr_employee_portal/src/View/MyDetailsView.php#L58), hence the reason for the error.
The fix was to check for if the role_revision_id was present or not before assigning.

<img width="1160" alt="dashboard staging57 2019-01-03 13-52-27" src="https://user-images.githubusercontent.com/6951813/50638645-d8ca7480-0f5e-11e9-9708-c7bd9bab74b4.png">
