### PR TITLE
PCHR-4424: Fixed File Get Contents Warning on Onboarding Form

### DIFF
--- a/civicrm_resources/civicrm_resources.module
+++ b/civicrm_resources/civicrm_resources.module
@@ -46,6 +46,9 @@ function _civicrm_resources_add_resource($extension_path, $resource_uri) {
   $resource_type = pathinfo($resource_uri, PATHINFO_EXTENSION);
   $extension_path_relative_to_drupal = str_replace(DRUPAL_ROOT, '', $extension_path);
   $resource_path_relative_to_drupal = $extension_path_relative_to_drupal . '/' . $resource_uri;
+  if (substr($resource_path_relative_to_drupal, 0, 1) === '/') {
+    $resource_path_relative_to_drupal = substr($resource_path_relative_to_drupal, 1);
+  }
 
   if ($resource_type === 'js') {
     drupal_add_js($resource_path_relative_to_drupal,  ['scope' => 'footer']);


### PR DESCRIPTION
## Overview
When filling the onboarding forms, a warning is usually displayed on the `Home Address` page with 
`Warning: file_get_contents(...)`. This affects three files - require.min.js, reqangular.min.js, and tasks-notification-badge.min.js. The warning can also be noticed on `My Details` page and `Add New Staff Member` page. This warning was fixed in this PR

## Before
File get contents warning came up while rendering some pages as part of the resource files could not be loaded.
<img width="715" alt="onboarding-form" src="https://user-images.githubusercontent.com/1507645/50685408-6074b980-1019-11e9-91ef-b96ac1fb3ba5.png">


## After
File get contents warning no longer show on affected pages.
<img width="717" alt="onboarding-form-after" src="https://user-images.githubusercontent.com/1507645/50686748-e3e4d980-101e-11e9-977f-50454617e714.png">


## Technical Details
When loading the affected resource files, a leading slash (`/`) was present in the file path. The `/` makes `file_get_contents` start at the top of filesystem, thereby raising a warning. A check was added to [civicrm_resources](https://github.com/compucorp/civihr-employee-portal/blob/master/civicrm_resources/civicrm_resources.module#L45) module  to test for leading slash and update resource path if present.

---

- [x] Manual Tests Pass
